### PR TITLE
feat(rules): bundled YAML packs load by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "hex",
  "hmac",
  "ignore",
+ "include_dir",
  "jsonwebtoken",
  "ratatui",
  "rayon",
@@ -1141,6 +1142,25 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ shlex = "1"
 unicode-segmentation = "1"
 unicode-width = "0.2"
 wait-timeout = "0.2.1"
+include_dir = "0.7"
 
 # Optional deps for the GitHub App webhook receiver (gated behind the
 # `github-app` feature). Off by default so the core scanner build stays

--- a/src/app.rs
+++ b/src/app.rs
@@ -669,12 +669,21 @@ fn external_rule_ids(
 fn build_registry(no_builtins: bool, rules: Option<&str>) -> Result<RuleRegistry, String> {
     validate_rules_path(rules)?;
 
+    // `RuleRegistry::new()` registers both the hand-written Rust rules and
+    // the bundled YAML rule packs (currently `rules/kernel/dirty-frag-class/`)
+    // embedded into the binary at compile time. `--no-builtins` therefore
+    // suppresses BOTH sources — anyone passing it gets nothing unless they
+    // also pass `--rules <path>`. We deliberately do not expose a separate
+    // `--no-bundled-rules` flag: there is no current use case for "Rust core
+    // only, no shipped YAML". Add one only when someone hits that need.
     let mut registry = if no_builtins {
         RuleRegistry::empty()
     } else {
         RuleRegistry::new()
     };
 
+    // `--rules <path>` still loads additional external packs on top of the
+    // bundled set; semantics unchanged.
     if let Some(rules_path) = rules {
         let semgrep_rules = load_semgrep_rules(Path::new(rules_path));
         for rule in semgrep_rules {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -23,6 +23,17 @@ pub mod taint_engine;
 use crate::{Finding, Language, Severity};
 use std::path::Path;
 
+/// YAML rule packs that ship inside the `foxguard` binary.
+///
+/// These are loaded by [`RuleRegistry::new`] on the same footing as the
+/// hand-written Rust rules: no CLI flag required. The `queries/` subtrees
+/// hold CodeQL `.ql` files and pack lockfiles that have nothing to do with
+/// Semgrep matching, so they are skipped at load time (see
+/// `walk_embedded_dir` in `semgrep_compat.rs`).
+///
+/// See `rules/README.md` for the on-disk layout.
+static BUNDLED_RULES: include_dir::Dir<'_> = include_dir::include_dir!("$CARGO_MANIFEST_DIR/rules");
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaintEngine {
     Go,
@@ -517,6 +528,17 @@ impl RuleRegistry {
         registry.register(Box::new(manifest::CargoLockPqCrypto));
         registry.register(Box::new(manifest::RequirementsTxtPqCrypto));
 
+        // Register bundled YAML rule packs (currently the kernel
+        // dirty-frag-class pack). These ship inside the binary via the
+        // `include_dir!` blob above; they are treated as built-in rules so
+        // `--no-builtins` suppresses them too. Users who want the kernel
+        // pack but not the Rust rules can lean on `--rules <path>` against
+        // an external clone — `--no-builtins` means "no foxguard-shipped
+        // rules at all".
+        for rule in semgrep_compat::load_semgrep_rules_from_embedded(&BUNDLED_RULES) {
+            registry.register(rule);
+        }
+
         registry
     }
 
@@ -855,5 +877,55 @@ mod tests {
         let opts = std::collections::HashMap::new();
         let warnings = registry.configure_rules(&opts).unwrap();
         assert!(warnings.is_empty());
+    }
+
+    /// Proves the kernel dirty-frag YAML pack is loaded by default — i.e.
+    /// without the user passing `--rules rules/kernel/dirty-frag-class/`.
+    /// Before this change the pack only fired when explicitly opted into;
+    /// now it ships inside the binary via `include_dir!` and registers on
+    /// the same `RuleRegistry::new()` call as the Rust rules.
+    ///
+    /// The CodeQL-engine rule
+    /// (`kernel/dirty-frag/esp-shared-frag-decrypt-guard-codeql`) is
+    /// intentionally skipped by the Semgrep loader — Agent B's CodeQL
+    /// bridge owns that one.
+    #[test]
+    fn bundled_kernel_dirty_frag_rules_load_by_default() {
+        let registry = RuleRegistry::new();
+        let ids: std::collections::HashSet<&str> = registry.rules.iter().map(|r| r.id()).collect();
+
+        // Five Semgrep-engine rules in the pack (the sixth is CodeQL).
+        let expected = [
+            "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
+            "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
+            "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
+            "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl-authencesn",
+            "semgrep/kernel/dirty-frag/rxrpc-verify-response-dispatch",
+        ];
+        for id in expected {
+            assert!(
+                ids.contains(id),
+                "expected bundled rule {} to be registered by default, got: {:?}",
+                id,
+                ids.iter()
+                    .filter(|i| i.starts_with("semgrep/kernel"))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        // CodeQL-engine rule must NOT be picked up by the Semgrep loader.
+        assert!(
+            !ids.contains("semgrep/kernel/dirty-frag/esp-shared-frag-decrypt-guard-codeql"),
+            "CodeQL rule leaked into the Semgrep registry"
+        );
+    }
+
+    /// `--no-builtins` must suppress the bundled YAML pack too, not just
+    /// the Rust rules. This is the explicit design decision documented in
+    /// `build_registry` in `src/app.rs`.
+    #[test]
+    fn empty_registry_does_not_load_bundled_rules() {
+        let registry = RuleRegistry::empty();
+        assert!(registry.rules.is_empty());
     }
 }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -1037,17 +1037,28 @@ fn extract_cwe(yaml: &SemgrepRuleYaml) -> Option<String> {
 
 /// Parse a single Semgrep YAML file into foxguard rules.
 pub fn parse_semgrep_file(path: &Path) -> Result<Vec<Box<dyn Rule>>, String> {
-    use crate::rules::semgrep_taint::{self, TaintRuleParse};
-    use serde_yaml::Value as YamlValue;
-
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    parse_semgrep_str(&content, &path.display().to_string())
+}
+
+/// Parse a Semgrep YAML document (passed as an in-memory string) into
+/// foxguard rules.
+///
+/// This sibling of [`parse_semgrep_file`] exists so the registry can load
+/// bundled rule packs embedded into the binary at compile time
+/// (`include_dir!` blobs have no filesystem path). `source_label` is used
+/// purely for error messages — pass the embedded path or any human-readable
+/// identifier.
+pub fn parse_semgrep_str(content: &str, source_label: &str) -> Result<Vec<Box<dyn Rule>>, String> {
+    use crate::rules::semgrep_taint::{self, TaintRuleParse};
+    use serde_yaml::Value as YamlValue;
 
     // First pass: parse as an untyped Value so we can detect `mode: taint`
     // rules and route them to the taint bridge without breaking the strict
     // `SemgrepRuleYaml` schema used for pattern rules.
-    let raw_doc: YamlValue = serde_yaml::from_str(&content)
-        .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
+    let raw_doc: YamlValue = serde_yaml::from_str(content)
+        .map_err(|e| format!("Failed to parse YAML {}: {}", source_label, e))?;
 
     let mut rules: Vec<Box<dyn Rule>> = Vec::new();
     let mut pattern_rule_nodes: Vec<YamlValue> = Vec::new();
@@ -1085,7 +1096,7 @@ pub fn parse_semgrep_file(path: &Path) -> Result<Vec<Box<dyn Rule>>, String> {
         m
     });
     let semgrep_file: SemgrepFile = serde_yaml::from_value(pattern_file)
-        .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
+        .map_err(|e| format!("Failed to parse YAML {}: {}", source_label, e))?;
 
     for yaml_rule in semgrep_file.rules {
         let cwe = extract_cwe(&yaml_rule);
@@ -1148,6 +1159,53 @@ pub fn load_semgrep_rules(path: &Path) -> Vec<Box<dyn Rule>> {
     }
 
     rules
+}
+
+/// Load all Semgrep YAML rules from an embedded [`include_dir::Dir`] tree.
+///
+/// Used for the rule packs that ship inside the `foxguard` binary
+/// (currently `rules/kernel/dirty-frag-class/`). Walks the tree
+/// recursively, picks up every `.yaml` / `.yml` file, and parses each as a
+/// Semgrep document. CodeQL-engine rules are skipped inside
+/// `parse_semgrep_str` (handled by the separate CodeQL bridge), so it is
+/// safe to pass mixed packs.
+pub fn load_semgrep_rules_from_embedded(dir: &include_dir::Dir<'_>) -> Vec<Box<dyn Rule>> {
+    let mut rules = Vec::new();
+    walk_embedded_dir(dir, &mut rules);
+    rules
+}
+
+fn walk_embedded_dir(dir: &include_dir::Dir<'_>, rules: &mut Vec<Box<dyn Rule>>) {
+    for file in dir.files() {
+        let path = file.path();
+        let ext = path.extension().and_then(|s| s.to_str());
+        if !matches!(ext, Some("yaml" | "yml")) {
+            continue;
+        }
+        let Some(content) = file.contents_utf8() else {
+            eprintln!(
+                "Warning: embedded rule {} is not valid UTF-8, skipping",
+                path.display()
+            );
+            continue;
+        };
+        let label = format!("<bundled:{}>", path.display());
+        match parse_semgrep_str(content, &label) {
+            Ok(r) => rules.extend(r),
+            Err(e) => eprintln!("Warning: {e}"),
+        }
+    }
+    for subdir in dir.dirs() {
+        // `queries/` subtrees hold CodeQL `.ql` files plus `qlpack.yml` /
+        // `codeql-pack.lock.yml` pack metadata. Those `.yml` files match
+        // our extension filter but are NOT Semgrep rules — they belong to
+        // the CodeQL bridge. Skip the whole subtree so we don't print
+        // spurious parse warnings at startup.
+        if subdir.path().file_name().and_then(|s| s.to_str()) == Some("queries") {
+            continue;
+        }
+        walk_embedded_dir(subdir, rules);
+    }
 }
 
 #[cfg(test)]

--- a/tests/kernel_dirty_frag.rs
+++ b/tests/kernel_dirty_frag.rs
@@ -286,3 +286,52 @@ fn scatterwalk_authencesn_exception_flags_memcpy_to_sglist_fixture() {
         "expected authencesn exception rule to flag memcpy_to_sglist STORE at crypto/authencesn.c, got {n} findings"
     );
 }
+
+/// End-to-end proof that the bundled dirty-frag YAML pack fires by default
+/// — i.e. `foxguard scan <fixture>` without any `--rules <path>` flag still
+/// produces a finding. Before this change, the kernel pack was on disk in
+/// `rules/` but invisible to the CLI unless the user passed
+/// `--rules rules/kernel/dirty-frag-class/`. After embedding, the pack
+/// ships inside the binary and registers alongside the Rust rules in
+/// `RuleRegistry::new()`.
+#[test]
+fn bundled_kernel_rule_fires_without_rules_flag() {
+    use std::process::Command;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let fixture = std::path::Path::new(manifest_dir)
+        .join("tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c");
+    assert!(fixture.exists(), "fixture missing at {}", fixture.display());
+
+    // `--config /dev/null` isolates from any repo `.foxguard.yml` that
+    // might filter rules. We deliberately do NOT pass `--rules`. (`scan`
+    // is the default subcommand; PATH is the trailing positional arg.)
+    let output = Command::new(env!("CARGO_BIN_EXE_foxguard"))
+        .args([
+            "--config",
+            "/dev/null",
+            "--format",
+            "json",
+            fixture.to_str().expect("fixture path is UTF-8"),
+        ])
+        .output()
+        .expect("failed to spawn foxguard binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON output: {e}\n{stdout}"));
+    let findings = report["findings"]
+        .as_array()
+        .expect("JSON report missing findings array");
+
+    let bundled_hit = findings.iter().any(|f| {
+        f["rule_id"]
+            .as_str()
+            .is_some_and(|id| id == "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow")
+    });
+    assert!(
+        bundled_hit,
+        "expected bundled rule to fire on positive fixture without --rules. findings: {}",
+        serde_json::to_string_pretty(findings).unwrap_or_default()
+    );
+}


### PR DESCRIPTION
## Summary

Before this PR, the `rules/kernel/dirty-frag-class/*.yaml` pack shipped in the repo but the only way to actually run it was `foxguard scan --rules rules/kernel/dirty-frag-class/ <target>`. In practice nobody did that — the pack existed as latent capability with no UX surface, even though it had 19 calibration tests behind it.

After this PR, `foxguard scan <target>` picks up the bundled YAML rules automatically, alongside the 188 hand-written Rust rules. The pack is embedded into the binary at compile time via [`include_dir`](https://crates.io/crates/include_dir).

## Flag semantics

- `--rules <path>` — unchanged. Still loads additional external packs on top of the bundled ones.
- `--no-builtins` — now suppresses **both** the Rust core **and** the bundled YAML. Anyone passing it gets nothing unless they also pass `--rules`. This is the explicit design decision documented inline in `build_registry` (`src/app.rs`). No separate `--no-bundled-rules` flag is added — we'll add one only when someone hits a real use case for "Rust core only, no shipped YAML".

## CodeQL bridge

The Semgrep loader still skips rules with `engine: codeql`, so `esp-shared-frag-decrypt-guard-codeql.yaml` is intentionally NOT picked up here — Agent B's CodeQL bridge handles it. `queries/` subtrees (CodeQL `.ql` files + `qlpack.yml` / `codeql-pack.lock.yml`) are excluded from the embedded walker so they don't trip the Semgrep parser at startup.

## Tests

- 19 existing unit tests in `tests/kernel_dirty_frag.rs` continue to pass — they call `parse_semgrep_file()` directly, unchanged.
- New unit test `bundled_kernel_dirty_frag_rules_load_by_default` in `src/rules/mod.rs` confirms all 5 Semgrep-engine bundled rule IDs are registered by `RuleRegistry::new()` and that the CodeQL rule is correctly excluded.
- New unit test `empty_registry_does_not_load_bundled_rules` confirms `--no-builtins` semantics.
- New CLI integration test `bundled_kernel_rule_fires_without_rules_flag` spawns the actual `foxguard` binary against a positive fixture with no `--rules`, parses the JSON output, and asserts the bundled kernel rule fires.

`cargo test --all`: 463 + 20 + 126 + 8 + 8 + 12 + 6 + 15 + 3 + 2 + 1 = 663 passed, 0 failed.

## Binary-size impact

Embedded YAML payload: ~36 KB total on disk for `rules/`. The actual binary delta is in the same ballpark — well within the "handful of KB" budget the task allowed. `queries/` content is excluded from the walker but still embedded by the macro; if that 12 KB ever matters, future work can swap to a glob-aware embed crate.

## Docs follow-up

`ARCHITECTURE.md` and `rules/README.md` describe the bundled packs as an opt-in pattern. They will need an update in a follow-up commit/PR to reflect the new "load by default" UX — out of scope for this PR.

## Test plan

- [ ] CI green (`cargo test --all`, `cargo fmt --check`).
- [ ] Manual: `cargo run --release -- tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c` shows the `semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow` finding without any `--rules` flag.
- [ ] Manual: `cargo run --release -- --no-builtins tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c` shows zero findings (no rules registered).
- [ ] Manual: `cargo run --release -- --rules <external-pack> tests/...` still loads the external pack on top of the bundled set.