### PR TITLE
fix: key the npm launcher cache by target platform

### DIFF
--- a/packages/npm/bin/foxguard
+++ b/packages/npm/bin/foxguard
@@ -45,8 +45,18 @@ function getCacheDir() {
   }
 }
 
-function getBinaryName() {
-  return os.platform() === "win32" ? "foxguard.exe" : "foxguard";
+function getBinaryName(platform = os.platform()) {
+  return platform === "win32" ? "foxguard.exe" : "foxguard";
+}
+
+function getCachePaths(target, platform = os.platform(), cacheRoot = getCacheDir()) {
+  const targetCacheDir = path.join(cacheRoot, target);
+  fs.mkdirSync(targetCacheDir, { recursive: true });
+  return {
+    cacheDir: targetCacheDir,
+    cachedBin: path.join(targetCacheDir, getBinaryName(platform)),
+    versionFile: path.join(targetCacheDir, ".version"),
+  };
 }
 
 function download(url) {
@@ -91,11 +101,8 @@ function sha256(buffer) {
 
 async function downloadBinary() {
   const target = getPlatformKey();
-  const cacheDir = getCacheDir();
-  const cachedBin = path.join(cacheDir, getBinaryName());
+  const { cachedBin, versionFile } = getCachePaths(target);
 
-  // Check version marker
-  const versionFile = path.join(cacheDir, ".version");
   if (fs.existsSync(cachedBin) && fs.existsSync(versionFile)) {
     const cached = fs.readFileSync(versionFile, "utf8").trim();
     if (cached === VERSION) {
@@ -174,4 +181,13 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  getBinaryName,
+  getCachePaths,
+  getPlatformKey,
+  PLATFORM_MAP,
+};

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -34,5 +34,8 @@
   ],
   "engines": {
     "node": ">=14"
+  },
+  "scripts": {
+    "test": "node test/foxguard.test.js"
   }
 }

--- a/packages/npm/test/foxguard.test.js
+++ b/packages/npm/test/foxguard.test.js
@@ -1,0 +1,40 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { getBinaryName, getCachePaths } = require("../bin/foxguard");
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "foxguard-npm-cache-"));
+
+const darwinX64 = getCachePaths("x86_64-apple-darwin", "darwin", tempRoot);
+const darwinArm64 = getCachePaths("aarch64-apple-darwin", "darwin", tempRoot);
+const windowsX64 = getCachePaths("x86_64-pc-windows-msvc", "win32", tempRoot);
+
+assert.notStrictEqual(
+  darwinX64.cacheDir,
+  darwinArm64.cacheDir,
+  "cache directories should be target-specific",
+);
+assert.notStrictEqual(
+  darwinX64.cachedBin,
+  darwinArm64.cachedBin,
+  "binary paths should be target-specific",
+);
+assert.notStrictEqual(
+  darwinX64.versionFile,
+  darwinArm64.versionFile,
+  "version markers should be target-specific",
+);
+assert.strictEqual(
+  path.basename(darwinX64.cachedBin),
+  getBinaryName("darwin"),
+  "non-Windows cache should use the plain binary name",
+);
+assert.strictEqual(
+  path.basename(windowsX64.cachedBin),
+  getBinaryName("win32"),
+  "Windows cache should keep the .exe suffix",
+);
+
+console.log("foxguard npm cache path tests passed");


### PR DESCRIPTION
Closes #521.

## Summary
- store the npm launcher cache under a target-specific directory instead of a single shared cache root
- keep the cached binary and `.version` marker isolated per resolved target triple
- add a small Node regression test covering cache-path separation across targets

## Testing
- `npm test` (in `packages/npm`)
- `npm_config_cache=/tmp/foxguard-npm-cache npm pack --dry-run` (in `packages/npm`)