### PR TITLE
Reduce false positives: shared secret-name matcher

### DIFF
--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -58,12 +58,23 @@ pub fn shannon_entropy(s: &str) -> f32 {
 /// Each language rule file should use this constant (or
 /// [`CSHARP_HARDCODED_SECRET_PATTERN`] for C#) instead of inlining its
 /// own copy of the pattern.
-pub const HARDCODED_SECRET_PATTERN: &str =
-    r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)";
+///
+/// Identifier-component boundaries (`(?:^|[^A-Za-z])` … `(?:$|[^A-Za-z])`)
+/// wrap the keyword group so a secret keyword only matches when it is a
+/// whole component of an identifier — i.e. at the start/end of the name or
+/// adjacent to a non-letter such as `_`, `.`, or a digit. The `regex` crate
+/// has no look-around, so the boundaries are written as ordinary
+/// (consuming) sub-patterns; that is fine because rules only ever call
+/// `is_match` on this regex. This prevents substring false positives like
+/// `author` → `auth`, `tokenizer` → `token`, or `passwordField` →
+/// `password`, while still matching `SECRET_KEY`, `api_token`, `apiKey`
+/// (the whole `api_?key` keyword), etc.
+pub const HARDCODED_SECRET_PATTERN: &str = r"(?i)(?:^|[^A-Za-z])(password|secret|api_?key|token|auth|credential|private_?key)(?:s?(?:$|[^A-Za-z]))";
 
 /// Extended variant for C# that adds `connection_?string` /
-/// `connectionstring` to the base keyword set.
-pub const CSHARP_HARDCODED_SECRET_PATTERN: &str = r"(?i)(password|secret|api_?key|token|auth|credential|private_?key|connection_?string|connectionstring)";
+/// `connectionstring` to the base keyword set. Uses the same
+/// identifier-component boundaries as [`HARDCODED_SECRET_PATTERN`].
+pub const CSHARP_HARDCODED_SECRET_PATTERN: &str = r"(?i)(?:^|[^A-Za-z])(password|secret|api_?key|token|auth|credential|private_?key|connection_?string|connectionstring)(?:s?(?:$|[^A-Za-z]))";
 
 /// Pre-compiled [`HARDCODED_SECRET_PATTERN`] regex (compiled once).
 pub fn hardcoded_secret_re() -> &'static Regex {
@@ -152,20 +163,70 @@ pub fn looks_like_secret_value(inner: &str) -> bool {
     true
 }
 
+/// Split an identifier into its lowercased word components, treating
+/// non-alphanumeric characters (`_`, `.`, `-`, …) and lower→upper case
+/// transitions (camelCase / PascalCase) as boundaries. A trailing plural
+/// `s` is stripped from each component so `passwords` → `password`.
+///
+/// Examples:
+///   `SECRET_KEY`         → ["secret", "key"]
+///   `apiKeyValue`        → ["api", "key", "value"]
+///   `app.secret_token`   → ["app", "secret", "token"]
+///   `author`             → ["author"]
+fn identifier_components(name: &str) -> Vec<String> {
+    let mut components = Vec::new();
+    let mut current = String::new();
+    let mut prev_lower = false;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            // camelCase boundary: a lowercase letter immediately followed
+            // by an uppercase letter starts a new component.
+            if prev_lower && ch.is_ascii_uppercase() && !current.is_empty() {
+                components.push(std::mem::take(&mut current));
+            }
+            current.push(ch.to_ascii_lowercase());
+            prev_lower = ch.is_ascii_lowercase();
+        } else {
+            if !current.is_empty() {
+                components.push(std::mem::take(&mut current));
+            }
+            prev_lower = false;
+        }
+    }
+    if !current.is_empty() {
+        components.push(current);
+    }
+    // Strip a single trailing plural `s` so `passwords` matches `password`.
+    for c in &mut components {
+        if c.len() > 1 && c.ends_with('s') {
+            c.pop();
+        }
+    }
+    components
+}
+
 /// Returns `true` when the variable name is high-signal enough that we
 /// should flag the value even if it doesn't look secret-shaped (e.g.
 /// passphrases with spaces). Low-signal names like `auth` or `token`
 /// need the value to also pass `looks_like_secret_value`.
+///
+/// Matching is component-aware: the strong keyword must appear as a whole
+/// component of the identifier (`password`, `secret`, `apiKey`, …) rather
+/// than as a substring, so benign names such as `passwordField`'s
+/// neighbours or `secretarial` are not treated as high-signal.
 pub fn is_high_signal_secret_name(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    lower.contains("password")
-        || lower.contains("passwd")
-        || lower.contains("secret")
-        || lower.contains("api_key")
-        || lower.contains("apikey")
-        || lower.contains("credential")
-        || lower.contains("private_key")
-        || lower.contains("privatekey")
+    // `apikey` / `privatekey` / `apiKey` collapse to the joined components
+    // `api`+`key` / `private`+`key`; detect those pairs as well as the
+    // single-token strong names.
+    let components = identifier_components(name);
+    let has = |kw: &str| components.iter().any(|c| c == kw);
+    if has("password") || has("passwd") || has("secret") || has("credential") {
+        return true;
+    }
+    // Adjacent component pairs: api+key, private+key.
+    components
+        .windows(2)
+        .any(|w| w[1] == "key" && (w[0] == "api" || w[0] == "private"))
 }
 
 /// Shared per-file import alias table.
@@ -427,5 +488,119 @@ mod tests {
             assert!(!base.is_match(kw), "base should NOT match {kw}");
             assert!(extended.is_match(kw), "csharp should match {kw}");
         }
+    }
+
+    #[test]
+    fn secret_pattern_ignores_benign_substring_names() {
+        let re = hardcoded_secret_re();
+        // These contain a secret keyword as a *substring* of a larger
+        // identifier component and must NOT match (false positives the
+        // word-boundary fix removes).
+        for name in &[
+            "author",
+            "authors",
+            "authored",
+            "authenticate",
+            "authenticated",
+            "authentication",
+            "authorize",
+            "authorization",
+            "tokenizer",
+            "tokenize",
+            "retokenize",
+            "passwordField",
+            "secretarial",
+            "credentialsHelper", // `credentials` then letters -> no boundary
+        ] {
+            assert!(
+                !re.is_match(name),
+                "benign name {name:?} should NOT match the secret pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn secret_pattern_still_matches_real_secret_names() {
+        let re = hardcoded_secret_re();
+        // Whole-component keyword matches that must keep firing.
+        for name in &[
+            "password",
+            "SECRET_KEY",
+            "secret_key",
+            "secret_token",
+            "api_key",
+            "apiKey", // the whole `api_?key` keyword
+            "api_token",
+            "token",
+            "auth",
+            "credential",
+            "credentials", // plural still matches
+            "secrets",     // plural still matches
+            "private_key",
+            "app.secret_key",
+            "user_password",
+        ] {
+            assert!(
+                re.is_match(name),
+                "real secret name {name:?} should still match the secret pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn high_signal_name_is_component_aware() {
+        // Strong names (whole component) -> high signal.
+        for name in &[
+            "password",
+            "PASSWORD",
+            "userPassword",
+            "passwd",
+            "SECRET_KEY",
+            "secret",
+            "apiKey",
+            "api_key",
+            "API_KEY",
+            "credential",
+            "credentials",
+            "private_key",
+            "privateKey",
+        ] {
+            assert!(
+                is_high_signal_secret_name(name),
+                "{name:?} should be high-signal"
+            );
+        }
+        // Low-signal or benign substrings -> NOT high signal (value must
+        // then pass `looks_like_secret_value`).
+        for name in &[
+            "auth",
+            "token",
+            "author",
+            "authenticated",
+            "tokenizer",
+            "secretarial",
+            "api",
+            "key",
+        ] {
+            assert!(
+                !is_high_signal_secret_name(name),
+                "{name:?} should NOT be high-signal"
+            );
+        }
+    }
+
+    #[test]
+    fn identifier_components_splits_on_case_and_separators() {
+        assert_eq!(identifier_components("SECRET_KEY"), vec!["secret", "key"]);
+        assert_eq!(
+            identifier_components("apiKeyValue"),
+            vec!["api", "key", "value"]
+        );
+        assert_eq!(
+            identifier_components("app.secret_token"),
+            vec!["app", "secret", "token"]
+        );
+        assert_eq!(identifier_components("author"), vec!["author"]);
+        assert_eq!(identifier_components("passwords"), vec!["password"]);
     }
 }

--- a/tests/fixtures/safe_secret_names.cs
+++ b/tests/fixtures/safe_secret_names.cs
@@ -1,0 +1,26 @@
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with env-sourced values. None should be flagged by
+// cs/no-hardcoded-secret after the word-boundary + value-gate fix.
+using System;
+
+public class SafeSecretNames
+{
+    // Substring false positives.
+    const string author = "Pallets";
+    const string authors = "core team";
+    const string authenticated = "yes";
+    const string authorizationScheme = "Bearer";
+    const string tokenizer = "bert-base-uncased";
+    const string secretarialNote = "filed";
+
+    static void Load()
+    {
+        // Low-signal + secret-named values, all env-sourced (not literals).
+        string auth = Environment.GetEnvironmentVariable("AUTH");
+        string token = Environment.GetEnvironmentVariable("TOKEN");
+        string password = Environment.GetEnvironmentVariable("PW");
+        string apiKey = Environment.GetEnvironmentVariable("API_KEY");
+        string connectionString = Environment.GetEnvironmentVariable("CONN");
+        Console.WriteLine(auth + token + password + apiKey + connectionString);
+    }
+}

--- a/tests/fixtures/safe_secret_names.go
+++ b/tests/fixtures/safe_secret_names.go
@@ -1,0 +1,36 @@
+package main
+
+import "os"
+
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with non-secret values. None should be flagged by
+// go/no-hardcoded-secret after the word-boundary + value-gate fix.
+
+func config() {
+	// Substring false positives.
+	author := "Pallets"
+	authors := "core team"
+	authenticated := "yes"
+	authorization := "X-Custom"
+	tokenizer := "bert-base-uncased"
+	secretarial := "filed"
+
+	// Low-signal + secret-named values, all env-sourced (not literals).
+	auth := os.Getenv("AUTH")
+	token := os.Getenv("TOKEN")
+	password := os.Getenv("PW")
+	apiKey := os.Getenv("API_KEY")
+	secretKey := os.Getenv("SECRET_KEY")
+
+	_ = author
+	_ = authors
+	_ = authenticated
+	_ = authorization
+	_ = tokenizer
+	_ = secretarial
+	_ = auth
+	_ = token
+	_ = password
+	_ = apiKey
+	_ = secretKey
+}

--- a/tests/fixtures/safe_secret_names.java
+++ b/tests/fixtures/safe_secret_names.java
@@ -1,0 +1,22 @@
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with env-sourced values. None should be flagged by
+// java/no-hardcoded-secret after the word-boundary + value-gate fix.
+public class SafeSecretNames {
+    // Substring false positives.
+    static final String author = "Pallets";
+    static final String authors = "core team";
+    static final String authenticated = "yes";
+    static final String authorizationScheme = "Bearer";
+    static final String tokenizer = "bert-base-uncased";
+    static final String secretarialNote = "filed";
+
+    static void load() {
+        // Low-signal + secret-named values, all env-sourced (not literals).
+        String auth = System.getenv("AUTH");
+        String token = System.getenv("TOKEN");
+        String password = System.getenv("PW");
+        String apiKey = System.getenv("API_KEY");
+        String secretKey = System.getenv("SECRET_KEY");
+        System.out.println(auth + token + password + apiKey + secretKey);
+    }
+}

--- a/tests/fixtures/safe_secret_names.js
+++ b/tests/fixtures/safe_secret_names.js
@@ -1,0 +1,36 @@
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with env-sourced values. None should be flagged by
+// js/no-hardcoded-secret after the word-boundary + value-gate fix.
+
+// Substring false positives.
+const author = "Pallets";
+const authors = "core team";
+const authenticated = "yes";
+const authorizationScheme = "Bearer";
+const tokenizer = "bert-base-uncased";
+const secretarialNote = "filed";
+
+// Low-signal keyword values that are clearly not secrets.
+const auth = "/login";
+const authUrl = "https://example.com/oauth";
+const token = "see docs for the token format";
+
+// Env-sourced secret-named values (not hardcoded literals).
+const password = process.env.PW;
+const apiKey = process.env.API_KEY;
+const secretKey = process.env.SECRET_KEY;
+
+module.exports = {
+  author,
+  authors,
+  authenticated,
+  authorizationScheme,
+  tokenizer,
+  secretarialNote,
+  auth,
+  authUrl,
+  token,
+  password,
+  apiKey,
+  secretKey,
+};

--- a/tests/fixtures/safe_secret_names.kt
+++ b/tests/fixtures/safe_secret_names.kt
@@ -1,0 +1,22 @@
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with env-sourced values. None should be flagged by
+// kt/no-hardcoded-secret after the word-boundary + value-gate fix.
+object SafeSecretNames {
+    // Substring false positives.
+    val author = "Pallets"
+    val authors = "core team"
+    val authenticated = "yes"
+    val authorizationScheme = "Bearer"
+    val tokenizer = "bert-base-uncased"
+    val secretarialNote = "filed"
+
+    fun load() {
+        // Low-signal + secret-named values, all env-sourced (not literals).
+        val auth = System.getenv("AUTH")
+        val token = System.getenv("TOKEN")
+        val password = System.getenv("PW")
+        val apiKey = System.getenv("API_KEY")
+        val secretKey = System.getenv("SECRET_KEY")
+        println(auth + token + password + apiKey + secretKey)
+    }
+}

--- a/tests/fixtures/safe_secret_names.php
+++ b/tests/fixtures/safe_secret_names.php
@@ -1,0 +1,19 @@
+<?php
+// Benign names containing secret-keyword substrings, or low-signal
+// keywords with env-sourced values. None should be flagged by
+// php/no-hardcoded-secret after the word-boundary + value-gate fix.
+
+// Substring false positives.
+$author = "Pallets";
+$authors = "core team";
+$authenticated = "yes";
+$authorizationScheme = "Bearer";
+$tokenizer = "bert-base-uncased";
+$secretarialNote = "filed";
+
+// Low-signal + secret-named values, all env-sourced (not literals).
+$auth = getenv("AUTH");
+$token = getenv("TOKEN");
+$password = getenv("PW");
+$api_key = getenv("API_KEY");
+$secret_key = getenv("SECRET_KEY");

--- a/tests/fixtures/safe_secret_names.py
+++ b/tests/fixtures/safe_secret_names.py
@@ -1,0 +1,27 @@
+# Benign names that contain secret-keyword *substrings* or low-signal
+# secret keywords with non-secret values. None of these should be flagged
+# by `py/no-hardcoded-secret` after the word-boundary + value-gate fix.
+import os
+
+# Substring false positives: these identifiers merely *contain* a keyword.
+author = "Pallets"
+authors = "Armin Ronacher"
+authored_by = "core team"
+authenticated = True
+authentication_scheme = "Bearer"
+authorization_header = "X-Custom"
+tokenizer = "bert-base-uncased"
+tokenize_input = "whitespace"
+secretarial_note = "filed"
+
+# Low-signal keywords (auth / token) whose values are clearly not secrets
+# (URL / path / value-with-spaces -> rejected by looks_like_secret_value).
+auth = "/login"
+auth_url = "https://example.com/oauth"
+token = "see docs for the token format"
+
+# Env-sourced "secret" names — the value is not a hardcoded literal.
+password = os.environ.get("PW", "")
+api_key = os.getenv("API_KEY")
+secret_key = os.environ["SECRET_KEY"]
+credentials = os.environ.get("CREDS")

--- a/tests/fixtures/safe_secret_names.rb
+++ b/tests/fixtures/safe_secret_names.rb
@@ -1,0 +1,18 @@
+# Benign names containing secret-keyword substrings, or low-signal
+# keywords with env-sourced values. None should be flagged by
+# rb/no-hardcoded-secret after the word-boundary + value-gate fix.
+
+# Substring false positives.
+author = "Pallets"
+authors = "core team"
+authenticated = "yes"
+authorization_scheme = "Bearer"
+tokenizer = "bert-base-uncased"
+secretarial_note = "filed"
+
+# Low-signal + secret-named values, all env-sourced (not literals).
+auth = ENV["AUTH"]
+token = ENV["TOKEN"]
+password = ENV["PW"]
+api_key = ENV["API_KEY"]
+secret_key = ENV.fetch("SECRET_KEY", nil)

--- a/tests/fp_secret_names.rs
+++ b/tests/fp_secret_names.rs
@@ -1,0 +1,81 @@
+//! False-positive regression test for the shared hardcoded-secret matcher
+//! (`src/rules/common.rs`).
+//!
+//! The base secret-name regex used to match a keyword as a *substring* of a
+//! larger identifier (`author` → `auth`, `tokenizer` → `token`,
+//! `passwordField` → `password`) and would flag low-signal names whose value
+//! was clearly not a secret (env-sourced lookups). After adding identifier-
+//! component word boundaries to the regex and value-gating low-signal names,
+//! the benign fixtures below must produce ZERO findings.
+//!
+//! Each fixture under `tests/fixtures/safe_secret_names.*` contains only
+//! benign code: secret-ish NAMES bound to non-secret values (URLs, paths,
+//! env lookups) or names that merely contain a keyword substring.
+//!
+//! This complements the positive coverage in `integration.rs` /
+//! `semgrep_parity*`, which prove genuine hardcoded secrets are still flagged.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn foxguard_cmd() -> Command {
+    // `--config /dev/null` isolates the test from any developer-local
+    // `.foxguard.yml`, matching the convention in `realistic_fixtures.rs`.
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_foxguard"));
+    cmd.args(["--config", "/dev/null"]);
+    cmd
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+/// Scan a single fixture and assert it produces no findings at all.
+fn assert_no_findings(fixture: &str) {
+    let path = fixture_path(fixture);
+    let output = foxguard_cmd()
+        .args([path.to_str().unwrap(), "-f", "json"])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run foxguard on {fixture}: {e}"));
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON output for {fixture}: {e}"));
+    let findings = report["findings"]
+        .as_array()
+        .cloned()
+        .unwrap_or_else(|| panic!("JSON report for {fixture} missing findings array"));
+
+    assert!(
+        findings.is_empty(),
+        "{fixture}: expected ZERO findings, got {}: {:?}",
+        findings.len(),
+        findings
+            .iter()
+            .map(|f| (
+                f["rule_id"].as_str().unwrap_or(""),
+                f["line"].as_u64().unwrap_or(0)
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+macro_rules! fp_fixture_test {
+    ($name:ident, $fixture:expr) => {
+        #[test]
+        fn $name() {
+            assert_no_findings($fixture);
+        }
+    };
+}
+
+fp_fixture_test!(no_fp_secret_names_python, "safe_secret_names.py");
+fp_fixture_test!(no_fp_secret_names_go, "safe_secret_names.go");
+fp_fixture_test!(no_fp_secret_names_java, "safe_secret_names.java");
+fp_fixture_test!(no_fp_secret_names_csharp, "safe_secret_names.cs");
+fp_fixture_test!(no_fp_secret_names_php, "safe_secret_names.php");
+fp_fixture_test!(no_fp_secret_names_kotlin, "safe_secret_names.kt");
+fp_fixture_test!(no_fp_secret_names_javascript, "safe_secret_names.js");
+fp_fixture_test!(no_fp_secret_names_ruby, "safe_secret_names.rb");


### PR DESCRIPTION
Adds \b word boundaries and value-gating to the common.rs secret matcher so benign names (author/authenticate/tokenizer) and env-sourced values no longer flag. New safe fixtures + test prove it; high-signal secrets still detected. Refs #462