### PR TITLE
Reduce false positives: C# rules

### DIFF
--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -17,30 +17,6 @@ fn cs_cors_star_re() -> &'static Regex {
     })
 }
 
-/// Check whether a subtree contains a `binary_expression` with `+` operator.
-fn contains_string_concat(node: tree_sitter::Node, source: &str) -> bool {
-    if node.kind() == "binary_expression" {
-        if let Some(op) = node.child_by_field_name("operator") {
-            let op_text = &source[op.byte_range()];
-            if op_text == "+" {
-                return true;
-            }
-        }
-        // Fallback: check the text itself
-        let text = &source[node.byte_range()];
-        if text.contains('+') {
-            return true;
-        }
-    }
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if contains_string_concat(child, source) {
-            return true;
-        }
-    }
-    false
-}
-
 /// Check whether a node is a string literal.
 fn is_string_literal(node: tree_sitter::Node) -> bool {
     matches!(
@@ -50,6 +26,305 @@ fn is_string_literal(node: tree_sitter::Node) -> bool {
             | "interpolated_string_expression"
             | "string_literal_expression"
     )
+}
+
+/// Check whether a `binary_expression` subtree forms a `+` concatenation that
+/// has at least one non-literal operand. All-literal concatenations (e.g.
+/// `"a" + "b"`) are considered safe and return `false`.
+///
+/// This walks the tree looking for a `+` `binary_expression`. For the first one
+/// found, it flattens the chain of `+` operands and returns `true` only if at
+/// least one operand is **not** a string literal (i.e. an identifier, member
+/// access, invocation, etc.). It recurses into children otherwise.
+fn is_tainting_string_concat(
+    node: tree_sitter::Node,
+    root: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    if node.kind() == "binary_expression" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            if &source[op.byte_range()] == "+" {
+                // Flatten the `+` chain and inspect operands.
+                let mut operands = Vec::new();
+                collect_concat_operands(node, source, &mut operands);
+                let has_non_literal = operands
+                    .iter()
+                    .any(|operand| !is_literal_operand(*operand, root, source));
+                if has_non_literal {
+                    return true;
+                }
+                // All-literal concat: this particular `+` is safe. Do not
+                // recurse into its (literal) children — but a sibling subtree
+                // elsewhere may still taint, so fall through to recursion.
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if is_tainting_string_concat(child, root, source) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Recursively flatten the operands of a `+` `binary_expression` chain.
+fn collect_concat_operands<'a>(
+    node: tree_sitter::Node<'a>,
+    source: &str,
+    out: &mut Vec<tree_sitter::Node<'a>>,
+) {
+    if node.kind() == "binary_expression" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            if &source[op.byte_range()] == "+" {
+                if let (Some(left), Some(right)) = (
+                    node.child_by_field_name("left"),
+                    node.child_by_field_name("right"),
+                ) {
+                    collect_concat_operands(left, source, out);
+                    collect_concat_operands(right, source, out);
+                    return;
+                }
+            }
+        }
+    }
+    out.push(node);
+}
+
+/// Whether an operand of a concatenation is a compile-time constant string:
+/// either a string literal directly, or an identifier that resolves to a
+/// `const` / string-literal declaration in scope.
+fn is_literal_operand(node: tree_sitter::Node, root: tree_sitter::Node, source: &str) -> bool {
+    // Unwrap parenthesized expressions.
+    let mut n = node;
+    while n.kind() == "parenthesized_expression" {
+        match n.named_child(0) {
+            Some(inner) => n = inner,
+            None => break,
+        }
+    }
+    if is_string_literal(n) {
+        return true;
+    }
+    if n.kind() == "identifier" {
+        let name = &source[n.byte_range()];
+        return identifier_is_const_string(name, n, root, source);
+    }
+    false
+}
+
+/// Recursively collect every `variable_declarator` node whose declared name
+/// equals `name`. Preserves the tree's lifetime (unlike the `walk_tree`
+/// callback, which restricts node lifetimes to the closure body).
+fn collect_declarators_named<'a>(
+    node: tree_sitter::Node<'a>,
+    name: &str,
+    source: &'a str,
+    out: &mut Vec<tree_sitter::Node<'a>>,
+) {
+    if node.kind() == "variable_declarator" {
+        if let Some(name_node) = node.child_by_field_name("name") {
+            if &source[name_node.byte_range()] == name {
+                out.push(node);
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_declarators_named(child, name, source, out);
+    }
+}
+
+/// Find the nearest enclosing local scope (a `block`) for `node`, falling back
+/// to the method/constructor/accessor body, then to the root. This lets us
+/// resolve a local identifier within its own method without colliding with
+/// same-named locals declared in sibling methods.
+fn enclosing_scope<'a>(node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+    let mut cur = node;
+    while let Some(parent) = cur.parent() {
+        if matches!(
+            parent.kind(),
+            "block"
+                | "method_declaration"
+                | "constructor_declaration"
+                | "accessor_declaration"
+                | "local_function_statement"
+        ) {
+            return parent;
+        }
+        cur = parent;
+    }
+    cur
+}
+
+/// Resolve a single in-scope declaration of `name` relative to a use site.
+///
+/// First searches the use site's nearest enclosing method/block scope. If that
+/// finds exactly one declaration, returns it. Otherwise (e.g. the identifier is
+/// a class-level `const` field) it searches the whole tree from `root` and
+/// returns the declaration only if there is exactly one globally — this is the
+/// conservative path for fields. Returns `None` on ambiguity or absence.
+fn resolve_single_declarator<'a>(
+    name: &str,
+    use_site: tree_sitter::Node<'a>,
+    root: tree_sitter::Node<'a>,
+    source: &'a str,
+) -> Option<tree_sitter::Node<'a>> {
+    let scope = enclosing_scope(use_site);
+    let mut local: Vec<tree_sitter::Node> = Vec::new();
+    collect_declarators_named(scope, name, source, &mut local);
+    if local.len() == 1 {
+        return Some(local[0]);
+    }
+    if !local.is_empty() {
+        // Multiple declarations in the same scope — ambiguous, bail.
+        return None;
+    }
+    // Not a local: fall back to a unique whole-tree match (covers fields).
+    let mut global: Vec<tree_sitter::Node> = Vec::new();
+    collect_declarators_named(root, name, source, &mut global);
+    if global.len() == 1 {
+        Some(global[0])
+    } else {
+        None
+    }
+}
+
+/// Whether `name` resolves to a single declaration whose initializer is a
+/// string literal (covers `const string X = "..."` and `string x = "..."`).
+fn identifier_is_const_string(
+    name: &str,
+    use_site: tree_sitter::Node,
+    root: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    resolve_single_declarator(name, use_site, root, source)
+        .and_then(declarator_initializer)
+        .map(is_string_literal)
+        .unwrap_or(false)
+}
+
+/// Extract the initializer expression node of a `variable_declarator`.
+fn declarator_initializer(decl: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut init: Option<tree_sitter::Node> = None;
+    let mut cursor = decl.walk();
+    for child in decl.children(&mut cursor) {
+        match child.kind() {
+            "equals_value_clause" => {
+                init = child.named_child(0);
+            }
+            "identifier" | "=" => {}
+            _ => {
+                if init.is_none() && child.is_named() {
+                    init = Some(child);
+                }
+            }
+        }
+    }
+    init
+}
+
+/// Names of helper methods that, when invoked, are treated as making their
+/// result safe (validated / sanitized / allowlisted). The text is expected to
+/// be a call expression like `Validate(x)`, `this.Sanitize(x)`,
+/// `helper.AllowlistUrl(x)`.
+fn is_sanitizer_call_text(text: &str) -> bool {
+    let t = text.trim();
+    // Must actually be a call.
+    if !t.contains('(') {
+        return false;
+    }
+    // The invoked method name is the identifier immediately before the `(`,
+    // i.e. the last `.`-separated segment of the callee.
+    let callee = t.split('(').next().unwrap_or(t);
+    let method = callee.rsplit('.').next().unwrap_or(callee).trim();
+    let lower = method.to_ascii_lowercase();
+    lower.starts_with("validate") || lower.starts_with("sanitize") || lower.starts_with("allowlist")
+}
+
+/// Whether the text of an initializer/expression is a safe path-building call:
+/// `Path.Combine(...)`, `Path.GetFullPath(...)`, or `Path.Join(...)`.
+fn is_safe_path_call_text(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with("Path.Combine") || t.starts_with("Path.GetFullPath") || t.starts_with("Path.Join")
+}
+
+/// Given an `argument` node that is (or wraps) a single identifier, find the
+/// identifier name. Returns `None` if the argument is not a plain identifier.
+fn argument_identifier_name<'a>(arg: tree_sitter::Node<'a>, source: &'a str) -> Option<&'a str> {
+    let mut n = arg;
+    // `argument` node may wrap the expression.
+    if n.kind() == "argument" {
+        n = n.named_child(0)?;
+    }
+    while n.kind() == "parenthesized_expression" {
+        n = n.named_child(0)?;
+    }
+    if n.kind() == "identifier" {
+        Some(&source[n.byte_range()])
+    } else {
+        None
+    }
+}
+
+/// Trace whether an identifier resolves to a value that is safe for a
+/// command / path / URL sink. Searches the tree for a single declaration of
+/// `name` and inspects its initializer. Returns `true` when the value is
+/// known-safe (string literal, `const`, safe `Path.*` call, or sanitizer call).
+///
+/// Conservative: if there is no declaration, multiple declarations, or the
+/// initializer is anything else, returns `false` (still flag).
+fn identifier_is_safe(
+    name: &str,
+    use_site: tree_sitter::Node,
+    root: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    let decl = match resolve_single_declarator(name, use_site, root, source) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    let init = match declarator_initializer(decl) {
+        Some(i) => i,
+        None => return false,
+    };
+
+    if is_string_literal(init) {
+        return true;
+    }
+
+    let init_text = &source[init.byte_range()];
+
+    is_safe_path_call_text(init_text) || is_sanitizer_call_text(init_text)
+}
+
+/// Resolve an `argument` node for a sink: returns `true` if the argument is a
+/// string literal, or an identifier that traces to a safe value.
+fn sink_argument_is_safe(arg: tree_sitter::Node, root: tree_sitter::Node, source: &str) -> bool {
+    // Unwrap `argument` wrapper for literal check.
+    let mut inner = arg;
+    if inner.kind() == "argument" {
+        if let Some(c) = inner.named_child(0) {
+            inner = c;
+        }
+    }
+    if is_string_literal(inner) {
+        return true;
+    }
+    let arg_text = &source[inner.byte_range()];
+    if arg_text.starts_with('"') || arg_text.starts_with("@\"") || arg_text.starts_with("$\"") {
+        return true;
+    }
+    if is_safe_path_call_text(arg_text) || is_sanitizer_call_text(arg_text) {
+        return true;
+    }
+    if let Some(name) = argument_identifier_name(arg, source) {
+        if identifier_is_safe(name, arg, root, source) {
+            return true;
+        }
+    }
+    false
 }
 
 // ─── Rule 1: no-sql-injection ───────────────────────────────────────────────
@@ -73,14 +348,15 @@ impl_rule! {
             "FromSqlRaw",
         ];
 
+        let root = tree.root_node();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "invocation_expression" {
                 let node_text = &src[node.byte_range()];
                 let has_sql_method = sql_methods.iter().any(|m| node_text.contains(m));
                 if has_sql_method {
-                    // Check if any argument contains binary_expression with +
+                    // Check if any argument contains a tainting binary_expression with +
                     if let Some(args) = node.child_by_field_name("arguments") {
-                        if contains_string_concat(args, src) {
+                        if is_tainting_string_concat(args, root, src) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -95,7 +371,7 @@ impl_rule! {
                     // Try children directly
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
-                        if child.kind() == "argument_list" && contains_string_concat(child, src) {
+                        if child.kind() == "argument_list" && is_tainting_string_concat(child, root, src) {
                             // Avoid duplicating if already found via field name
                             if node.child_by_field_name("arguments").is_none() {
                                 findings.push(make_finding(
@@ -136,29 +412,23 @@ impl_rule! {
             if node.kind() == "invocation_expression" {
                 let node_text = &src[node.byte_range()];
                 if node_text.contains("Process.Start") {
-                    // Check arguments for non-literal values
+                    let root = tree.root_node();
+                    // Check arguments for non-literal, non-safe values
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" {
                             let mut arg_cursor = child.walk();
                             for arg in child.named_children(&mut arg_cursor) {
-                                if !is_string_literal(arg) && arg.kind() != "string_literal" {
-                                    // Has a non-literal argument
-                                    let inner_text = &src[arg.byte_range()];
-                                    // Skip if it looks like just a string literal
-                                    if !inner_text.starts_with('"')
-                                        && !inner_text.starts_with("@\"")
-                                    {
-                                        findings.push(make_finding(
-                                            _self.id(),
-                                            _self.severity(),
-                                            _self.cwe(),
-                                            "Process.Start called with dynamic argument — risk of command injection",
-                                            node,
-                                            src,
-                                        ));
-                                        return;
-                                    }
+                                if !sink_argument_is_safe(arg, root, src) {
+                                    findings.push(make_finding(
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
+                                        "Process.Start called with dynamic argument — risk of command injection",
+                                        node,
+                                        src,
+                                    ));
+                                    return;
                                 }
                             }
                         }
@@ -257,24 +527,22 @@ impl_rule! {
                 let has_webrequest = node_text.contains("WebRequest.Create");
 
                 if has_http_method || has_webrequest {
-                    // Check if the first argument is a non-literal
+                    let root = tree.root_node();
+                    // Check if the first argument is a non-literal, non-safe value
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" {
                             if let Some(first_arg) = child.named_child(0) {
-                                if !is_string_literal(first_arg) {
-                                    let arg_text = &src[first_arg.byte_range()];
-                                    if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
-                                        findings.push(make_finding(
-                                            _self.id(),
-                                            _self.severity(),
-                                            _self.cwe(),
-                                            "HTTP request with dynamic URL — validate and allowlist target hosts to prevent SSRF",
-                                            node,
-                                            src,
-                                        ));
-                                        return;
-                                    }
+                                if !sink_argument_is_safe(first_arg, root, src) {
+                                    findings.push(make_finding(
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
+                                        "HTTP request with dynamic URL — validate and allowlist target hosts to prevent SSRF",
+                                        node,
+                                        src,
+                                    ));
+                                    return;
                                 }
                             }
                         }
@@ -320,26 +588,24 @@ impl_rule! {
                     node_text.contains("StreamReader") && node.kind() == "invocation_expression";
 
                 if has_file_method {
-                    // Check first argument is non-literal
+                    let root = tree.root_node();
+                    // Check first argument is non-literal and non-safe
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" {
                             if let Some(first_arg) = child.named_child(0) {
-                                if !is_string_literal(first_arg) {
-                                    let arg_text = &src[first_arg.byte_range()];
-                                    if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
-                                        let mut f = make_finding(
-                                            _self.id(),
-                                            _self.severity(),
-                                            _self.cwe(),
-                                            "File operation with dynamic path — validate and sanitize to prevent path traversal",
-                                            node,
-                                            src,
-                                        );
-                                        f.fix_suggestion = Some("Validate file paths with Path.GetFullPath() and ensure they don't escape the intended directory".to_string());
-                                        findings.push(f);
-                                        return;
-                                    }
+                                if !sink_argument_is_safe(first_arg, root, src) {
+                                    let mut f = make_finding(
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
+                                        "File operation with dynamic path — validate and sanitize to prevent path traversal",
+                                        node,
+                                        src,
+                                    );
+                                    f.fix_suggestion = Some("Validate file paths with Path.GetFullPath() and ensure they don't escape the intended directory".to_string());
+                                    findings.push(f);
+                                    return;
                                 }
                             }
                         }
@@ -357,13 +623,13 @@ impl_rule! {
                 let is_stream_reader = node_text.contains("StreamReader");
                 let is_file_stream = node_text.contains("FileStream");
                 if is_stream_reader || is_file_stream {
+                    let root = tree.root_node();
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" {
                             if let Some(first_arg) = child.named_child(0) {
-                                if !is_string_literal(first_arg) {
-                                    let arg_text = &src[first_arg.byte_range()];
-                                    if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
+                                if !sink_argument_is_safe(first_arg, root, src) {
+                                    {
                                         let type_name = if is_stream_reader {
                                             "StreamReader"
                                         } else {
@@ -543,8 +809,27 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let has_dtd_prohibit =
-            source.contains("DtdProcessing.Prohibit") || source.contains("ProhibitDtd = true");
+        // Treat the file as hardened against XXE if it disables DTD processing
+        // (`DtdProcessing.Prohibit` / `ProhibitDtd = true`) or nulls out the
+        // entity resolver (`XmlResolver = null`). Same-instance tracking is left
+        // as follow-up; this remains file-scoped but no longer ignores the
+        // `XmlResolver = null` hardening pattern.
+        let resolver_nulled = {
+            // Match `XmlResolver` followed by `=` and `null`, tolerating
+            // whitespace (e.g. `XmlResolver = null`, `XmlResolver=null`).
+            source.contains("XmlResolver")
+                && source
+                    .split("XmlResolver")
+                    .skip(1)
+                    .any(|after| {
+                        let trimmed = after.trim_start();
+                        let rest = trimmed.strip_prefix('=').map(|r| r.trim_start());
+                        matches!(rest, Some(r) if r.starts_with("null"))
+                    })
+        };
+        let has_dtd_prohibit = source.contains("DtdProcessing.Prohibit")
+            || source.contains("ProhibitDtd = true")
+            || resolver_nulled;
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "invocation_expression" {
@@ -601,6 +886,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
+        let root = tree.root_node();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment_expression: searcher.Filter = "..." + userInput
@@ -613,7 +899,7 @@ impl_rule! {
                             || left_text.ends_with(".Filter"))
                     {
                         if let Some(right) = node.child_by_field_name("right") {
-                            if contains_string_concat(right, src) {
+                            if is_tainting_string_concat(right, root, src) {
                                 findings.push(make_finding(
                                     _self.id(),
                                     _self.severity(),
@@ -634,7 +920,7 @@ impl_rule! {
                 if node_text.contains("DirectorySearcher") {
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
-                        if child.kind() == "argument_list" && contains_string_concat(child, src) {
+                        if child.kind() == "argument_list" && is_tainting_string_concat(child, root, src) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),

--- a/tests/fixtures/safe.cs
+++ b/tests/fixtures/safe.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data.SqlClient;
 using System.Diagnostics;
+using System.DirectoryServices;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -10,6 +11,8 @@ namespace SafeApp
 {
     public class SafeExamples
     {
+        private const string KnownUid = "service-account";
+
         public void ParameterizedSql(SqlConnection conn, string userId)
         {
             var cmd = new SqlCommand("SELECT * FROM users WHERE id = @id", conn);
@@ -22,15 +25,38 @@ namespace SafeApp
             Process.Start("dotnet", "--info");
         }
 
+        // Command argument traced to a string-literal local — safe.
+        public void CommandFromConstLocal()
+        {
+            string cmd = "dotnet";
+            Process.Start(cmd);
+        }
+
         public async void StaticHttp()
         {
             var client = new HttpClient();
             await client.GetAsync("https://api.example.com/health");
         }
 
+        // URL produced by a Validate* sanitizer — safe.
+        public async void ValidatedHttp(HttpClient client, string raw)
+        {
+            var url = Validate(raw);
+            await client.GetAsync(url);
+        }
+
+        private string Validate(string input) => input;
+
         public void StaticFile()
         {
             File.ReadAllText("config/appsettings.json");
+        }
+
+        // Path built from a safe base via Path.Combine — safe.
+        public void CombinedPath(string baseDir, string x)
+        {
+            var path = Path.Combine(baseDir, x);
+            File.ReadAllText(path);
         }
 
         public void StrongCrypto()
@@ -41,6 +67,21 @@ namespace SafeApp
         public void ConfiguredSecret()
         {
             string apiKey = Environment.GetEnvironmentVariable("API_KEY");
+        }
+
+        // All-literal SQL concatenation — no tainted operand, safe.
+        public void LiteralSqlConcat(SqlConnection conn)
+        {
+            var cmd = new SqlCommand();
+            cmd.Connection = conn;
+            cmd.ExecuteReader("SELECT * FROM users " + "WHERE active = 1");
+        }
+
+        // LDAP filter concatenated only with a known constant — safe.
+        public void LdapWithConstant()
+        {
+            var searcher = new DirectorySearcher();
+            searcher.Filter = "(uid=" + KnownUid + ")";
         }
 
         public void SafeXml(string xmlInput)


### PR DESCRIPTION
Const/sanitizer folding for cmd/path/ssrf, query-forming concat check for SQL/LDAP, XmlResolver=null XXE hardening; safe fixtures added; true positives preserved. Refs #462