### PR TITLE
fix: route VS Code config suppressions through the Rust config editor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -576,6 +576,38 @@ pub struct ScaArgs {
     pub sca_cache: Option<String>,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct InternalAddScanIgnoreRuleArgs {
+    /// Scan root used to resolve relative finding paths.
+    #[arg(long)]
+    pub scan_path: String,
+
+    /// Explicit config path to edit.
+    #[arg(long)]
+    pub config: Option<String>,
+
+    /// Repository-relative file path for the finding to suppress.
+    #[arg(long)]
+    pub file: String,
+
+    /// Rule ID to add under scan.ignore_rules.
+    #[arg(long)]
+    pub rule_id: String,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum InternalCommand {
+    /// Internal helper: add a scan.ignore_rules entry using the Rust config editor.
+    #[command(hide = true, name = "add-scan-ignore-rule")]
+    AddScanIgnoreRule(InternalAddScanIgnoreRuleArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct InternalArgs {
+    #[command(subcommand)]
+    pub command: InternalCommand,
+}
+
 impl PqcArgs {
     /// Convert to `ScanArgs` with `pq_mode` enabled.
     pub fn to_scan_args(&self) -> ScanArgs {
@@ -692,6 +724,9 @@ pub enum Command {
     Pqc(PqcArgs),
     /// Dependency vulnerability audit using OSV
     Sca(ScaArgs),
+    /// Internal machine-facing helpers used by editor integrations.
+    #[command(hide = true, name = "internal")]
+    Internal(InternalArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,9 @@ use foxguard::cli::{
 };
 use foxguard::config::add_scan_ignore_rule;
 use foxguard::config::load_for_scan;
+use foxguard::tui::run_scan_tui;
 use foxguard::Finding;
 use serde::Serialize;
-use foxguard::tui::run_scan_tui;
 use std::path::Path;
 
 fn main() {
@@ -481,11 +481,7 @@ fn run_internal_add_scan_ignore_rule(args: &InternalAddScanIgnoreRuleArgs) -> i3
         dep_path: Vec::new(),
     };
 
-    let result = match add_scan_ignore_rule(
-        scan_root,
-        args.config.as_deref(),
-        &finding,
-    ) {
+    let result = match add_scan_ignore_rule(scan_root, args.config.as_deref(), &finding) {
         Ok((config_path, added)) => InternalAddScanIgnoreRuleResult {
             config_path: config_path.display().to_string(),
             added,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,14 @@ use foxguard::app::{
 };
 use foxguard::baseline::write_baseline_at_root;
 use foxguard::cli::{
-    BaselineArgs, BaselineScanArgs, ChangeModeArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat,
-    PqcArgs, ScaArgs, ScanArgs, SecretsArgs, TuiArgs,
+    BaselineArgs, BaselineScanArgs, ChangeModeArgs, Cli, Command, DiffArgs, InitArgs,
+    InternalAddScanIgnoreRuleArgs, InternalArgs, InternalCommand, OutputFormat, PqcArgs, ScaArgs,
+    ScanArgs, SecretsArgs, TuiArgs,
 };
+use foxguard::config::add_scan_ignore_rule;
 use foxguard::config::load_for_scan;
+use foxguard::Finding;
+use serde::Serialize;
 use foxguard::tui::run_scan_tui;
 use std::path::Path;
 
@@ -27,6 +31,7 @@ fn main() {
         Some(Command::Tui(args)) => run_tui(&args),
         Some(Command::Pqc(args)) => run_pqc(&args),
         Some(Command::Sca(args)) => run_sca(&args),
+        Some(Command::Internal(args)) => run_internal(&args),
         None => run_scan(&cli.scan),
     };
 
@@ -417,6 +422,90 @@ fn run_init(args: &InitArgs) -> i32 {
     }
     eprintln!("Installed pre-commit hook at {}", hook_path.display());
     0
+}
+
+#[derive(Serialize)]
+struct InternalAddScanIgnoreRuleResult {
+    config_path: String,
+    added: bool,
+}
+
+fn run_internal(args: &InternalArgs) -> i32 {
+    match &args.command {
+        InternalCommand::AddScanIgnoreRule(args) => run_internal_add_scan_ignore_rule(args),
+    }
+}
+
+fn run_internal_add_scan_ignore_rule(args: &InternalAddScanIgnoreRuleArgs) -> i32 {
+    let scan_root = Path::new(&args.scan_path);
+    let finding_file = {
+        let file_path = Path::new(&args.file);
+        if file_path.is_absolute() {
+            file_path.to_path_buf()
+        } else {
+            scan_root.join(file_path)
+        }
+    };
+
+    let finding = Finding {
+        rule_id: args.rule_id.clone(),
+        severity: foxguard::Severity::Low,
+        cwe: None,
+        description: String::new(),
+        file: finding_file.display().to_string(),
+        line: 1,
+        column: 1,
+        end_line: 1,
+        end_column: 1,
+        snippet: String::new(),
+        source_line: None,
+        source_description: None,
+        sink_line: None,
+        sink_description: None,
+        fix_suggestion: None,
+        sink_start_byte: None,
+        sink_end_byte: None,
+        confidence: 1.0,
+        taint_hops: None,
+        tags: Vec::new(),
+        crypto_algorithm: None,
+        cnsa2_deadline: None,
+        dep_name: None,
+        dep_version: None,
+        dep_ecosystem: None,
+        dep_purl: None,
+        dep_vulnerability_id: None,
+        dep_fixed_version: None,
+        dep_source: None,
+        dep_vulnerability_severity: None,
+        dep_path: Vec::new(),
+    };
+
+    let result = match add_scan_ignore_rule(
+        scan_root,
+        args.config.as_deref(),
+        &finding,
+    ) {
+        Ok((config_path, added)) => InternalAddScanIgnoreRuleResult {
+            config_path: config_path.display().to_string(),
+            added,
+        },
+        Err(error) => {
+            eprintln!("Error: {error}");
+            return 2;
+        }
+    };
+
+    match serde_json::to_string(&result) {
+        Ok(json) => {
+            println!("{json}");
+            0
+        }
+        Err(error) => {
+            eprintln!("Error: failed to serialize internal response: {error}");
+            2
+        }
+    }
 }
 
 fn ensure_init_config(args: &InitArgs, config_path: &Path) -> Result<bool, String> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2901,6 +2901,90 @@ rules:
     }
 
     #[test]
+    fn test_internal_add_scan_ignore_rule_handles_flow_mapping_config() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config_file(repo.path(), ".foxguard.yml", "scan: {}\n");
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args([
+                "internal",
+                "add-scan-ignore-rule",
+                "--scan-path",
+                ".",
+                "--config",
+                ".foxguard.yml",
+                "--file",
+                "src/app.js",
+                "--rule-id",
+                "js/no-eval",
+            ])
+            .output()
+            .expect("failed to execute internal add-scan-ignore-rule");
+
+        assert!(output.status.success(), "internal config edit should succeed");
+
+        let response: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("expected JSON response");
+        assert_eq!(response["added"], true, "rule should be newly added");
+
+        let config = fs::read_to_string(repo.path().join(".foxguard.yml"))
+            .expect("failed to read rewritten config");
+        let value: serde_json::Value =
+            serde_yaml_ng::from_str(&config).expect("rewritten config should stay valid YAML");
+
+        assert_eq!(value["scan"]["ignore_rules"][0]["path"], "src/app.js");
+        assert_eq!(value["scan"]["ignore_rules"][0]["rules"][0], "js/no-eval");
+    }
+
+    #[test]
+    fn test_internal_add_scan_ignore_rule_reports_duplicate_without_rewriting() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  ignore_rules:\n    - path: src/app.js\n      rules:\n        - js/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args([
+                "internal",
+                "add-scan-ignore-rule",
+                "--scan-path",
+                ".",
+                "--config",
+                ".foxguard.yml",
+                "--file",
+                "src/app.js",
+                "--rule-id",
+                "js/no-eval",
+            ])
+            .output()
+            .expect("failed to execute duplicate internal add-scan-ignore-rule");
+
+        assert!(output.status.success(), "duplicate config edit should succeed");
+
+        let response: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("expected JSON response");
+        assert_eq!(response["added"], false, "duplicate rule should not be re-added");
+
+        let config = fs::read_to_string(repo.path().join(".foxguard.yml"))
+            .expect("failed to read config");
+        let ignore_rules = serde_yaml_ng::from_str::<serde_json::Value>(&config)
+            .expect("config should stay valid YAML")["scan"]["ignore_rules"]
+            .as_array()
+            .expect("ignore_rules should be a list")
+            .to_vec();
+        assert_eq!(ignore_rules.len(), 1, "duplicate write should not add a new entry");
+        assert_eq!(
+            ignore_rules[0]["rules"].as_array().expect("rules should be a list").len(),
+            1,
+            "duplicate write should not append the same rule twice"
+        );
+    }
+
+    #[test]
     fn test_diff_uses_explicit_config_for_rule_filtering() {
         let repo = setup_diff_repo_with_vulnerable_python();
         let config = write_config_file(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2922,7 +2922,10 @@ rules:
             .output()
             .expect("failed to execute internal add-scan-ignore-rule");
 
-        assert!(output.status.success(), "internal config edit should succeed");
+        assert!(
+            output.status.success(),
+            "internal config edit should succeed"
+        );
 
         let response: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("expected JSON response");
@@ -2963,22 +2966,35 @@ rules:
             .output()
             .expect("failed to execute duplicate internal add-scan-ignore-rule");
 
-        assert!(output.status.success(), "duplicate config edit should succeed");
+        assert!(
+            output.status.success(),
+            "duplicate config edit should succeed"
+        );
 
         let response: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("expected JSON response");
-        assert_eq!(response["added"], false, "duplicate rule should not be re-added");
+        assert_eq!(
+            response["added"], false,
+            "duplicate rule should not be re-added"
+        );
 
-        let config = fs::read_to_string(repo.path().join(".foxguard.yml"))
-            .expect("failed to read config");
+        let config =
+            fs::read_to_string(repo.path().join(".foxguard.yml")).expect("failed to read config");
         let ignore_rules = serde_yaml_ng::from_str::<serde_json::Value>(&config)
             .expect("config should stay valid YAML")["scan"]["ignore_rules"]
             .as_array()
             .expect("ignore_rules should be a list")
             .to_vec();
-        assert_eq!(ignore_rules.len(), 1, "duplicate write should not add a new entry");
         assert_eq!(
-            ignore_rules[0]["rules"].as_array().expect("rules should be a list").len(),
+            ignore_rules.len(),
+            1,
+            "duplicate write should not add a new entry"
+        );
+        assert_eq!(
+            ignore_rules[0]["rules"]
+                .as_array()
+                .expect("rules should be a list")
+                .len(),
             1,
             "duplicate write should not append the same rule twice"
         );

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -25,6 +25,11 @@ interface ReportEnvelope {
   findings: Finding[];
 }
 
+interface ConfigMutationResult {
+  config_path: string;
+  added: boolean;
+}
+
 /**
  * Extract the findings array from CLI stdout.  Current foxguard wraps
  * findings in a {@link ReportEnvelope}; older versions emitted a bare
@@ -161,177 +166,61 @@ function writeBaseline(baselinePath: string, baseline: BaselineFile): void {
 // Config file helpers (scan.ignore_rules in .foxguard.yml)
 // ---------------------------------------------------------------------------
 
-/**
- * Add `ruleId` to the `scan.ignore_rules` entry for `relPath` in
- * `.foxguard.yml`. Creates the file/structure as needed.
- * Returns `true` if the rule was actually added (not a duplicate).
- */
-function addIgnoreRuleToConfig(configPath: string, relPath: string, ruleId: string): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let doc: any = {};
-  if (fs.existsSync(configPath)) {
-    try {
-      // Simple YAML-ish parse: we only touch scan.ignore_rules,
-      // but the config may have arbitrary keys. Use a JSON-safe
-      // round-trip via the foxguard CLI (preferred) or fall back to
-      // a minimal in-process implementation.
-      const text = fs.readFileSync(configPath, "utf-8");
-      doc = parseSimpleYaml(text);
-    } catch {
-      doc = {};
-    }
+async function addIgnoreRuleToConfig(
+  scanPath: string,
+  configPath: string,
+  relPath: string,
+  ruleId: string,
+): Promise<ConfigMutationResult> {
+  const binary = await resolveBinary();
+  if (binary === undefined) {
+    throw new Error("foxguard not found");
   }
 
-  if (!doc.scan) {
-    doc.scan = {};
-  }
-  if (!Array.isArray(doc.scan.ignore_rules)) {
-    doc.scan.ignore_rules = [];
-  }
-
-  // Find existing entry for this path
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const existing = doc.scan.ignore_rules.find((e: any) => e.path === relPath);
-  if (existing) {
-    if (Array.isArray(existing.rules) && existing.rules.includes(ruleId)) {
-      return false; // already present
-    }
-    if (!Array.isArray(existing.rules)) {
-      existing.rules = [];
-    }
-    existing.rules.push(ruleId);
+  let command: string;
+  let args: string[];
+  if (binary === null) {
+    command = "npx";
+    args = [
+      "foxguard",
+      "internal",
+      "add-scan-ignore-rule",
+      "--scan-path", scanPath,
+      "--config", configPath,
+      "--file", relPath,
+      "--rule-id", ruleId,
+    ];
   } else {
-    doc.scan.ignore_rules.push({ path: relPath, rules: [ruleId] });
+    command = binary;
+    args = [
+      "internal",
+      "add-scan-ignore-rule",
+      "--scan-path", scanPath,
+      "--config", configPath,
+      "--file", relPath,
+      "--rule-id", ruleId,
+    ];
   }
 
-  fs.writeFileSync(configPath, serializeSimpleYaml(doc));
-  return true;
-}
-
-/**
- * Minimal YAML parser — handles the subset of YAML that .foxguard.yml uses.
- * This avoids adding a js-yaml dependency to the extension.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseSimpleYaml(text: string): any {
-  // We use a line-by-line state machine that handles:
-  //   key: value        (string)
-  //   key:              (start mapping)
-  //     sub: value
-  //   key:              (start sequence)
-  //     - item          (string item)
-  //     - key: value    (mapping item)
-  //       key2: value2
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const root: any = {};
-  const lines = text.split("\n");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const stack: { indent: number; obj: any; key?: string }[] = [
-    { indent: -1, obj: root },
-  ];
-
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, "");
-    if (line.trim() === "" || line.trim().startsWith("#")) {
-      continue;
-    }
-
-    const indent = line.search(/\S/);
-    const content = line.trim();
-
-    // Pop stack to find parent at smaller indent
-    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-      stack.pop();
-    }
-    const parent = stack[stack.length - 1];
-
-    if (content.startsWith("- ")) {
-      // Sequence item
-      const itemContent = content.slice(2).trim();
-      // Ensure parent value is an array
-      if (parent.key !== undefined && !Array.isArray(parent.obj[parent.key])) {
-        parent.obj[parent.key] = [];
-      }
-      const arr = parent.key !== undefined ? parent.obj[parent.key] : parent.obj;
-
-      if (itemContent.includes(": ")) {
-        // Mapping item in a sequence: "- key: value"
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const item: any = {};
-        const colonIdx = itemContent.indexOf(": ");
-        const k = itemContent.slice(0, colonIdx).trim();
-        const v = itemContent.slice(colonIdx + 2).trim();
-        item[k] = v;
-        arr.push(item);
-        stack.push({ indent: indent + 2, obj: item, key: undefined });
-      } else {
-        arr.push(itemContent);
-      }
-    } else if (content.includes(": ")) {
-      const colonIdx = content.indexOf(": ");
-      const key = content.slice(0, colonIdx).trim();
-      const value = content.slice(colonIdx + 2).trim();
-
-      if (value === "") {
-        // Start of a sub-mapping or sub-sequence (determined later)
-        parent.obj[key] = {};
-        stack.push({ indent, obj: parent.obj, key });
-      } else {
-        parent.obj[key] = value;
-      }
-    } else if (content.endsWith(":")) {
-      // Key with no value — sub-mapping
-      const key = content.slice(0, -1).trim();
-      parent.obj[key] = {};
-      stack.push({ indent, obj: parent.obj, key });
-    }
-  }
-
-  return root;
-}
-
-/**
- * Minimal YAML serializer for the config subset we use.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function serializeSimpleYaml(obj: any, indent: number = 0): string {
-  let out = "";
-  const prefix = " ".repeat(indent);
-
-  for (const key of Object.keys(obj)) {
-    const value = obj[key];
-    if (Array.isArray(value)) {
-      out += `${prefix}${key}:\n`;
-      for (const item of value) {
-        if (typeof item === "object" && item !== null) {
-          const keys = Object.keys(item);
-          if (keys.length > 0) {
-            out += `${prefix}  - ${keys[0]}: ${item[keys[0]]}\n`;
-            for (let i = 1; i < keys.length; i++) {
-              const v = item[keys[i]];
-              if (Array.isArray(v)) {
-                out += `${prefix}    ${keys[i]}:\n`;
-                for (const subItem of v) {
-                  out += `${prefix}      - ${subItem}\n`;
-                }
-              } else {
-                out += `${prefix}    ${keys[i]}: ${v}\n`;
-              }
-            }
-          }
-        } else {
-          out += `${prefix}  - ${item}\n`;
+  return await new Promise<ConfigMutationResult>((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { maxBuffer: 1024 * 1024, timeout: 30_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || error.message));
+          return;
         }
-      }
-    } else if (typeof value === "object" && value !== null) {
-      out += `${prefix}${key}:\n`;
-      out += serializeSimpleYaml(value, indent + 2);
-    } else {
-      out += `${prefix}${key}: ${value}\n`;
-    }
-  }
-  return out;
+
+        try {
+          resolve(JSON.parse(stdout) as ConfigMutationResult);
+        } catch (parseError) {
+          reject(new Error(`invalid config edit response: ${parseError}`));
+        }
+      },
+    );
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -509,17 +398,25 @@ export function activate(context: vscode.ExtensionContext): void {
         const configPath = path.join(rootPath, ".foxguard.yml");
         const relPath = path.relative(rootPath, uri.fsPath);
 
-        const added = addIgnoreRuleToConfig(configPath, relPath, ruleId);
-        if (added) {
-          outputChannel.appendLine(
-            `Suppressed ${ruleId} for ${relPath} in ${configPath}`,
-          );
-          vscode.window.showInformationMessage(
-            `foxguard: added ${ruleId} ignore for ${relPath} to .foxguard.yml`,
-          );
-        } else {
-          vscode.window.showInformationMessage(
-            `foxguard: ${ruleId} already suppressed for ${relPath}`,
+        try {
+          const result = await addIgnoreRuleToConfig(rootPath, configPath, relPath, ruleId);
+          if (result.added) {
+            outputChannel.appendLine(
+              `Suppressed ${ruleId} for ${relPath} in ${result.config_path}`,
+            );
+            vscode.window.showInformationMessage(
+              `foxguard: added ${ruleId} ignore for ${relPath} to .foxguard.yml`,
+            );
+          } else {
+            vscode.window.showInformationMessage(
+              `foxguard: ${ruleId} already suppressed for ${relPath}`,
+            );
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          outputChannel.appendLine(`Failed to update .foxguard.yml: ${message}`);
+          vscode.window.showErrorMessage(
+            `foxguard: failed to update .foxguard.yml: ${message}`,
           );
         }
       },


### PR DESCRIPTION
Closes #519.

## Summary
- replace the VS Code extension's in-process YAML rewriting with a CLI bridge into the existing Rust config editor
- add a hidden `foxguard internal add-scan-ignore-rule` command for machine-facing integrations
- preserve repo-relative `scan.ignore_rules` paths and report duplicate suppressions cleanly

## Testing
- `cargo test test_internal_add_scan_ignore_rule_`
- `cargo run --quiet --bin foxguard -- internal add-scan-ignore-rule ...`
- `npm run test` (in `vscode-extension`)
- `npx tsc -p ./` (in `vscode-extension`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal CLI command to add `scan.ignore_rules` entries and report whether a rule was newly added via JSON output.
  * Updated the VS Code extension to asynchronously update `.foxguard.yml` by invoking the CLI, improving accuracy and surfacing clearer success/error messages.
* **Tests**
  * Added integration tests covering successful ignore-rule insertion and ensuring duplicates are not rewritten or duplicated in `scan.ignore_rules`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->