### PR TITLE
fix(vscode): handle versioned JSON envelope from CLI output

### DIFF
--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -7802,16 +7802,16 @@
       "line": 328
     },
     {
-      "fingerprint": "56e07b4339a62164ecbff21e94eafbaf1ca97d6e99b56300e4b14acda6318444",
+      "fingerprint": "b1ce75957d582e0ca76386975b2c23fb09ad77f4a81dbc6513ae957de7230824",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
+      "file": "/Users/peak/coding/0sec/foxguard/vscode-extension/src/extension.ts",
       "line": 263
     },
     {
-      "fingerprint": "4cf1c478a2c49176af7c1f72f0f07ee70372ce79a946079bdb42dbf5b83d28b1",
+      "fingerprint": "a041300cf7a11c01ffbd47ff0dbc9b8911eb53c07d3021ac911eea2518fa7f61",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
-      "line": 368
+      "file": "/Users/peak/coding/0sec/foxguard/vscode-extension/src/extension.ts",
+      "line": 369
     }
   ]
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -277,7 +277,8 @@ function scanDocument(document: vscode.TextDocument): void {
 
         let findings: Finding[];
         try {
-          findings = JSON.parse(stdout);
+          const report = JSON.parse(stdout);
+          findings = Array.isArray(report) ? report : report.findings;
         } catch (e) {
           outputChannel.appendLine(`Parse error: ${e}`);
           setStatusDone(0);
@@ -378,7 +379,8 @@ async function scanWorkspace(): Promise<void> {
 
             let findings: Finding[];
             try {
-              findings = JSON.parse(stdout);
+              const report = JSON.parse(stdout);
+              findings = Array.isArray(report) ? report : report.findings;
             } catch {
               resolve();
               return;


### PR DESCRIPTION
## Summary

- The CLI now emits a `JsonReportEnvelope` with a `findings` field, but the VS Code extension assumed stdout was a raw findings array.
- Both `scanDocument` and `scanWorkspace` JSON parsing sites are updated to handle both envelope and legacy formats: `const findings = Array.isArray(report) ? report : report.findings`.
- Updated the scan baseline to account for shifted line numbers in `extension.ts`.

Closes #400

## Test plan

- [ ] Run the extension against a CLI that emits the new envelope format and verify diagnostics appear
- [ ] Run the extension against an older CLI that emits a raw array and verify backward compatibility
- [ ] Verify `npm run compile` passes cleanly

none