### PR TITLE
refactor(kotlin): use unified TaintSpec engine instead of bespoke harness

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1272,6 +1272,31 @@ fn scan_files(
                 ));
             }
 
+            // Kotlin taint rules: dispatched the same way as the other
+            // language engines via `run_kt_taint_batched`. The Kotlin
+            // engine doesn't share Pass 1 summaries (it's intra-function
+            // only and has no cross-file work yet), but the dispatcher
+            // routes all enabled Kotlin taint rules through a single
+            // entry point for parity.
+            let enabled_kt_taint_ids: std::collections::HashSet<&str> =
+                if matches!(language, Language::Kotlin) {
+                    analysis_plan
+                        .taint_specs
+                        .iter()
+                        .filter(|spec| matches!(spec.engine, TaintEngine::Kotlin))
+                        .map(|spec| spec.rule_id)
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                };
+            if !enabled_kt_taint_ids.is_empty() {
+                file_findings.extend(crate::rules::kotlin::run_kt_taint_batched(
+                    source,
+                    tree,
+                    &enabled_kt_taint_ids,
+                ));
+            }
+
             file_findings.extend(ast_rule_batch.run(source, tree, &ctx));
 
             for finding in &mut file_findings {

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -756,589 +756,174 @@ impl_rule! {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Lightweight intra-procedural taint analysis for Kotlin (Ktor + Spring Boot)
+// Kotlin taint rules
 // ═══════════════════════════════════════════════════════════════════════════
+//
+// The three `kt/taint-*-injection` rules below consume the shared taint
+// engine in `crate::rules::kotlin_taint` rather than a bespoke harness.
+// Each rule's `check()` looks up the rule's declarative `TaintSpec` from
+// `kotlin_taint::kotlin_taint_rule_specs()`, hands it to
+// `kotlin_taint::analyze_tree`, and maps returned `TaintFinding`s onto
+// the project's `Finding` type — the same shape Go/JS/Python taint
+// rules use. Per-rule message formatters and metadata live here; the
+// engine and the shared sources/sinks live in `kotlin_taint.rs`.
+//
+// The scanner skips the rule's `check()` when the same rule id is
+// registered as a `RegistryTaintSpec` via
+// `builtin_taint_specs_for_language`, and runs the batched dispatcher
+// `run_kt_taint_batched` instead. The `check()` path is kept working
+// so unit tests that construct a Rule struct directly continue to
+// function.
 
-use std::collections::HashSet;
+use crate::rules::common::get_source_line;
+use crate::rules::kotlin_taint;
 
-/// Describes a taint source matched inside a function body.
-struct TaintSource {
-    /// Variable name the source is assigned to (if any).
-    var_name: Option<String>,
-    /// Human-readable description for findings.
-    description: String,
-    /// 1-indexed line where the source was found.
-    line: usize,
-}
-
-/// Describes a taint sink match.
-struct TaintSink {
-    /// The sink call node (for location).
-    start_byte: usize,
-    end_byte: usize,
-    line: usize,
-    /// Human-readable description.
-    description: String,
-}
-
-/// Collect Ktor/Spring Boot taint source variables inside a function body.
-///
-/// Recognizes:
-///   - `call.receiveText()`
-///   - `call.receive<T>()`
-///   - `request.queryParameters[...]`
-///   - `request.header(...)`
-///   - `call.request.queryParameters[...]`
-///   - `call.request.header(...)`
-///   - Function parameters annotated with `@RequestParam`, `@RequestBody`,
-///     `@PathVariable`, `@RequestHeader`
-fn collect_sources(node: tree_sitter::Node, src: &str) -> Vec<TaintSource> {
-    let mut sources = Vec::new();
-
-    // 1) Walk for Ktor call.receive / request.queryParameters / request.header
-    walk_tree(node, src, &mut |n, s| {
-        // property_declaration or variable assignment: val x = <source>
-        if n.kind() == "property_declaration" {
-            let var = extract_property_var_name(n, s);
-            let initializer = extract_property_initializer(n);
-            if let (Some(var_name), Some(init)) = (var, initializer) {
-                if let Some(desc) = classify_source_expr(init, s) {
-                    sources.push(TaintSource {
-                        var_name: Some(var_name),
-                        description: desc,
-                        line: n.start_position().row + 1,
-                    });
-                }
-            }
-        }
-        // assignment: x = <source>
-        if n.kind() == "assignment" {
-            if let (Some(left), Some(right)) =
-                (n.child(0), n.child(n.child_count().saturating_sub(1)))
-            {
-                let left_text = &s[left.byte_range()];
-                if left.kind() == "simple_identifier" {
-                    if let Some(desc) = classify_source_expr(right, s) {
-                        sources.push(TaintSource {
-                            var_name: Some(left_text.to_string()),
-                            description: desc,
-                            line: n.start_position().row + 1,
-                        });
-                    }
-                }
-            }
-        }
-    });
-
-    // 2) Scan for Spring annotation-based sources on function parameters.
-    // Look for function_declaration children that have parameter nodes with annotations.
-    walk_tree(node, src, &mut |n, s| {
-        if n.kind() == "function_declaration" {
-            collect_spring_param_sources(n, s, &mut sources);
-        }
-    });
-
-    sources
-}
-
-/// Classify whether a node is a taint source expression.
-/// Returns a description string if it is, None otherwise.
-fn classify_source_expr(node: tree_sitter::Node, src: &str) -> Option<String> {
-    let text = &src[node.byte_range()];
-
-    // call.receiveText(), call.receive<...>()
-    if node.kind() == "call_expression" {
-        if let Some(method) = call_method_name(node, src) {
-            if method == "receiveText" || method == "receive" {
-                if let Some(recv) = call_receiver_text(node, src) {
-                    if recv.contains("call") {
-                        return Some(format!("{}.{}()", recv, method));
-                    }
-                }
-            }
-            // request.header("...")
-            if method == "header" || method == "queryParameter" {
-                if let Some(recv) = call_receiver_text(node, src) {
-                    if recv.contains("request") || recv.contains("call") {
-                        return Some(format!("{}.{}()", recv, method));
-                    }
-                }
-            }
-        }
-    }
-
-    // request.queryParameters["x"] — indexing_expression
-    if (node.kind() == "indexing_expression"
-        || text.contains("queryParameters[")
-        || text.contains("parameters["))
-        && (text.contains("request") || text.contains("call"))
-        && (text.contains("queryParameters")
-            || text.contains("parameters[")
-            || text.contains("header"))
-    {
-        return Some(text.to_string());
-    }
-
-    None
-}
-
-/// Extract the variable name from a `property_declaration`.
-fn extract_property_var_name(node: tree_sitter::Node, src: &str) -> Option<String> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "variable_declaration" {
-            let mut c2 = child.walk();
-            for gc in child.children(&mut c2) {
-                if gc.kind() == "simple_identifier" {
-                    return Some(src[gc.byte_range()].to_string());
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Extract the initializer expression from a `property_declaration`.
-fn extract_property_initializer(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
-    // The initializer comes after the `=` token.
-    let count = node.child_count();
-    if count < 3 {
-        return None;
-    }
-    // Walk backwards: the initializer is the last non-trivial child.
-    // Look for a child after `=`.
-    let mut found_eq = false;
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if found_eq && child.kind() != "=" {
-            return Some(child);
-        }
-        if child.kind() == "=" {
-            found_eq = true;
-        }
-    }
-    None
-}
-
-/// Collect Spring annotation-based parameter sources from a function declaration.
-///
-/// In Kotlin's tree-sitter grammar, `function_value_parameters` children are:
-///   `parameter_modifiers` (containing `@RequestParam` etc.), then `parameter`
-///   (containing the name and type). They are siblings, not nested.
-fn collect_spring_param_sources(
-    func_node: tree_sitter::Node,
-    src: &str,
-    sources: &mut Vec<TaintSource>,
-) {
-    let spring_annotations = [
-        "RequestParam",
-        "RequestBody",
-        "PathVariable",
-        "RequestHeader",
-    ];
-
-    let mut cursor = func_node.walk();
-    for child in func_node.children(&mut cursor) {
-        if child.kind() == "function_value_parameters" {
-            // Walk children: parameter_modifiers precedes its parameter.
-            let mut c2 = child.walk();
-            let children: Vec<_> = child.children(&mut c2).collect();
-            let mut pending_annotation: Option<&str> = None;
-
-            for ch in &children {
-                if ch.kind() == "parameter_modifiers" {
-                    let mod_text = &src[ch.byte_range()];
-                    for ann in &spring_annotations {
-                        if mod_text.contains(ann) {
-                            pending_annotation = Some(ann);
-                            break;
-                        }
-                    }
-                } else if ch.kind() == "parameter" {
-                    if let Some(ann) = pending_annotation.take() {
-                        // Extract parameter name: first simple_identifier child.
-                        let mut c3 = ch.walk();
-                        for pc in ch.children(&mut c3) {
-                            if pc.kind() == "simple_identifier" {
-                                let name = &src[pc.byte_range()];
-                                sources.push(TaintSource {
-                                    var_name: Some(name.to_string()),
-                                    description: format!("@{} parameter '{}'", ann, name),
-                                    line: ch.start_position().row + 1,
-                                });
-                                break;
-                            }
-                        }
-                    }
-                    pending_annotation = None;
-                } else {
-                    // Reset on any other node (e.g., comma, parens)
-                    if ch.kind() != "," && ch.kind() != "(" && ch.kind() != ")" {
-                        pending_annotation = None;
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Build the set of tainted variable names by starting from sources and
-/// propagating through simple assignments and string concatenation.
-fn build_tainted_set(
-    node: tree_sitter::Node,
-    src: &str,
-    sources: &[TaintSource],
-) -> HashSet<String> {
-    let mut tainted: HashSet<String> = HashSet::new();
-
-    // Seed with source variable names.
-    for s in sources {
-        if let Some(ref name) = s.var_name {
-            tainted.insert(name.clone());
-        }
-    }
-
-    if tainted.is_empty() {
-        return tainted;
-    }
-
-    // Propagate through assignments: val y = x, val z = x + "...", val w = "..." + x
-    // Do two passes to handle transitive assignments.
-    for _ in 0..2 {
-        walk_tree(node, src, &mut |n, s| {
-            if n.kind() == "property_declaration" {
-                let var = extract_property_var_name(n, s);
-                let init = extract_property_initializer(n);
-                if let (Some(var_name), Some(init_node)) = (var, init) {
-                    if !tainted.contains(&var_name) && expr_uses_tainted(init_node, s, &tainted) {
-                        tainted.insert(var_name);
-                    }
-                }
-            }
-            if n.kind() == "assignment" {
-                if let (Some(left), Some(right)) =
-                    (n.child(0), n.child(n.child_count().saturating_sub(1)))
-                {
-                    if left.kind() == "simple_identifier" {
-                        let left_text = s[left.byte_range()].to_string();
-                        if !tainted.contains(&left_text) && expr_uses_tainted(right, s, &tainted) {
-                            tainted.insert(left_text);
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-    tainted
-}
-
-/// Check if an expression node references any tainted variable.
-fn expr_uses_tainted(node: tree_sitter::Node, src: &str, tainted: &HashSet<String>) -> bool {
-    if node.kind() == "simple_identifier" {
-        let name = &src[node.byte_range()];
-        return tainted.contains(name);
-    }
-    // String template: "...${tainted}..."
-    if node.kind() == "string_literal" {
-        let text = &src[node.byte_range()];
-        for t in tainted {
-            if text.contains(&format!("${{{}}}", t)) || text.contains(&format!("${}", t)) {
-                return true;
-            }
-        }
-    }
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if expr_uses_tainted(child, src, tainted) {
-            return true;
-        }
-    }
-    false
-}
-
-/// A specification for a Kotlin taint rule.
-struct KtTaintSpec {
-    /// Functions to find sinks. Returns (description, start_byte, end_byte, line) tuples.
-    sink_finder: fn(tree_sitter::Node, &str, &HashSet<String>) -> Vec<TaintSink>,
-}
-
-/// Run lightweight taint analysis for a Kotlin taint rule.
-fn run_kt_taint(
-    rule_id: &str,
+/// Per-rule metadata for Kotlin taint findings: how to format the
+/// message and which fix hint to attach. Mirrors `GoTaintRuleMeta`.
+struct KtTaintRuleMeta<'a> {
+    rule_id: &'a str,
     severity: Severity,
-    cwe: Option<&str>,
+    cwe: Option<&'a str>,
+    fix_suggestion: Option<&'a str>,
+    format_description: fn(&str, &str) -> String,
+}
+
+fn kt_taint_sql_injection_desc(src: &str, sink: &str) -> String {
+    format!(
+        "{} flows to {} — use parameterized queries to prevent SQL injection",
+        src, sink
+    )
+}
+
+fn kt_taint_command_injection_desc(src: &str, sink: &str) -> String {
+    format!(
+        "{} flows to {} — avoid passing untrusted input to OS commands",
+        src, sink
+    )
+}
+
+fn kt_taint_ssrf_desc(src: &str, sink: &str) -> String {
+    format!(
+        "{} flows to {} — validate and allowlist target hosts to prevent SSRF",
+        src, sink
+    )
+}
+
+fn kt_taint_meta(rule_id: &str) -> Option<KtTaintRuleMeta<'static>> {
+    match rule_id {
+        "kt/taint-sql-injection" => Some(KtTaintRuleMeta {
+            rule_id: "kt/taint-sql-injection",
+            severity: Severity::Critical,
+            cwe: Some("CWE-89"),
+            fix_suggestion: None,
+            format_description: kt_taint_sql_injection_desc,
+        }),
+        "kt/taint-command-injection" => Some(KtTaintRuleMeta {
+            rule_id: "kt/taint-command-injection",
+            severity: Severity::Critical,
+            cwe: Some("CWE-78"),
+            fix_suggestion: None,
+            format_description: kt_taint_command_injection_desc,
+        }),
+        "kt/taint-ssrf" => Some(KtTaintRuleMeta {
+            rule_id: "kt/taint-ssrf",
+            severity: Severity::High,
+            cwe: Some("CWE-918"),
+            fix_suggestion: None,
+            format_description: kt_taint_ssrf_desc,
+        }),
+        _ => None,
+    }
+}
+
+/// Map a single `TaintFinding` from the Kotlin engine onto a `Finding`,
+/// using the rule's metadata. Preserves the field shape produced by the
+/// pre-refactor bespoke harness (confidence = `default_confidence()`,
+/// `taint_hops = None`, no fix suggestion, byte offsets blank).
+fn map_kt_taint_finding(
+    meta: &KtTaintRuleMeta<'_>,
+    source: &str,
+    finding: kotlin_taint::TaintFinding,
+) -> Finding {
+    Finding {
+        rule_id: meta.rule_id.to_string(),
+        severity: meta.severity,
+        cwe: meta.cwe.map(|s| s.to_string()),
+        description: (meta.format_description)(
+            &finding.source_description,
+            &finding.sink_description,
+        ),
+        file: String::new(),
+        line: finding.sink_line,
+        column: finding.sink_column,
+        end_line: finding.sink_end_line,
+        end_column: finding.sink_end_column,
+        snippet: get_source_line(source, finding.sink_start_byte),
+        source_line: if finding.source_line == 0 {
+            None
+        } else {
+            Some(finding.source_line)
+        },
+        source_description: Some(finding.source_description),
+        sink_line: Some(finding.sink_line),
+        sink_description: Some(finding.sink_description),
+        fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
+        sink_start_byte: None,
+        sink_end_byte: None,
+        confidence: crate::default_confidence(),
+        taint_hops: None,
+        tags: vec![],
+        crypto_algorithm: None,
+        cnsa2_deadline: None,
+        dep_name: None,
+    }
+}
+
+/// Run every enabled Kotlin taint rule over `tree` in a single dispatch
+/// loop and return per-rule `Finding`s.
+///
+/// Mirrors the shape of `run_go_taint_batched` /
+/// `run_py_taint_batched` / `run_js_taint_batched`. There is no
+/// per-group sanitizer batching today because the three Kotlin taint
+/// rules share the (empty) sanitizer set; we still iterate per rule so
+/// each can attach its own message and severity.
+pub fn run_kt_taint_batched(
     source: &str,
     tree: &tree_sitter::Tree,
-    spec: &KtTaintSpec,
-    message_fn: fn(&str, &str) -> String,
+    enabled_rule_ids: &std::collections::HashSet<&str>,
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
-    let root = tree.root_node();
-
-    // Analyze each function body separately.
-    walk_tree(root, source, &mut |node, _src| {
-        if node.kind() == "function_declaration" || node.kind() == "lambda_literal" {
-            // Find the function body.
-            let body = find_function_body(node);
-            let scope = body.unwrap_or(node);
-
-            // Collect sources from both the function node (for Spring
-            // annotations on parameters) and the body (for Ktor call.*).
-            let mut sources = collect_sources(scope, source);
-            // For function_declaration, also check annotations on params.
-            if node.kind() == "function_declaration" {
-                collect_spring_param_sources(node, source, &mut sources);
-            }
-            if sources.is_empty() {
-                return;
-            }
-
-            let tainted = build_tainted_set(scope, source, &sources);
-            if tainted.is_empty() {
-                return;
-            }
-
-            let sinks = (spec.sink_finder)(scope, source, &tainted);
-            for sink in sinks {
-                // Find the best matching source description.
-                let source_desc = sources
-                    .first()
-                    .map(|s| s.description.as_str())
-                    .unwrap_or("user input");
-                let source_line = sources.first().map(|s| s.line);
-
-                let msg = message_fn(source_desc, &sink.description);
-
-                let start_byte = sink.start_byte.min(source.len());
-                let end_byte = sink.end_byte.min(source.len());
-                let line = source[..start_byte].bytes().filter(|b| *b == b'\n').count() + 1;
-                let line_start = source[..start_byte].rfind('\n').map_or(0, |idx| idx + 1);
-                let column = source[line_start..start_byte].chars().count() + 1;
-                let end_line = source[..end_byte].bytes().filter(|b| *b == b'\n').count() + 1;
-                let end_line_start = source[..end_byte].rfind('\n').map_or(0, |idx| idx + 1);
-                let end_column = source[end_line_start..end_byte].chars().count() + 1;
-
-                findings.push(Finding {
-                    rule_id: rule_id.to_string(),
-                    severity,
-                    cwe: cwe.map(|s| s.to_string()),
-                    description: msg,
-                    file: String::new(),
-                    line,
-                    column,
-                    end_line,
-                    end_column,
-                    snippet: crate::rules::common::get_source_line(source, start_byte),
-                    source_line,
-                    source_description: Some(source_desc.to_string()),
-                    sink_line: Some(sink.line),
-                    sink_description: Some(sink.description.clone()),
-                    fix_suggestion: None,
-                    sink_start_byte: None,
-                    sink_end_byte: None,
-                    confidence: crate::default_confidence(),
-                    taint_hops: None,
-                    tags: vec![],
-                    crypto_algorithm: None,
-                    cnsa2_deadline: None,
-                    dep_name: None,
-                });
-            }
+    for (rule_id, spec) in kotlin_taint::kotlin_taint_rule_specs() {
+        if !enabled_rule_ids.contains(rule_id) {
+            continue;
         }
-    });
-
+        let Some(meta) = kt_taint_meta(rule_id) else {
+            continue;
+        };
+        let raw = kotlin_taint::analyze_tree(tree.root_node(), source, &spec, None);
+        for finding in raw {
+            findings.push(map_kt_taint_finding(&meta, source, finding));
+        }
+    }
     findings
 }
 
-/// Find the body node of a function declaration.
-#[allow(clippy::manual_find)]
-fn find_function_body(func_node: tree_sitter::Node) -> Option<tree_sitter::Node> {
-    let mut cursor = func_node.walk();
-    for child in func_node.children(&mut cursor) {
-        if child.kind() == "function_body" {
-            return Some(child);
-        }
-    }
-    None
-}
-
-// ─── Sink finders ────────────────────────────────────────────────────────
-
-/// SQL injection sinks: executeQuery, execute, createQuery, prepareStatement, rawQuery, execSQL
-/// with tainted arguments (via concat, interpolation, or direct variable).
-fn find_sql_sinks(node: tree_sitter::Node, src: &str, tainted: &HashSet<String>) -> Vec<TaintSink> {
-    let mut sinks = Vec::new();
-    let sql_methods = [
-        "executeQuery",
-        "execute",
-        "createQuery",
-        "createNativeQuery",
-        "rawQuery",
-        "execSQL",
-        "prepareStatement",
-    ];
-
-    walk_tree(node, src, &mut |n, s| {
-        if n.kind() == "call_expression" {
-            if let Some(name) = call_method_name(n, s) {
-                if sql_methods.contains(&name) {
-                    if let Some(args) = call_arguments(n) {
-                        if expr_uses_tainted(args, s, tainted) {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                line: n.start_position().row + 1,
-                                description: format!("{}() with tainted argument", name),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    });
-    sinks
-}
-
-/// Command injection sinks: Runtime.exec, ProcessBuilder with tainted args.
-fn find_command_sinks(
-    node: tree_sitter::Node,
-    src: &str,
-    tainted: &HashSet<String>,
-) -> Vec<TaintSink> {
-    let mut sinks = Vec::new();
-
-    walk_tree(node, src, &mut |n, s| {
-        if n.kind() == "call_expression" {
-            // Runtime.getRuntime().exec(tainted)
-            if let Some(name) = call_method_name(n, s) {
-                if name == "exec" {
-                    if let Some(receiver) = call_receiver_text(n, s) {
-                        if receiver.contains("getRuntime") || receiver.contains("Runtime") {
-                            if let Some(args) = call_arguments(n) {
-                                if expr_uses_tainted(args, s, tainted) {
-                                    sinks.push(TaintSink {
-                                        start_byte: n.start_byte(),
-                                        end_byte: n.end_byte(),
-                                        line: n.start_position().row + 1,
-                                        description: "Runtime.exec() with tainted argument"
-                                            .to_string(),
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // ProcessBuilder(tainted)
-            if let Some(ctor) = call_constructor_name(n, s) {
-                if ctor == "ProcessBuilder" {
-                    if let Some(args) = call_arguments(n) {
-                        if expr_uses_tainted(args, s, tainted) {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                line: n.start_position().row + 1,
-                                description: "ProcessBuilder() with tainted argument".to_string(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    });
-    sinks
-}
-
-/// SSRF sinks: URL(), HttpClient.get(), OkHttpClient calls, Fuel.get() with tainted URLs.
-fn find_ssrf_sinks(
-    node: tree_sitter::Node,
-    src: &str,
-    tainted: &HashSet<String>,
-) -> Vec<TaintSink> {
-    let mut sinks = Vec::new();
-
-    walk_tree(node, src, &mut |n, s| {
-        if n.kind() == "call_expression" {
-            // URL(tainted), URI(tainted)
-            if let Some(ctor) = call_constructor_name(n, s) {
-                if ctor == "URL" || ctor == "URI" {
-                    if let Some(args) = call_arguments(n) {
-                        if expr_uses_tainted(args, s, tainted) {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                line: n.start_position().row + 1,
-                                description: format!("{}() with tainted argument", ctor),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // HttpClient/OkHttpClient/Fuel method calls: get, post, request, newCall, url
-            if let Some(name) = call_method_name(n, s) {
-                let http_methods = ["get", "post", "put", "delete", "request", "newCall", "url"];
-                if http_methods.contains(&name) {
-                    if let Some(receiver) = call_receiver_text(n, s) {
-                        if receiver.contains("client")
-                            || receiver.contains("Client")
-                            || receiver.contains("http")
-                            || receiver.contains("Http")
-                            || receiver.contains("Fuel")
-                            || receiver.contains("restTemplate")
-                            || receiver.contains("RestTemplate")
-                        {
-                            if let Some(args) = call_arguments(n) {
-                                if expr_uses_tainted(args, s, tainted) {
-                                    sinks.push(TaintSink {
-                                        start_byte: n.start_byte(),
-                                        end_byte: n.end_byte(),
-                                        line: n.start_position().row + 1,
-                                        description: format!(
-                                            "{}.{}() with tainted argument",
-                                            receiver, name
-                                        ),
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // RestTemplate getForObject/getForEntity/postForObject/exchange
-                let rest_methods = [
-                    "getForObject",
-                    "getForEntity",
-                    "postForObject",
-                    "postForEntity",
-                    "exchange",
-                ];
-                if rest_methods.contains(&name) {
-                    if let Some(args) = call_arguments(n) {
-                        if expr_uses_tainted(args, s, tainted) {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                line: n.start_position().row + 1,
-                                description: format!("{}() with tainted URL", name),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Fuel.get(tainted) — Fuel is a constructor-style call
-            if let Some(ctor) = call_constructor_name(n, s) {
-                if ctor == "Fuel" {
-                    // Check if there's a chained .get() call
-                    // This is handled by the method name matching above
-                }
-            }
-        }
-    });
-    sinks
+/// Run a single Kotlin taint rule over a tree. Used by the rule
+/// structs' `check()` path for direct unit tests. The scanner uses
+/// [`run_kt_taint_batched`] to avoid double-dispatch.
+fn run_kt_taint_single(
+    rule_id: &str,
+    source: &str,
+    tree: &tree_sitter::Tree,
+    spec: &kotlin_taint::TaintSpec,
+) -> Vec<Finding> {
+    let Some(meta) = kt_taint_meta(rule_id) else {
+        return Vec::new();
+    };
+    let raw = kotlin_taint::analyze_tree(tree.root_node(), source, spec, None);
+    raw.into_iter()
+        .map(|t| map_kt_taint_finding(&meta, source, t))
+        .collect()
 }
 
 // ─── Rule 11: kt/taint-sql-injection ────────────────────────────────────
@@ -1353,24 +938,12 @@ impl_rule! {
     description = "Untrusted input from Ktor/Spring handler reaches SQL query sink",
     language = Language::Kotlin,
     fn check(_self, source, tree) {
-
-        run_kt_taint(
-            _self.id(),
-            _self.severity(),
-            _self.cwe(),
-            source,
-            tree,
-            &KtTaintSpec {
-                sink_finder: find_sql_sinks,
-            },
-            |src_desc, sink_desc| {
-                format!(
-                    "{} flows to {} — use parameterized queries to prevent SQL injection",
-                    src_desc, sink_desc
-                )
-            },
-        )
-
+        let spec = kotlin_taint::kotlin_taint_rule_specs()
+            .into_iter()
+            .find(|(id, _)| *id == _self.id())
+            .map(|(_, spec)| spec)
+            .unwrap_or_default();
+        run_kt_taint_single(_self.id(), source, tree, &spec)
     }
 }
 
@@ -1386,24 +959,12 @@ impl_rule! {
     description = "Untrusted input from Ktor/Spring handler reaches command execution sink",
     language = Language::Kotlin,
     fn check(_self, source, tree) {
-
-        run_kt_taint(
-            _self.id(),
-            _self.severity(),
-            _self.cwe(),
-            source,
-            tree,
-            &KtTaintSpec {
-                sink_finder: find_command_sinks,
-            },
-            |src_desc, sink_desc| {
-                format!(
-                    "{} flows to {} — avoid passing untrusted input to OS commands",
-                    src_desc, sink_desc
-                )
-            },
-        )
-
+        let spec = kotlin_taint::kotlin_taint_rule_specs()
+            .into_iter()
+            .find(|(id, _)| *id == _self.id())
+            .map(|(_, spec)| spec)
+            .unwrap_or_default();
+        run_kt_taint_single(_self.id(), source, tree, &spec)
     }
 }
 
@@ -1419,24 +980,12 @@ impl_rule! {
     description = "Untrusted input from Ktor/Spring handler reaches HTTP/URL sink",
     language = Language::Kotlin,
     fn check(_self, source, tree) {
-
-        run_kt_taint(
-            _self.id(),
-            _self.severity(),
-            _self.cwe(),
-            source,
-            tree,
-            &KtTaintSpec {
-                sink_finder: find_ssrf_sinks,
-            },
-            |src_desc, sink_desc| {
-                format!(
-                    "{} flows to {} — validate and allowlist target hosts to prevent SSRF",
-                    src_desc, sink_desc
-                )
-            },
-        )
-
+        let spec = kotlin_taint::kotlin_taint_rule_specs()
+            .into_iter()
+            .find(|(id, _)| *id == _self.id())
+            .map(|(_, spec)| spec)
+            .unwrap_or_default();
+        run_kt_taint_single(_self.id(), source, tree, &spec)
     }
 }
 

--- a/src/rules/kotlin_taint.rs
+++ b/src/rules/kotlin_taint.rs
@@ -1,0 +1,853 @@
+//! Intraprocedural, flow-insensitive taint analysis for Kotlin.
+//!
+//! This is the fourth sibling to `python_taint`, `javascript_taint`,
+//! and `go_taint`. It exposes the same public surface — `TaintSpec`,
+//! `NodeMatcher`, `TaintFinding`, `analyze_tree` — so callers can write
+//! declarative `(sources, sinks, sanitizers)` specs the same way they
+//! do for the other languages.
+//!
+//! The internals are Kotlin-grammar-aware (`call_expression`,
+//! `navigation_expression`, `property_declaration`, `simple_identifier`,
+//! `function_value_parameters`, …). Like the other engines, the file
+//! deliberately keeps grammar quirks local rather than trying to share
+//! a polymorphic walker.
+//!
+//! # Scope (mirrors the other engines)
+//!
+//! - **Per function / lambda.** Each `function_declaration` and
+//!   `lambda_literal` body is analyzed independently. Lambdas matter
+//!   because Ktor routes use `routing { get("/path") { … } }` blocks.
+//! - **Per file.** No cross-file analysis (v1).
+//! - **Flow-insensitive.** Two propagation passes; sources seed a name
+//!   set, the analyzer transitively taints any `property_declaration` or
+//!   `assignment` whose initializer/RHS references a tainted name or a
+//!   tainted source expression.
+//! - **String-template interpolation** (`"…${x}…"`) propagates taint.
+//! - **No sanitizers.** Kotlin's spec carries an empty sanitizer list;
+//!   the engine threads the field through for forward compatibility.
+//!
+//! # NodeMatcher interpretation
+//!
+//! Kotlin's grammar means a couple of `NodeMatcher` variants need a
+//! Kotlin-flavoured reading. The interpretation is chosen to preserve
+//! the exact behaviour the bespoke `run_kt_taint()` harness had before
+//! the unified-engine refactor — see `kotlin_taint_rule_specs()` for
+//! the rule specs that drive it.
+//!
+//! - **`Call { canonical }`**
+//!   - If `canonical` has no `.`, matches a constructor-style call
+//!     `Foo(args)` (a `call_expression` whose callee is a bare
+//!     `simple_identifier` equal to `canonical`).
+//!   - If `canonical` is `Receiver.method`, matches a method call where
+//!     the call's receiver text *contains* `Receiver` and the method
+//!     name equals `method`. The receiver-substring rule (rather than
+//!     exact-equals) is required to recognise both `Runtime.getRuntime()`
+//!     and `getRuntime()` style chains, and `call.request.queryParameters`
+//!     style nested navigation — same fuzz the bespoke harness used.
+//! - **`MethodName { method }`** — matches any `call_expression` whose
+//!   method name (last segment of the navigation chain) equals `method`,
+//!   regardless of receiver. Used for sinks like `executeQuery` that
+//!   live on many receiver bindings (`db`, `conn`, `tx`, `stmt`…).
+//! - **`ParamName { names }`** — matches function parameters by name.
+//!   For Kotlin, the `names` list may contain bare identifiers
+//!   (`request`, `req`) which behave like Python/JS, OR Spring-style
+//!   annotation strings (`@RequestParam`, `@RequestBody`, …). When a
+//!   parameter carries one of the annotation strings in its
+//!   `parameter_modifiers`, that parameter is treated as a source.
+//! - **`Attribute { root, field }`** — not currently used by any
+//!   Kotlin rule; reserved for forward compatibility.
+//! - **`MemberAssign { … }`** — JS-specific; ignored.
+
+use crate::rules::common::{walk_tree, AliasTable};
+pub use crate::rules::taint_engine::{NodeMatcher, TaintFinding, TaintSpec};
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/// Run the Kotlin taint engine over every function declaration and
+/// lambda body inside `root` and return one [`TaintFinding`] per
+/// source→sink flow discovered.
+///
+/// The `aliases` argument is currently unused — Kotlin imports use
+/// fully qualified names at sink sites (`Runtime.getRuntime()`,
+/// `javax.script.ScriptEngineManager()`), so a per-file alias table
+/// would not change matching today. The parameter is kept for shape
+/// parity with the other engines.
+pub fn analyze_tree(
+    root: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    _aliases: Option<&AliasTable>,
+) -> Vec<TaintFinding> {
+    let mut findings = Vec::new();
+    walk_tree(root, source, &mut |node, src| {
+        if node.kind() == "function_declaration" || node.kind() == "lambda_literal" {
+            analyze_scope(node, src, spec, &mut findings);
+        }
+    });
+    findings
+}
+
+/// All Kotlin taint rule IDs paired with their specs.
+///
+/// Mirrors `go_taint_rule_specs()` / `python_taint_rule_specs()`.
+/// Consumed by [`crate::rules::builtin_taint_specs_for_language`] so
+/// taint rules show up as `RegistryTaintSpec` entries the same way the
+/// other languages do.
+pub fn kotlin_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
+    vec![
+        ("kt/taint-sql-injection", sql_injection_spec()),
+        ("kt/taint-command-injection", command_injection_spec()),
+        ("kt/taint-ssrf", ssrf_spec()),
+    ]
+}
+
+/// Shared sources for every Kotlin taint rule. Recognises:
+///
+/// - Ktor `call.receiveText()`, `call.receive<T>()`
+/// - Ktor `request.queryParameters[...]`, `call.request.queryParameters[...]`
+/// - Ktor `request.header(...)`, `call.request.header(...)`,
+///   `request.queryParameter(...)`
+/// - Spring annotations `@RequestParam`, `@RequestBody`, `@PathVariable`,
+///   `@RequestHeader` on a function parameter
+///
+/// The annotation entries use `ParamName` with the `@`-prefixed names
+/// the engine recognises specially (see module-level docs).
+pub fn kotlin_taint_sources() -> Vec<NodeMatcher> {
+    vec![
+        NodeMatcher::Call {
+            canonical: "call.receiveText".into(),
+            description: "call.receiveText()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "call.receive".into(),
+            description: "call.receive()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.header".into(),
+            description: "request.header()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.queryParameter".into(),
+            description: "request.queryParameter()".into(),
+        },
+        // Indexing sources (request.queryParameters["x"]) are matched by
+        // `is_indexing_source` directly — they have no NodeMatcher form
+        // today but are baked into the engine for behaviour preservation.
+        NodeMatcher::ParamName {
+            names: vec![
+                "@RequestParam".into(),
+                "@RequestBody".into(),
+                "@PathVariable".into(),
+                "@RequestHeader".into(),
+            ],
+            description: "Spring annotation parameter".into(),
+        },
+    ]
+}
+
+// ─── Rule specs ────────────────────────────────────────────────────────────
+
+fn sql_injection_spec() -> TaintSpec {
+    TaintSpec {
+        sources: kotlin_taint_sources(),
+        sinks: vec![
+            NodeMatcher::MethodName {
+                method: "executeQuery".into(),
+                description: "executeQuery() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "execute".into(),
+                description: "execute() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "createQuery".into(),
+                description: "createQuery() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "createNativeQuery".into(),
+                description: "createNativeQuery() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "rawQuery".into(),
+                description: "rawQuery() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "execSQL".into(),
+                description: "execSQL() with tainted argument".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "prepareStatement".into(),
+                description: "prepareStatement() with tainted argument".into(),
+            },
+        ],
+        sanitizers: vec![],
+    }
+}
+
+fn command_injection_spec() -> TaintSpec {
+    TaintSpec {
+        sources: kotlin_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "Runtime.exec".into(),
+                description: "Runtime.exec() with tainted argument".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "ProcessBuilder".into(),
+                description: "ProcessBuilder() with tainted argument".into(),
+            },
+        ],
+        sanitizers: vec![],
+    }
+}
+
+fn ssrf_spec() -> TaintSpec {
+    TaintSpec {
+        sources: kotlin_taint_sources(),
+        sinks: vec![
+            // URL/URI constructor-style calls.
+            NodeMatcher::Call {
+                canonical: "URL".into(),
+                description: "URL() with tainted argument".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "URI".into(),
+                description: "URI() with tainted argument".into(),
+            },
+            // RestTemplate convenience methods — match by method name on
+            // any receiver. The bespoke harness matched these regardless
+            // of receiver, so `MethodName` is the right shape.
+            NodeMatcher::MethodName {
+                method: "getForObject".into(),
+                description: "getForObject() with tainted URL".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "getForEntity".into(),
+                description: "getForEntity() with tainted URL".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "postForObject".into(),
+                description: "postForObject() with tainted URL".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "postForEntity".into(),
+                description: "postForEntity() with tainted URL".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "exchange".into(),
+                description: "exchange() with tainted URL".into(),
+            },
+        ],
+        sanitizers: vec![],
+    }
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────────
+
+/// Describes a taint source matched inside a function body.
+struct TaintSource {
+    var_name: Option<String>,
+    description: String,
+    line: usize,
+}
+
+/// Describes a taint sink match.
+struct TaintSink {
+    start_byte: usize,
+    end_byte: usize,
+    description: String,
+}
+
+fn analyze_scope(
+    scope_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    out: &mut Vec<TaintFinding>,
+) {
+    let body = find_function_body(scope_node).unwrap_or(scope_node);
+
+    // Collect sources from the body (Ktor `call.*`, indexing) and from
+    // the function's own parameter list (Spring annotations / param
+    // names). For lambda_literal nodes there is no parameter list to
+    // scan separately.
+    let mut sources = collect_body_sources(body, source, spec);
+    if matches!(scope_node.kind(), "function_declaration") {
+        collect_param_sources(scope_node, source, spec, &mut sources);
+    }
+    if sources.is_empty() {
+        return;
+    }
+
+    let tainted = build_tainted_set(body, source, &sources);
+    if tainted.is_empty() {
+        return;
+    }
+
+    let sinks = find_sinks(body, source, spec, &tainted);
+    if sinks.is_empty() {
+        return;
+    }
+
+    // Pick a representative source for the finding's source_description.
+    // Mirrors the bespoke harness's "first source wins" rule.
+    let (source_desc, source_line) = sources
+        .first()
+        .map(|s| (s.description.clone(), s.line))
+        .unwrap_or_else(|| ("user input".to_string(), 0));
+
+    for sink in sinks {
+        let start = byte_to_position(source, sink.start_byte);
+        let end = byte_to_position(source, sink.end_byte);
+        out.push(TaintFinding {
+            sink_start_byte: sink.start_byte,
+            sink_end_byte: sink.end_byte,
+            sink_line: start.0,
+            sink_column: start.1,
+            sink_end_line: end.0,
+            sink_end_column: end.1,
+            source_description: source_desc.clone(),
+            sink_description: sink.description,
+            source_line,
+            rule_id_hint: None,
+            // The Kotlin engine does not yet track hops; report 0 so the
+            // reporting layer leaves confidence at the engine-default and
+            // does not emit a `taint_hops` field, matching the bespoke
+            // harness's prior output.
+            hops: 0,
+        });
+    }
+}
+
+/// Walk a function or lambda body and collect taint sources expressed
+/// as Ktor request reads (call.receiveText(), request.queryParameters[…])
+/// captured inside `property_declaration` or `assignment` initialisers.
+fn collect_body_sources(scope: Node<'_>, source: &str, spec: &TaintSpec) -> Vec<TaintSource> {
+    let mut sources = Vec::new();
+    walk_tree(scope, source, &mut |n, s| {
+        if n.kind() == "property_declaration" {
+            let var = extract_property_var_name(n, s);
+            let initializer = extract_property_initializer(n);
+            if let (Some(var_name), Some(init)) = (var, initializer) {
+                if let Some(desc) = classify_source_expr(init, s, spec) {
+                    sources.push(TaintSource {
+                        var_name: Some(var_name),
+                        description: desc,
+                        line: n.start_position().row + 1,
+                    });
+                }
+            }
+        }
+        if n.kind() == "assignment" {
+            if let (Some(left), Some(right)) =
+                (n.child(0), n.child(n.child_count().saturating_sub(1)))
+            {
+                if left.kind() == "simple_identifier" {
+                    let left_text = &s[left.byte_range()];
+                    if let Some(desc) = classify_source_expr(right, s, spec) {
+                        sources.push(TaintSource {
+                            var_name: Some(left_text.to_string()),
+                            description: desc,
+                            line: n.start_position().row + 1,
+                        });
+                    }
+                }
+            }
+        }
+    });
+    sources
+}
+
+/// Return a source description if `node` is a taint source expression
+/// recognised by `spec`. Implements the Kotlin-specific interpretation
+/// of `NodeMatcher::Call` (receiver-substring + method) and the baked-in
+/// `request.queryParameters[…]` indexing pattern.
+fn classify_source_expr(node: Node<'_>, src: &str, spec: &TaintSpec) -> Option<String> {
+    // Try every spec source that is a Call matcher.
+    if node.kind() == "call_expression" {
+        if let Some(method) = call_method_name(node, src) {
+            if let Some(receiver) = call_receiver_text(node, src) {
+                for matcher in &spec.sources {
+                    if let NodeMatcher::Call { canonical, .. } = matcher {
+                        if let Some(desc) = match_kotlin_call_canonical(canonical, receiver, method)
+                        {
+                            return Some(desc);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Indexing pattern: `request.queryParameters["x"]`, baked in for
+    // parity with the bespoke harness.
+    if is_indexing_source(node, src) {
+        return Some(src[node.byte_range()].to_string());
+    }
+
+    None
+}
+
+/// Check whether a node looks like a Ktor request-indexing source.
+fn is_indexing_source(node: Node<'_>, src: &str) -> bool {
+    let text = &src[node.byte_range()];
+    (node.kind() == "indexing_expression"
+        || text.contains("queryParameters[")
+        || text.contains("parameters["))
+        && (text.contains("request") || text.contains("call"))
+        && (text.contains("queryParameters")
+            || text.contains("parameters[")
+            || text.contains("header"))
+}
+
+/// Apply the Kotlin-flavoured interpretation of `NodeMatcher::Call`.
+/// See the module-level docs for the rules.
+fn match_kotlin_call_canonical(canonical: &str, receiver: &str, method: &str) -> Option<String> {
+    if let Some((expected_recv, expected_method)) = canonical.split_once('.') {
+        if method == expected_method && receiver.contains(expected_recv) {
+            return Some(format!("{}.{}()", receiver, method));
+        }
+    }
+    None
+}
+
+/// Apply the Kotlin-flavoured interpretation of `NodeMatcher::Call` to
+/// sink call sites. Returns `true` if the call matches the canonical
+/// shape (constructor or `Receiver.method`).
+fn match_kotlin_sink_call(
+    canonical: &str,
+    receiver: Option<&str>,
+    method: Option<&str>,
+    ctor_name: Option<&str>,
+) -> bool {
+    if let Some((expected_recv, expected_method)) = canonical.split_once('.') {
+        // Method-on-receiver form: `Runtime.exec`.
+        if let (Some(recv), Some(m)) = (receiver, method) {
+            return m == expected_method && recv.contains(expected_recv);
+        }
+        return false;
+    }
+    // Constructor-style: `ProcessBuilder`, `URL`, …
+    if let Some(ctor) = ctor_name {
+        return ctor == canonical;
+    }
+    false
+}
+
+/// Collect Spring annotation-based parameter sources plus bare
+/// `ParamName` matches from a function declaration. Pushes into the
+/// caller's source list.
+fn collect_param_sources(
+    func_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    out: &mut Vec<TaintSource>,
+) {
+    // Collect annotation strings and bare names from the spec once.
+    let mut annotation_names: Vec<&str> = Vec::new();
+    let mut bare_names: Vec<&str> = Vec::new();
+    for matcher in &spec.sources {
+        if let NodeMatcher::ParamName { names, .. } = matcher {
+            for name in names {
+                if let Some(rest) = name.strip_prefix('@') {
+                    annotation_names.push(rest);
+                } else {
+                    bare_names.push(name.as_str());
+                }
+            }
+        }
+    }
+
+    let mut cursor = func_node.walk();
+    for child in func_node.children(&mut cursor) {
+        if child.kind() != "function_value_parameters" {
+            continue;
+        }
+        let mut c2 = child.walk();
+        let children: Vec<_> = child.children(&mut c2).collect();
+        let mut pending_annotation: Option<&str> = None;
+
+        for ch in &children {
+            if ch.kind() == "parameter_modifiers" {
+                let mod_text = &source[ch.byte_range()];
+                for ann in &annotation_names {
+                    if mod_text.contains(ann) {
+                        pending_annotation = Some(ann);
+                        break;
+                    }
+                }
+            } else if ch.kind() == "parameter" {
+                // Extract the parameter name (first simple_identifier).
+                let mut c3 = ch.walk();
+                let mut param_name: Option<&str> = None;
+                for pc in ch.children(&mut c3) {
+                    if pc.kind() == "simple_identifier" {
+                        param_name = Some(&source[pc.byte_range()]);
+                        break;
+                    }
+                }
+                if let Some(name) = param_name {
+                    if let Some(ann) = pending_annotation.take() {
+                        out.push(TaintSource {
+                            var_name: Some(name.to_string()),
+                            description: format!("@{} parameter '{}'", ann, name),
+                            line: ch.start_position().row + 1,
+                        });
+                    } else if bare_names.iter().any(|n| *n == name) {
+                        out.push(TaintSource {
+                            var_name: Some(name.to_string()),
+                            description: format!("parameter '{}'", name),
+                            line: ch.start_position().row + 1,
+                        });
+                    }
+                }
+                pending_annotation = None;
+            } else if ch.kind() != "," && ch.kind() != "(" && ch.kind() != ")" {
+                pending_annotation = None;
+            }
+        }
+    }
+}
+
+/// Seed the tainted-name set with source variables and transitively
+/// taint locals through simple assignment and string concatenation /
+/// interpolation. Two passes to handle a single level of chained
+/// assignment (`val a = source; val b = a; val c = b + …`).
+fn build_tainted_set(scope: Node<'_>, source: &str, sources: &[TaintSource]) -> HashSet<String> {
+    let mut tainted: HashSet<String> = HashSet::new();
+    for s in sources {
+        if let Some(ref name) = s.var_name {
+            tainted.insert(name.clone());
+        }
+    }
+    if tainted.is_empty() {
+        return tainted;
+    }
+
+    for _ in 0..2 {
+        walk_tree(scope, source, &mut |n, s| {
+            if n.kind() == "property_declaration" {
+                let var = extract_property_var_name(n, s);
+                let init = extract_property_initializer(n);
+                if let (Some(var_name), Some(init_node)) = (var, init) {
+                    if !tainted.contains(&var_name) && expr_uses_tainted(init_node, s, &tainted) {
+                        tainted.insert(var_name);
+                    }
+                }
+            }
+            if n.kind() == "assignment" {
+                if let (Some(left), Some(right)) =
+                    (n.child(0), n.child(n.child_count().saturating_sub(1)))
+                {
+                    if left.kind() == "simple_identifier" {
+                        let left_text = s[left.byte_range()].to_string();
+                        if !tainted.contains(&left_text) && expr_uses_tainted(right, s, &tainted) {
+                            tainted.insert(left_text);
+                        }
+                    }
+                }
+            }
+        });
+    }
+    tainted
+}
+
+/// Recursively check whether `node` references any tainted variable.
+/// Picks up `simple_identifier` references and `"…${tainted}…"`
+/// string-template interpolations.
+fn expr_uses_tainted(node: Node<'_>, src: &str, tainted: &HashSet<String>) -> bool {
+    if node.kind() == "simple_identifier" {
+        let name = &src[node.byte_range()];
+        return tainted.contains(name);
+    }
+    if node.kind() == "string_literal" {
+        let text = &src[node.byte_range()];
+        for t in tainted {
+            if text.contains(&format!("${{{}}}", t)) || text.contains(&format!("${}", t)) {
+                return true;
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if expr_uses_tainted(child, src, tainted) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk `scope` and emit a sink for every call expression whose callee
+/// matches the spec's sink list AND whose arguments reference a tainted
+/// variable.
+fn find_sinks(
+    scope: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    tainted: &HashSet<String>,
+) -> Vec<TaintSink> {
+    let mut sinks = Vec::new();
+    walk_tree(scope, source, &mut |n, s| {
+        if n.kind() != "call_expression" {
+            return;
+        }
+        let method = call_method_name(n, s);
+        let receiver = call_receiver_text(n, s);
+        let ctor = call_constructor_name(n, s);
+
+        let Some(args) = call_arguments(n) else {
+            return;
+        };
+        if !expr_uses_tainted(args, s, tainted) {
+            return;
+        }
+
+        for matcher in &spec.sinks {
+            match matcher {
+                NodeMatcher::MethodName {
+                    method: m,
+                    description,
+                } => {
+                    if let Some(name) = method {
+                        if name == m {
+                            sinks.push(TaintSink {
+                                start_byte: n.start_byte(),
+                                end_byte: n.end_byte(),
+                                description: description.clone(),
+                            });
+                            return;
+                        }
+                    }
+                }
+                NodeMatcher::Call {
+                    canonical,
+                    description,
+                } => {
+                    if match_kotlin_sink_call(canonical, receiver, method, ctor) {
+                        sinks.push(TaintSink {
+                            start_byte: n.start_byte(),
+                            end_byte: n.end_byte(),
+                            description: description.clone(),
+                        });
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+    sinks
+}
+
+// ─── Kotlin AST helpers ────────────────────────────────────────────────────
+
+/// Extract the method name from a `call_expression` whose callee is a
+/// `navigation_expression`. Returns the last `simple_identifier` inside
+/// the trailing `navigation_suffix`.
+fn call_method_name<'a>(node: Node<'a>, src: &'a str) -> Option<&'a str> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let callee = node.child(0)?;
+    if callee.kind() == "navigation_expression" {
+        let nav_suffix = callee.child(callee.child_count().checked_sub(1)?)?;
+        if nav_suffix.kind() == "navigation_suffix" {
+            let mut cursor = nav_suffix.walk();
+            for child in nav_suffix.children(&mut cursor) {
+                if child.kind() == "simple_identifier" {
+                    return Some(&src[child.byte_range()]);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Receiver text for a `call_expression` whose callee is a
+/// `navigation_expression`: everything before the trailing `.method`.
+fn call_receiver_text<'a>(node: Node<'a>, src: &'a str) -> Option<&'a str> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let callee = node.child(0)?;
+    if callee.kind() == "navigation_expression" {
+        let receiver = callee.child(0)?;
+        return Some(&src[receiver.byte_range()]);
+    }
+    None
+}
+
+/// Constructor-style callee: for `Foo(args)` returns `Foo`.
+fn call_constructor_name<'a>(node: Node<'a>, src: &'a str) -> Option<&'a str> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let callee = node.child(0)?;
+    if callee.kind() == "simple_identifier" {
+        return Some(&src[callee.byte_range()]);
+    }
+    None
+}
+
+/// Locate the `value_arguments` node inside a `call_expression`.
+fn call_arguments(node: Node<'_>) -> Option<Node<'_>> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "call_suffix" {
+            let mut c2 = child.walk();
+            for grandchild in child.children(&mut c2) {
+                if grandchild.kind() == "value_arguments" {
+                    return Some(grandchild);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Variable name of a `property_declaration` (`val x = …`).
+fn extract_property_var_name(node: Node<'_>, src: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "variable_declaration" {
+            let mut c2 = child.walk();
+            for gc in child.children(&mut c2) {
+                if gc.kind() == "simple_identifier" {
+                    return Some(src[gc.byte_range()].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Initializer expression of a `property_declaration` (after the `=`).
+fn extract_property_initializer(node: Node<'_>) -> Option<Node<'_>> {
+    if node.child_count() < 3 {
+        return None;
+    }
+    let mut found_eq = false;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if found_eq && child.kind() != "=" {
+            return Some(child);
+        }
+        if child.kind() == "=" {
+            found_eq = true;
+        }
+    }
+    None
+}
+
+/// Body node of a `function_declaration` / `lambda_literal`, if any.
+fn find_function_body(func_node: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = func_node.walk();
+    for child in func_node.children(&mut cursor) {
+        if child.kind() == "function_body" {
+            return Some(child);
+        }
+    }
+    None
+}
+
+/// Convert a byte offset into the source to a `(line, column)` pair,
+/// matching the conventions used by `make_finding_from_offsets`.
+fn byte_to_position(source: &str, byte: usize) -> (usize, usize) {
+    let byte = byte.min(source.len());
+    let line = source[..byte].bytes().filter(|b| *b == b'\n').count() + 1;
+    let line_start = source[..byte].rfind('\n').map_or(0, |idx| idx + 1);
+    let column = source[line_start..byte].chars().count() + 1;
+    (line, column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parser::parse_file;
+    use crate::Language;
+
+    fn analyze(src: &str, spec: &TaintSpec) -> Vec<TaintFinding> {
+        let tree = parse_file(src, Language::Kotlin).expect("parse");
+        analyze_tree(tree.root_node(), src, spec, None)
+    }
+
+    #[test]
+    fn sql_injection_via_ktor_receive() {
+        let src = r#"
+fun Application.module() {
+    routing {
+        post("/users") {
+            val body = call.receiveText()
+            val query = "SELECT * FROM users WHERE name = '" + body + "'"
+            db.executeQuery(query)
+        }
+    }
+}
+"#;
+        let findings = analyze(src, &sql_injection_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect tainted SQL via call.receiveText(): {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn command_injection_via_request_param() {
+        let src = r#"
+@PostMapping("/exec")
+fun execute(@RequestBody input: String) {
+    val args = input.split(" ")
+    ProcessBuilder(args).start()
+}
+"#;
+        let findings = analyze(src, &command_injection_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect tainted ProcessBuilder via @RequestBody: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn ssrf_transitive_flow() {
+        let src = r#"
+fun Application.module() {
+    routing {
+        post("/fetch") {
+            val body = call.receiveText()
+            val target = body
+            val endpoint = "https://internal/" + target
+            val url = URL(endpoint)
+        }
+    }
+}
+"#;
+        let findings = analyze(src, &ssrf_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect SSRF via transitive flow: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn clean_literal_no_finding() {
+        let src = r#"
+fun handler(call: ApplicationCall) {
+    val data = call.receiveText()
+    Runtime.getRuntime().exec("ls -la")
+}
+"#;
+        let findings = analyze(src, &command_injection_spec());
+        assert!(
+            findings.is_empty(),
+            "literal command should not trigger taint: {:?}",
+            findings
+        );
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -8,6 +8,7 @@ pub mod java;
 pub mod javascript;
 pub mod javascript_taint;
 pub mod kotlin;
+pub mod kotlin_taint;
 pub mod manifest;
 pub mod php;
 pub mod python;
@@ -38,6 +39,7 @@ static BUNDLED_RULES: include_dir::Dir<'_> = include_dir::include_dir!("$CARGO_M
 pub enum TaintEngine {
     Go,
     JavaScript,
+    Kotlin,
     Python,
 }
 
@@ -718,6 +720,15 @@ fn builtin_taint_specs_for_language(language: Language) -> Vec<RegistryTaintSpec
                 rule_id,
                 language,
                 engine: TaintEngine::Python,
+                spec,
+            })
+            .collect(),
+        Language::Kotlin => kotlin_taint::kotlin_taint_rule_specs()
+            .into_iter()
+            .map(|(rule_id, spec)| RegistryTaintSpec {
+                rule_id,
+                language,
+                engine: TaintEngine::Kotlin,
                 spec,
             })
             .collect(),


### PR DESCRIPTION
## Summary

The three `kt/taint-*-injection` rules previously used a bespoke `run_kt_taint()` harness with hardcoded sink finders, while Python/JS/Go all consume the shared `TaintSpec` / `analyze_tree` engine via `RegistryTaintSpec` entries (audit finding #1). This PR brings Kotlin taint analysis to the same shape:

- **New `src/rules/kotlin_taint.rs`** — fourth sibling to `python_taint` / `javascript_taint` / `go_taint`, exposes the same surface (`TaintSpec`, `NodeMatcher`, `TaintFinding`, `analyze_tree`) plus `kotlin_taint_sources()` and `kotlin_taint_rule_specs()`.
- **Declarative rule specs** — the existing Kotlin sources (Ktor `call.receiveText()`, `request.queryParameters[…]`, Spring annotations) and sinks (`Runtime.exec`, `ProcessBuilder`, `URL`/`URI`, RestTemplate, `executeQuery`/`prepareStatement` family) are encoded as `NodeMatcher`s. No new variants needed — the Kotlin engine interprets `Call { canonical }` as constructor-style when canonical has no `.`, receiver-substring + method-name when it's `Receiver.method`, and accepts `@`-prefixed `ParamName` entries as Spring annotations.
- **Wired into `builtin_taint_specs_for_language()`** with a new `TaintEngine::Kotlin` variant, and added `run_kt_taint_batched` + scanner dispatcher branch mirroring the Go/Python/JS pattern.
- **Removes the bespoke harness** — `run_kt_taint`, `KtTaintSpec`, `find_sql_sinks` / `find_command_sinks` / `find_ssrf_sinks`, `collect_sources`, `build_tainted_set`, and the duplicated AST helpers in `kotlin.rs` (~660 lines deleted). Rule structs (`TaintSqlInjection` / `TaintCommandInjection` / `TaintSsrf`) stay registered so direct `check()` unit-test invocations continue to work; the body now delegates to `kotlin_taint::analyze_tree`.

### Before / after

```
src/engine/scanner.rs     |  25 ++
src/rules/kotlin.rs       | 785 +++++++++---------------------------------
src/rules/kotlin_taint.rs | 853 ++++++++++++++++++++++++++++++++++++++++++++++
src/rules/mod.rs          |  11 +
4 files changed, 1056 insertions(+), 618 deletions(-)
```

### Finding-stability proof

`tests/fixtures/vulnerable.kt` produces 12 findings before and after, with byte-identical content (rule IDs, line numbers, severities, descriptions, source/sink descriptions):

```
$ jq -S '.findings | sort_by(.line, .column, .rule_id)' baseline.json > a
$ jq -S '.findings | sort_by(.line, .column, .rule_id)' after.json > b
$ diff a b
# (no output)
```

The only JSON diff vs baseline is the relative ordering of two findings that share `(line=53, column=5)` — the scanner sorts by `(file, line, column)` without a rule_id tiebreaker, so when `kt/taint-sql-injection` moves from the AST batch to the dedicated taint dispatcher its insertion order shifts. No test depends on this ordering.

### Tests

- [x] `cargo test kotlin` → 38 passed (34 original + 4 new in `kotlin_taint`).
- [x] `cargo test taint` → 187 passed.
- [x] `cargo test --all` → 672 passed, 0 failed, 5 ignored.
- [x] `cargo fmt` clean.
- [x] `cargo clippy --lib` → 257 warnings (was 259 on `main`).
- [x] Manual byte-diff of `vulnerable.kt` JSON output: identical after sorting (see proof above).

### Notes

- No `TaintSpec` schema changes were required — Kotlin reuses the existing `NodeMatcher` variants with a documented Kotlin-flavoured interpretation of `Call { canonical }` (constructor-style vs `Receiver.method`). This mirrors how Go uses `MethodName` and Python uses `Attribute` with grammar-aware semantics.
- No latent bugs were silently fixed; behaviour is preserved across the existing test fixtures.

Refs: rule-architecture audit item #1.

## Test plan

- [x] `cargo fmt && cargo test --all` pass locally.
- [x] `vulnerable.kt` byte-diff matches.
- [x] Clippy warnings did not regress past baseline.