### PR TITLE
feat: add first-class TypeScript and TSX parsing

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -82,7 +82,8 @@ Taint rules (`mode: taint`):
 
 Language mapping:
 
-- JavaScript / TypeScript
+- JavaScript (`.js`, `.jsx`, `.mjs`, `.cjs`)
+- TypeScript (`.ts`, `.mts`, `.cts`) and TSX (`.tsx`) use dedicated tree-sitter grammars and reuse compatible JavaScript rule IDs where the AST surface aligns
 - Python
 - Go
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-swift",
+ "tree-sitter-typescript",
  "unicode-segmentation",
  "unicode-width",
  "uuid",
@@ -1871,6 +1872,16 @@ name = "tree-sitter-swift"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 clap = { version = "4", features = ["derive"] }
 tree-sitter = "0.25"
 tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.23"
 tree-sitter-python = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-ruby = "0.23"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   <br/><em><code>foxguard tui .</code> — interactive triage with scan, diff, secrets, and PQ modes. <a href="https://foxguard.dev/blog/foxguard-0-7-0-tui-launch">Launch post</a>.</em>
 </p>
 
-foxguard is a security scanner you can run on every save. A single Rust binary with 170+ built-in rules across 10 source languages, plus C via Semgrep-compatible YAML rule packs and Coccinelle-backed semantic patches (kernel/dirty-frag class shipped), cross-file taint tracking, Semgrep-compatible YAML loading, and four top-level modes — general scan, diff-against-branch, secrets, and post-quantum crypto audit — all reachable from the same CLI or interactive TUI.
+foxguard is a security scanner you can run on every save. A single Rust binary with 170+ built-in rules across 10 source-language families, first-class JavaScript/TypeScript/TSX parsing, plus C via Semgrep-compatible YAML rule packs and Coccinelle-backed semantic patches (kernel/dirty-frag class shipped), cross-file taint tracking, Semgrep-compatible YAML loading, and four top-level modes — general scan, diff-against-branch, secrets, and post-quantum crypto audit — all reachable from the same CLI or interactive TUI.
 
 It is fast enough for pre-commit hooks and the `--changed` path runs in milliseconds on a real repo. Output formats: terminal, JSON, SARIF (for GitHub Code Scanning), and CycloneDX 1.6 CBOM.
 
@@ -168,7 +168,7 @@ Sentry is the stress target at ~1.3M Python LoC: foxguard scans the whole tree i
 
 ## Rules
 
-170+ built-in rules across 10 source languages, plus C via Semgrep-compatible YAML rule packs (kernel/dirty-frag class shipped), covering SQL injection, XSS, SSRF, command injection, hardcoded secrets, weak crypto, unsafe deserialization, log injection, PQ-vulnerable crypto, crypto-agility, and framework-specific checks. Full per-rule coverage, precision tiers, and false-positive methodology live in [docs/precision.md](docs/precision.md) and on the [rules page at foxguard.dev](https://foxguard.dev/rules).
+170+ built-in rules across 10 source-language families, with first-class JavaScript, TypeScript, and TSX parsers plus C via Semgrep-compatible YAML rule packs (kernel/dirty-frag class shipped), covering SQL injection, XSS, SSRF, command injection, hardcoded secrets, weak crypto, unsafe deserialization, log injection, PQ-vulnerable crypto, crypto-agility, and framework-specific checks. Full per-rule coverage, precision tiers, and false-positive methodology live in [docs/precision.md](docs/precision.md) and on the [rules page at foxguard.dev](https://foxguard.dev/rules).
 
 ## Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -272,9 +272,9 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     if files_scanned == 0 && coccinelle_candidate_files == 0 {
         if stats.files_discovered == 0 {
             let supported = if coccinelle_rules.is_empty() {
-                ".js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
+                ".js, .jsx, .ts, .tsx, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
             } else {
-                ".js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt, .c, .h"
+                ".js, .jsx, .ts, .tsx, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt, .c, .h"
             };
             notices.push(format!("Warning: no files found. Supported: {supported}"));
         } else {

--- a/src/bin/gen_rules_ts.rs
+++ b/src/bin/gen_rules_ts.rs
@@ -35,6 +35,8 @@ const LANGUAGE_ORDER: &[Language] = &[
 fn language_slug(language: Language) -> &'static str {
     match language {
         Language::JavaScript => "js",
+        Language::TypeScript => "ts",
+        Language::Tsx => "tsx",
         Language::Python => "py",
         Language::Go => "go",
         Language::Ruby => "rb",
@@ -56,6 +58,8 @@ fn language_slug(language: Language) -> &'static str {
 fn language_display_name(language: Language) -> &'static str {
     match language {
         Language::JavaScript => "JavaScript / TypeScript",
+        Language::TypeScript => "TypeScript",
+        Language::Tsx => "TSX",
         Language::Python => "Python",
         Language::Go => "Go",
         Language::Ruby => "Ruby",
@@ -77,6 +81,8 @@ fn language_display_name(language: Language) -> &'static str {
 fn language_array_name(language: Language) -> &'static str {
     match language {
         Language::JavaScript => "jsRules",
+        Language::TypeScript => "tsRules",
+        Language::Tsx => "tsxRules",
         Language::Python => "pyRules",
         Language::Go => "goRules",
         Language::Ruby => "rubyRules",

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -6,6 +6,8 @@ pub fn parse_file(source: &str, language: Language) -> Option<tree_sitter::Tree>
 
     let ts_language = match language {
         Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+        Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        Language::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
         Language::Python => tree_sitter_python::LANGUAGE.into(),
         Language::Go => tree_sitter_go::LANGUAGE.into(),
         Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
@@ -25,4 +27,35 @@ pub fn parse_file(source: &str, language: Language) -> Option<tree_sitter::Tree>
 
     parser.set_language(&ts_language).ok()?;
     parser.parse(source, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_typescript_without_javascript_recovery_errors() {
+        let source = r#"
+type RequestLike = { body: { name: string } };
+
+export function render(request: RequestLike): string {
+    return request.body.name;
+}
+"#;
+        let tree = parse_file(source, Language::TypeScript).expect("failed to parse TypeScript");
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_tsx_without_javascript_recovery_errors() {
+        let source = r#"
+type Props = { title: string };
+
+export function Card({ title }: Props) {
+    return <section data-kind="card">{title}</section>;
+}
+"#;
+        let tree = parse_file(source, Language::Tsx).expect("failed to parse TSX");
+        assert!(!tree.root_node().has_error());
+    }
 }

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -278,7 +278,9 @@ pub fn detect_language(path: &Path) -> Option<Language> {
     }
 
     match path.extension()?.to_str()? {
-        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => Some(Language::JavaScript),
+        "js" | "jsx" | "mjs" | "cjs" => Some(Language::JavaScript),
+        "ts" | "mts" | "cts" => Some(Language::TypeScript),
+        "tsx" => Some(Language::Tsx),
         "py" | "pyw" => Some(Language::Python),
         "go" => Some(Language::Go),
         "rb" | "rake" | "gemspec" => Some(Language::Ruby),
@@ -607,16 +609,17 @@ fn parse_inline_ignore(line: &str, language: Language) -> Option<(bool, InlineIg
     }
 
     // Fallback: block comment /* foxguard: ignore */ — only for languages with /* */ syntax
-    if matches!(
-        language,
-        Language::JavaScript
-            | Language::Go
-            | Language::Java
-            | Language::Rust
-            | Language::CSharp
-            | Language::Swift
-            | Language::Php
-    ) {
+    if language.is_javascript_family()
+        || matches!(
+            language,
+            Language::Go
+                | Language::Java
+                | Language::Rust
+                | Language::CSharp
+                | Language::Swift
+                | Language::Php
+        )
+    {
         if let Some(result) = parse_block_comment_ignore(line) {
             return Some(result);
         }
@@ -644,10 +647,10 @@ fn is_comment_only_line(trimmed_line: &str, language: Language) -> bool {
 
 fn comment_markers(language: Language) -> &'static [&'static str] {
     match language {
+        Language::JavaScript | Language::TypeScript | Language::Tsx => &["//"],
         Language::Python | Language::Ruby => &["#"],
         Language::Php => &["//", "#"],
-        Language::JavaScript
-        | Language::Go
+        Language::Go
         | Language::Java
         | Language::Rust
         | Language::CSharp
@@ -698,9 +701,9 @@ fn scan_files(
     let has_python_taint_rules = rules_by_lang
         .get(&Language::Python)
         .is_some_and(|rules| rules.iter().any(|rule| rule.id().contains("/taint-")));
-    let has_js_taint_rules = rules_by_lang
-        .get(&Language::JavaScript)
-        .is_some_and(|rules| rules.iter().any(|rule| rule.id().contains("/taint-")));
+    let has_js_taint_rules = rules_by_lang.iter().any(|(language, rules)| {
+        language.is_javascript_family() && rules.iter().any(|rule| rule.id().contains("/taint-"))
+    });
     let has_go_taint_rules = rules_by_lang
         .get(&Language::Go)
         .is_some_and(|rules| rules.iter().any(|rule| rule.id().contains("/taint-")));
@@ -720,9 +723,15 @@ fn scan_files(
     }
     let python_files: Vec<_> = files_by_lang.remove(&Language::Python).unwrap_or_default();
     let go_files: Vec<_> = files_by_lang.remove(&Language::Go).unwrap_or_default();
-    let js_files: Vec<_> = files_by_lang
+    let mut js_files: Vec<_> = files_by_lang
         .remove(&Language::JavaScript)
         .unwrap_or_default();
+    js_files.extend(
+        files_by_lang
+            .remove(&Language::TypeScript)
+            .unwrap_or_default(),
+    );
+    js_files.extend(files_by_lang.remove(&Language::Tsx).unwrap_or_default());
 
     let (mut cross_file_summaries, has_python_cross_file): (CrossFileSummaryMap, bool) =
         if has_python_taint_rules && python_files.len() > 1 {
@@ -781,7 +790,7 @@ fn scan_files(
         let js_rule_specs = crate::rules::javascript::js_taint_rule_specs();
         let prepared_js: Vec<_> = js_files
             .par_iter()
-            .filter_map(|(path, _)| {
+            .filter_map(|(path, language)| {
                 if std::fs::metadata(path).ok()?.len() > max_file_size {
                     return None;
                 }
@@ -789,10 +798,8 @@ fn scan_files(
                 if is_minified(&source) {
                     return None;
                 }
-                let tree = super::parser::parse_file(&source, Language::JavaScript)?;
-                if treats_tree_errors_as_parse_failures(Language::JavaScript, path)
-                    && tree.root_node().has_error()
-                {
+                let tree = super::parser::parse_file(&source, *language)?;
+                if treats_tree_errors_as_parse_failures(*language) && tree.root_node().has_error() {
                     return None;
                 }
                 let aliases = js_aliases_from_tree(&source, &tree);
@@ -972,7 +979,7 @@ fn scan_files(
 
             let owned_tree;
             let tree = if let Some(prepared) = prepared {
-                if treats_tree_errors_as_parse_failures(*language, path)
+                if treats_tree_errors_as_parse_failures(*language)
                     && prepared.tree.root_node().has_error()
                 {
                     warnings.lock().expect("lock poisoned").push(format!(
@@ -990,7 +997,7 @@ fn scan_files(
                     ));
                     return FileScanOutcome::skipped(ScanSkipReason::ParseError);
                 };
-                if treats_tree_errors_as_parse_failures(*language, path)
+                if treats_tree_errors_as_parse_failures(*language)
                     && parsed_tree.root_node().has_error()
                 {
                     warnings.lock().expect("lock poisoned").push(format!(
@@ -1029,7 +1036,7 @@ fn scan_files(
                 None
             };
             let owned_javascript_aliases;
-            let javascript_aliases = if matches!(language, Language::JavaScript) {
+            let javascript_aliases = if language.is_javascript_family() {
                 if let Some(prepared) = prepared {
                     Some(&prepared.aliases)
                 } else {
@@ -1069,9 +1076,7 @@ fn scan_files(
                 };
 
             // Build JavaScript import-to-path map for cross-file resolution.
-            let javascript_import_paths = if has_js_cross_file
-                && matches!(language, Language::JavaScript)
-            {
+            let javascript_import_paths = if has_js_cross_file && language.is_javascript_family() {
                 let mut imports = javascript_taint::resolve_js_imports_to_paths(source, tree, path);
                 let canonical: HashMap<String, PathBuf> = imports
                     .drain()
@@ -1177,7 +1182,7 @@ fn scan_files(
             // JavaScript taint rules: same batched approach as Go/Python
             // above — see `crate::rules::javascript::run_js_taint_batched`.
             let enabled_js_taint_ids: std::collections::HashSet<&str> =
-                if matches!(language, Language::JavaScript) {
+                if language.is_javascript_family() {
                     rules
                         .iter()
                         .filter(|r| {
@@ -1257,22 +1262,14 @@ fn resolve_canonical_path(lookup: &HashMap<PathBuf, PathBuf>, path: &Path) -> Pa
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn treats_tree_errors_as_parse_failures(language: Language, path: &Path) -> bool {
-    match language {
-        Language::JavaScript => !is_typescript_path(path),
+fn treats_tree_errors_as_parse_failures(language: Language) -> bool {
+    !matches!(
+        language,
         Language::NginxConf
-        | Language::ApacheConf
-        | Language::HAProxyConf
-        | Language::Dockerfile
-        | Language::Manifest => false,
-        _ => true,
-    }
-}
-
-fn is_typescript_path(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|extension| extension.to_str()),
-        Some("ts" | "tsx" | "mts" | "cts")
+            | Language::ApacheConf
+            | Language::HAProxyConf
+            | Language::Dockerfile
+            | Language::Manifest
     )
 }
 
@@ -1363,6 +1360,27 @@ mod tests {
 
         assert!(matcher.is_excluded(Path::new("generated/foo/bar.js")));
         assert!(!matcher.is_excluded(Path::new("generated/foo/bar.ts")));
+    }
+
+    #[test]
+    fn detect_language_distinguishes_javascript_typescript_and_tsx() {
+        assert_eq!(
+            detect_language(Path::new("app.js")),
+            Some(Language::JavaScript)
+        );
+        assert_eq!(
+            detect_language(Path::new("app.jsx")),
+            Some(Language::JavaScript)
+        );
+        assert_eq!(
+            detect_language(Path::new("app.ts")),
+            Some(Language::TypeScript)
+        );
+        assert_eq!(
+            detect_language(Path::new("app.mts")),
+            Some(Language::TypeScript)
+        );
+        assert_eq!(detect_language(Path::new("app.tsx")), Some(Language::Tsx));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ impl std::fmt::Display for Severity {
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     JavaScript,
+    TypeScript,
+    Tsx,
     Python,
     Go,
     Ruby,
@@ -57,10 +59,21 @@ pub enum Language {
     Manifest,
 }
 
+impl Language {
+    pub fn is_javascript_family(self) -> bool {
+        matches!(
+            self,
+            Language::JavaScript | Language::TypeScript | Language::Tsx
+        )
+    }
+}
+
 impl std::fmt::Display for Language {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Language::JavaScript => write!(f, "javascript"),
+            Language::TypeScript => write!(f, "typescript"),
+            Language::Tsx => write!(f, "tsx"),
             Language::Python => write!(f, "python"),
             Language::Go => write!(f, "go"),
             Language::Ruby => write!(f, "ruby"),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -498,7 +498,7 @@ impl RuleRegistry {
     pub fn rules_for_language(&self, language: Language) -> Vec<&dyn Rule> {
         self.rules
             .iter()
-            .filter(|r| r.language() == language)
+            .filter(|r| rule_language_applies_to(r.language(), language))
             .map(|r| r.as_ref())
             .collect()
     }
@@ -581,6 +581,13 @@ impl RuleRegistry {
 
         unknown
     }
+}
+
+fn rule_language_applies_to(rule_language: Language, target_language: Language) -> bool {
+    rule_language == target_language
+        || (target_language == Language::TypeScript && rule_language == Language::JavaScript)
+        || (target_language == Language::Tsx
+            && matches!(rule_language, Language::JavaScript | Language::TypeScript))
 }
 
 #[cfg(test)]

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -805,7 +805,9 @@ fn map_severity(s: &SemgrepSeverity) -> Severity {
 
 fn map_language(lang_str: &str) -> Option<Language> {
     match lang_str.to_lowercase().as_str() {
-        "javascript" | "js" | "typescript" | "ts" | "jsx" | "tsx" => Some(Language::JavaScript),
+        "javascript" | "js" | "jsx" => Some(Language::JavaScript),
+        "typescript" | "ts" => Some(Language::TypeScript),
+        "tsx" => Some(Language::Tsx),
         "python" | "py" => Some(Language::Python),
         "go" | "golang" => Some(Language::Go),
         "ruby" | "rb" => Some(Language::Ruby),
@@ -1126,12 +1128,28 @@ rules:
     pattern: res.send("Hello World")
     message: Exact Express response send call
     severity: WARNING
-    languages: [javascript, typescript]
+    languages: [javascript, js]
 "#;
         let f = make_yaml(yaml);
         let rules = parse_semgrep_file(f.path()).unwrap();
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].language(), Language::JavaScript);
+    }
+
+    #[test]
+    fn test_typescript_language_maps_to_typescript_parser() {
+        let yaml = r#"
+rules:
+  - id: ts-send
+    pattern: res.send("Hello World")
+    message: Exact Express response send call
+    severity: WARNING
+    languages: [typescript]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].language(), Language::TypeScript);
     }
 
     #[test]

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -283,7 +283,7 @@ impl Rule for SemgrepTaintRule {
                     .map(TaintFindingView::from_python)
                     .collect()
             }
-            Language::JavaScript => {
+            language if language.is_javascript_family() => {
                 let spec = to_js_spec(&self.spec);
                 javascript_taint::analyze_tree(
                     tree.root_node(),
@@ -380,8 +380,16 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
                         detected = Some(Language::Python);
                         break;
                     }
-                    "javascript" | "js" | "typescript" | "ts" => {
+                    "javascript" | "js" => {
                         detected = Some(Language::JavaScript);
+                        break;
+                    }
+                    "typescript" | "ts" => {
+                        detected = Some(Language::TypeScript);
+                        break;
+                    }
+                    "tsx" => {
+                        detected = Some(Language::Tsx);
                         break;
                     }
                     "go" | "golang" => {
@@ -878,7 +886,7 @@ pattern-sinks: [{pattern: eval($X)}]
     }
 
     #[test]
-    fn taint_rule_with_typescript_language_compiles_as_javascript() {
+    fn taint_rule_with_typescript_language_compiles() {
         let yaml = r#"
 id: ts-taint
 mode: taint
@@ -890,7 +898,7 @@ pattern-sinks: [{pattern: eval($X)}]
 "#;
         let v: YamlValue = serde_yaml::from_str(yaml).unwrap();
         match parse_taint_rule(&v) {
-            TaintRuleParse::Compiled(r) => assert_eq!(r.lang, Language::JavaScript),
+            TaintRuleParse::Compiled(r) => assert_eq!(r.lang, Language::TypeScript),
             TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
             TaintRuleParse::NotTaint => panic!("expected taint rule"),
         }

--- a/tests/fixtures/safe_tsx_taint.tsx
+++ b/tests/fixtures/safe_tsx_taint.tsx
@@ -1,0 +1,9 @@
+type Props = {
+    title: string;
+};
+
+export function Preview({ title }: Props) {
+    const el = <section className="preview">{title}</section>;
+    document.write("<h1>Preview</h1>");
+    return el;
+}

--- a/tests/fixtures/vulnerable_tsx_taint.tsx
+++ b/tests/fixtures/vulnerable_tsx_taint.tsx
@@ -1,0 +1,13 @@
+type Props = {
+    request: {
+        body: {
+            title: string;
+        };
+    };
+};
+
+export function Preview({ request }: Props) {
+    const el = <section className="preview">Preview</section>;
+    document.write(request.body.title); // js/taint-xss-innerhtml
+    return el;
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -837,6 +837,48 @@ mod javascript {
         );
     }
 
+    #[test]
+    fn test_vulnerable_tsx_taint_catches_flow() {
+        let output = foxguard_cmd_isolated()
+            .args(["tests/fixtures/vulnerable_tsx_taint.tsx", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        assert!(!output.status.success());
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+            .count();
+        assert_eq!(
+            n, 1,
+            "js/taint-xss-innerhtml should fire once on vulnerable_tsx_taint.tsx, got {} findings: {:?}",
+            n, findings
+        );
+    }
+
+    #[test]
+    fn test_safe_tsx_taint_has_no_taint_findings() {
+        let output = foxguard_cmd_isolated()
+            .args(["tests/fixtures/safe_tsx_taint.tsx", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+            .count();
+        assert_eq!(
+            n, 0,
+            "js/taint-xss-innerhtml should not fire on safe_tsx_taint.tsx, got {} findings",
+            n
+        );
+    }
+
     /// Issue #32 — Hono taint sources. `c` is intentionally NOT a ParamName
     /// matcher; the engine must pick up `c.req.query(...)` / `c.req.param(...)`
     /// through the explicit `Call` matchers.


### PR DESCRIPTION
## Summary
- add dedicated TypeScript and TSX language variants backed by tree-sitter-typescript
- keep compatible JavaScript built-ins and taint analysis active for TypeScript/TSX files
- map Semgrep-compatible TypeScript/TSX languages to the dedicated parsers
- add parser, detection, and TSX taint fixtures/tests

## Tests
- cargo fmt --check
- git diff --check
- cargo test
- cargo clippy --all-targets -- -D warnings

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class TypeScript and TSX support with dedicated language detection for `.ts`, `.tsx`, `.mts`, and `.cts` file extensions.
  * JavaScript-family rules now apply across JavaScript, TypeScript, and TSX files.

* **Tests**
  * Added taint analysis test cases for TSX files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->