### PR TITLE
feat(github-app): full-tree scan with diff-scoped fallback on timeout (+ noise exclusions)

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -428,6 +428,7 @@ fn scan_args(request: &AdapterRequest, path: String, pq_mode: bool) -> ScanArgs 
         codeql_db: None,
         no_builtins: request.no_builtins,
         changes: change_mode_args(request.change_mode),
+        changed_files_from: None,
         exclude: request.exclude.clone(),
         baseline: resolve_optional_workspace_path(
             request.baseline.as_deref(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -133,7 +133,14 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
         }
     }
     let excludes = PathExcludeMatcher::new(&scan.exclude)?;
-    let targets = collect_changed_targets(&scan.path, scan.changes.selection())?;
+    let targets = if let Some(list_file) = scan.changed_files_from.as_deref() {
+        // Explicit changed-file list (e.g. from the GitHub App): scan only
+        // these paths but keep `scan.path` as the analysis root so cross-file
+        // taint context is preserved. Precedence over the change-mode flags.
+        Some(resolve_changed_files_from(&scan.path, list_file)?)
+    } else {
+        collect_changed_targets(&scan.path, scan.changes.selection())?
+    };
     let coccinelle_rule_ids = coccinelle::rule_ids(&coccinelle_rules);
     let codeql_rule_ids = codeql::rule_ids(&codeql_rules);
 
@@ -607,6 +614,7 @@ fn tui_scan_args(args: &TuiArgs) -> ScanArgs {
         no_builtins: args.no_builtins,
         codeql_db: None,
         changes: args.changes.clone(),
+        changed_files_from: None,
         exclude: args.exclude.clone(),
         baseline: args.baseline.clone(),
         write_baseline: None,
@@ -782,6 +790,34 @@ fn collect_changed_targets(
     Ok(Some(files))
 }
 
+/// Resolve an explicit changed-file list (newline-delimited, repo-root-relative
+/// paths) into scan targets rooted at `scan_path`. Blank lines and comments
+/// (`#`) are ignored, and paths that no longer exist on disk (e.g. files a PR
+/// deleted) are skipped. Returned paths are kept relative to `scan_path` so the
+/// exclude matcher sees repo-root-relative paths. An empty resolved list is a
+/// valid result: the caller scans nothing and reports zero findings rather than
+/// falling back to a full-tree scan.
+fn resolve_changed_files_from(scan_path: &str, list_file: &str) -> Result<Vec<PathBuf>, String> {
+    let contents = std::fs::read_to_string(list_file)
+        .map_err(|e| format!("failed to read changed-files list '{}': {}", list_file, e))?;
+
+    let root = Path::new(scan_path);
+    let mut files = Vec::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let candidate = root.join(line);
+        // A PR can delete files; skip anything that is not a present file so we
+        // never error out or scan phantom paths.
+        if candidate.is_file() {
+            files.push(candidate);
+        }
+    }
+    Ok(files)
+}
+
 fn count_secret_files(scan_path: &Path) -> usize {
     if scan_path.is_file() {
         return 1;
@@ -812,5 +848,42 @@ mod tests {
 
         assert!(ids.contains(&"kernel/pq-vulnerable-cocci".to_string()));
         assert!(!ids.contains(&"kernel/non-pq-cocci".to_string()));
+    }
+
+    #[test]
+    fn resolve_changed_files_from_skips_missing_and_comments() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("a.py"), "print(1)\n").unwrap();
+        std::fs::create_dir(root.join("sub")).unwrap();
+        std::fs::write(root.join("sub").join("b.py"), "print(2)\n").unwrap();
+
+        let list = root.join("changed.txt");
+        std::fs::write(&list, "# comment\n\na.py\nsub/b.py\ndeleted/gone.py\n").unwrap();
+
+        let files = resolve_changed_files_from(root.to_str().unwrap(), list.to_str().unwrap())
+            .expect("resolve");
+
+        // Existing files resolve (rooted at scan path); the missing/deleted
+        // path and the comment/blank lines are dropped.
+        assert_eq!(files.len(), 2, "got {files:?}");
+        assert!(files.contains(&root.join("a.py")));
+        assert!(files.contains(&root.join("sub").join("b.py")));
+    }
+
+    #[test]
+    fn resolve_changed_files_from_empty_list_is_empty_not_full_tree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("a.py"), "print(1)\n").unwrap();
+        let list = root.join("changed.txt");
+        std::fs::write(&list, "\n  \n# only comments\n").unwrap();
+
+        let files = resolve_changed_files_from(root.to_str().unwrap(), list.to_str().unwrap())
+            .expect("resolve");
+        assert!(
+            files.is_empty(),
+            "empty list must not fall back to full tree; got {files:?}"
+        );
     }
 }

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -545,21 +545,45 @@ fn run_pull_request_scan(
         ));
     }
 
-    // Diff-scope the scan to the PR's changed files when we have them. The list
-    // is written inside the workspace tempdir and passed to the CLI, which
-    // scans only those paths but keeps the full checkout as the analysis root
-    // (cross-file taint preserved). Absent the list, we scan the whole tree.
+    // Full-tree scan FIRST — this preserves whole-repo cross-file taint context
+    // (a source in an unchanged file reaching a sink in a changed file is still
+    // caught), which is foxguard's headline capability. The ~80% of PRs whose
+    // repos scan within the timeout get this full coverage.
+    //
+    // Only when the full scan TIMES OUT — which in production happens on large
+    // repos / monorepos (e.g. the biggest offenders had every PR blow the 60s
+    // cap and get NO review at all) — do we fall back to a diff-scoped scan of
+    // just the PR's changed files. That scan keeps the full checkout as its
+    // analysis root (so cross-file taint AMONG the changed files is preserved)
+    // and is fast, so a large-repo PR gets *some* review instead of none. The
+    // accepted, bounded tradeoff on the fallback path: a cross-file flow whose
+    // source is in an unchanged file is not caught (only the changed-file set
+    // is analysed). This is strictly better than the previous "timeout = no
+    // review" behaviour and never reduces coverage for scans that finish.
     let changed_files_list = match &changed_files {
-        Some(files) => {
+        Some(files) if !files.is_empty() => {
             let list_path = workspace.path().join("changed-files.txt");
             std::fs::write(&list_path, files.join("\n"))
                 .map_err(|error| format!("failed to write changed-files list: {error}"))?;
             Some(list_path)
         }
-        None => None,
+        _ => None,
     };
 
-    let output = run_scanner(&checkout, changed_files_list.as_deref())?;
+    let output = match run_scanner(&checkout, None) {
+        Ok(output) => output,
+        Err(error) if is_scan_timeout(&error) && changed_files_list.is_some() => {
+            warn!(
+                repo = target_repo,
+                pr_number = pull_request.number,
+                "full-tree scan timed out; falling back to a diff-scoped scan of \
+                 the PR's changed files (cross-file taint from unchanged files not \
+                 analysed on this path)"
+            );
+            run_scanner(&checkout, changed_files_list.as_deref())?
+        }
+        Err(error) => return Err(error),
+    };
     let mut findings = parse_json_findings(&output)?;
     for finding in &mut findings {
         finding.file = relative_path(&finding.file, Some(&checkout));
@@ -766,6 +790,14 @@ fn run_scanner(checkout: &Path, changed_files_list: Option<&Path>) -> Result<Str
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     run_command_with_timeout(command, PULL_REQUEST_SCAN_TIMEOUT, "foxguard")
+}
+
+/// True when a scan failure is the wall-clock timeout (as opposed to a spawn or
+/// other error). Used to decide whether to retry with a diff-scoped scan. The
+/// marker is the message produced by [`run_command_with_timeout`] on the
+/// `TimedOut` branch.
+fn is_scan_timeout(error: &str) -> bool {
+    error.contains("timed out after")
 }
 
 fn run_command_with_timeout(
@@ -1004,6 +1036,20 @@ mod tests {
                 "missing --exclude {glob}"
             );
         }
+    }
+
+    #[test]
+    fn is_scan_timeout_detects_only_the_timeout_error() {
+        use super::is_scan_timeout;
+        // The exact message run_command_with_timeout emits on the TimedOut branch.
+        assert!(is_scan_timeout("foxguard timed out after 60s"));
+        assert!(is_scan_timeout("git timed out after 60s"));
+        // Other scan failures must NOT trigger the diff-scoped fallback.
+        assert!(!is_scan_timeout(
+            "failed to run foxguard: No such file or directory"
+        ));
+        assert!(!is_scan_timeout("foxguard failed with exit status: 101"));
+        assert!(!is_scan_timeout(""));
     }
 
     #[test]

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -12,7 +12,8 @@
 //! Run:      `FOXGUARD_WEBHOOK_SECRET=xxx FOXGUARD_BIND=0.0.0.0:8080 foxguard-github-app`
 //! Docker:   `docker build -f Dockerfile.github-app -t ghcr.io/0sec-labs/foxguard-github-app .`
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -439,18 +440,44 @@ async fn process_pull_request_delivery(
         .await
         .map_err(|error| error.to_string())?;
 
+    let pr_number = pull_request.number;
+    let repo_full_name = repository.full_name.clone();
+
+    // Fetch the PR's changed lines BEFORE scanning so the scan can be
+    // diff-scoped to just the changed files — while still cloning the full
+    // repo so the analysis root preserves cross-file taint. On failure we
+    // fall back to a full-tree scan (safer: keeps coverage) and log it.
+    let changed_lines: Option<HashMap<String, HashSet<usize>>> = match state
+        .review
+        .pull_request_changed_lines(&repo_full_name, pr_number, &token)
+        .await
+    {
+        Ok(lines) => Some(lines),
+        Err(error) => {
+            warn!(
+                repo = repo_full_name,
+                pr_number,
+                %error,
+                "failed to fetch PR changed lines; falling back to full-tree scan"
+            );
+            None
+        }
+    };
+    let changed_files: Option<Vec<String>> = changed_lines
+        .as_ref()
+        .map(|lines| lines.keys().cloned().collect());
+
     let scan_token = token.clone();
     let mut result = tokio::task::spawn_blocking(move || {
-        run_pull_request_scan(pull_request, &repository.full_name, &scan_token)
+        run_pull_request_scan(
+            pull_request,
+            &repository.full_name,
+            &scan_token,
+            changed_files,
+        )
     })
     .await
     .map_err(|error| format!("pull_request scan task failed: {error}"))??;
-
-    let changed_lines = state
-        .review
-        .pull_request_changed_lines(&result.repo, result.pr_number, &token)
-        .await
-        .map_err(|error| error.to_string())?;
 
     let review = state
         .review
@@ -461,7 +488,7 @@ async fn process_pull_request_delivery(
             &result.findings,
             None,
             &token,
-            Some(&changed_lines),
+            changed_lines.as_ref(),
         )
         .await
         .map_err(|error| error.to_string())?;
@@ -474,7 +501,7 @@ async fn process_pull_request_delivery(
             &result.head_sha,
             &result.findings,
             &token,
-            Some(&changed_lines),
+            changed_lines.as_ref(),
         )
         .await
     {
@@ -497,6 +524,7 @@ fn run_pull_request_scan(
     pull_request: GitHubPullRequest,
     target_repo: &str,
     installation_token: &str,
+    changed_files: Option<Vec<String>>,
 ) -> Result<PullRequestScanResult, String> {
     let workspace =
         tempfile::tempdir().map_err(|error| format!("failed to create scan workspace: {error}"))?;
@@ -517,7 +545,21 @@ fn run_pull_request_scan(
         ));
     }
 
-    let output = run_scanner(&checkout)?;
+    // Diff-scope the scan to the PR's changed files when we have them. The list
+    // is written inside the workspace tempdir and passed to the CLI, which
+    // scans only those paths but keeps the full checkout as the analysis root
+    // (cross-file taint preserved). Absent the list, we scan the whole tree.
+    let changed_files_list = match &changed_files {
+        Some(files) => {
+            let list_path = workspace.path().join("changed-files.txt");
+            std::fs::write(&list_path, files.join("\n"))
+                .map_err(|error| format!("failed to write changed-files list: {error}"))?;
+            Some(list_path)
+        }
+        None => None,
+    };
+
+    let output = run_scanner(&checkout, changed_files_list.as_deref())?;
     let mut findings = parse_json_findings(&output)?;
     for finding in &mut findings {
         finding.file = relative_path(&finding.file, Some(&checkout));
@@ -683,12 +725,44 @@ fn redact_git_error(error: &str, installation_token: &str) -> String {
     redacted
 }
 
-fn run_scanner(checkout: &Path) -> Result<String, String> {
+/// Path globs excluded from every PR scan to strip clearly non-reviewable
+/// files (fixtures, vendored deps, generated/minified bundles). This cuts scan
+/// time — a major driver of the 60s timeouts — without dropping real code.
+const SCAN_EXCLUDE_GLOBS: &[&str] = &[
+    "tests/fixtures",
+    "**/examples/**",
+    "*-min.js",
+    "**/vendor/**",
+    "**/node_modules/**",
+    "**/*.min.*",
+    "**/dist/**",
+    "**/build/**",
+];
+
+/// Build the `foxguard` argument vector. When `changed_files_list` is provided
+/// the scan is diff-scoped to that file (with `checkout` as the analysis root,
+/// preserving cross-file taint); path exclusions are always applied. Pure and
+/// unit-tested — the live invocation in `run_scanner` just feeds these to the
+/// process.
+fn build_scanner_args(checkout: &Path, changed_files_list: Option<&Path>) -> Vec<OsString> {
+    let mut args: Vec<OsString> = vec![checkout.as_os_str().to_owned()];
+    if let Some(list) = changed_files_list {
+        args.push("--changed-files-from".into());
+        args.push(list.as_os_str().to_owned());
+    }
+    for glob in SCAN_EXCLUDE_GLOBS {
+        args.push("--exclude".into());
+        args.push(OsString::from(*glob));
+    }
+    args.push("--format".into());
+    args.push("json".into());
+    args
+}
+
+fn run_scanner(checkout: &Path, changed_files_list: Option<&Path>) -> Result<String, String> {
     let mut command = Command::new("foxguard");
     command
-        .arg(checkout)
-        .arg("--format")
-        .arg("json")
+        .args(build_scanner_args(checkout, changed_files_list))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     run_command_with_timeout(command, PULL_REQUEST_SCAN_TIMEOUT, "foxguard")
@@ -895,6 +969,60 @@ mod tests {
 
         assert_eq!(payload.action.as_deref(), Some("synchronize"));
         assert!(payload.installation.is_none());
+    }
+
+    #[test]
+    fn build_scanner_args_diff_scopes_and_excludes_noise() {
+        let checkout = Path::new("/work/repo");
+        let list = Path::new("/work/changed-files.txt");
+        let args = build_scanner_args(checkout, Some(list));
+        let args: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        // Scans the checkout as the analysis root (cross-file taint context).
+        assert_eq!(args.first().map(String::as_str), Some("/work/repo"));
+        // Diff-scoped to the changed-files list.
+        let idx = args
+            .iter()
+            .position(|a| a == "--changed-files-from")
+            .expect("expected --changed-files-from flag");
+        assert_eq!(
+            args.get(idx + 1).map(String::as_str),
+            Some("/work/changed-files.txt")
+        );
+        // JSON output for machine parsing.
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--format" && w[1] == "json"));
+        // Every configured noise glob is passed as an --exclude.
+        for glob in SCAN_EXCLUDE_GLOBS {
+            assert!(
+                args.windows(2)
+                    .any(|w| w[0] == "--exclude" && w[1] == *glob),
+                "missing --exclude {glob}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_scanner_args_full_tree_fallback_omits_changed_files_flag() {
+        let args = build_scanner_args(Path::new("/work/repo"), None);
+        let args: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        // No diff-scoping flag when the changed-files list is unavailable.
+        assert!(!args.iter().any(|a| a == "--changed-files-from"));
+        // Exclusions still apply to keep the fallback scan cheaper.
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--exclude" && w[1] == "**/vendor/**"));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--format" && w[1] == "json"));
     }
 
     #[test]

--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -444,6 +444,7 @@ fn scan_args(arguments: &Value, pq_mode: bool) -> Result<ScanArgs, String> {
         codeql_db: optional_string(arguments, "codeql_db")?,
         no_builtins: optional_bool(arguments, "no_builtins")?,
         changes: change_mode_args(arguments)?,
+        changed_files_from: None,
         exclude: optional_string_array(arguments, "exclude")?,
         baseline: optional_string(arguments, "baseline")?,
         write_baseline: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,14 @@ pub struct ScanArgs {
     #[command(flatten)]
     pub changes: ChangeModeArgs,
 
+    /// Scan only the newline-delimited, repo-root-relative paths listed in
+    /// this file, using the scan path as the analysis root so cross-file
+    /// taint context is preserved. Missing (e.g. deleted) files are skipped;
+    /// an empty list produces zero findings without falling back to a
+    /// full-tree scan. Takes precedence over the change-mode flags.
+    #[arg(long = "changed-files-from")]
+    pub changed_files_from: Option<String>,
+
     /// Exclude scan-relative paths by glob or prefix (repeatable)
     #[arg(long)]
     pub exclude: Vec<String>,
@@ -624,6 +632,7 @@ impl PqcArgs {
             codeql_db: None,
             no_builtins: false,
             changes: self.changes.clone(),
+            changed_files_from: None,
             exclude: self.exclude.clone(),
             baseline: self.baseline.clone(),
             write_baseline: None,
@@ -659,6 +668,7 @@ impl ScaArgs {
             codeql_db: None,
             no_builtins: true,
             changes: self.changes.clone(),
+            changed_files_from: None,
             exclude: self.exclude.clone(),
             baseline: self.baseline.clone(),
             write_baseline: None,
@@ -691,6 +701,7 @@ impl BaselineScanArgs {
             codeql_db: self.codeql_db.clone(),
             no_builtins: self.no_builtins,
             changes: self.changes.clone(),
+            changed_files_from: None,
             exclude: self.exclude.clone(),
             baseline: self.baseline.clone(),
             write_baseline: self.write_baseline.clone(),

--- a/tests/changed_files_from.rs
+++ b/tests/changed_files_from.rs
@@ -1,0 +1,172 @@
+// Integration tests for the `--changed-files-from <FILE>` scan flag.
+//
+// This flag diff-scopes a scan to a newline-delimited, root-relative file
+// list while keeping the scan path as the analysis root, so the GitHub App
+// can scan only a PR's changed files instead of the whole cloned tree.
+//
+// IMPORTANT ENGINE NOTE (verified, diverges from the original design memo):
+// "root context" does NOT pull *unlisted* sibling files into taint analysis.
+// `scan_paths_with_root` builds cross-file taint summaries only from the
+// files actually passed in; `scan_root` is used for path attribution and
+// exclude matching, not for discovering additional context files. Concretely:
+// a cross-file flow is resolved only when BOTH the source file and the sink
+// file are in the listed subset. If the source (or sink) lives in an unlisted
+// file, the flow is lost. The tests below pin exactly this behavior.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn foxguard_cmd() -> Command {
+    // `--config /dev/null` isolates from any developer-local `.foxguard.yml`
+    // and the repo baseline (which suppresses tests/fixtures findings).
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_foxguard"));
+    cmd.args(["--config", "/dev/null"]);
+    cmd
+}
+
+fn django_chain_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("realistic")
+        .join("django_chain")
+}
+
+/// Run a scan against `root` with the given `--changed-files-from` list
+/// contents. Returns (exit_success, rule_ids-with-basenames).
+fn scan_with_list(
+    root: &Path,
+    list_contents: &str,
+    extra: &[&str],
+) -> (bool, Vec<(String, String)>) {
+    let list_file = tempfile::NamedTempFile::new().expect("create temp list file");
+    std::fs::write(list_file.path(), list_contents).expect("write list file");
+
+    let output = foxguard_cmd()
+        .arg(root)
+        .arg("--changed-files-from")
+        .arg(list_file.path())
+        .args(extra)
+        .args(["-f", "json"])
+        .output()
+        .expect("run foxguard");
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON report");
+    let findings = report["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .map(|f| {
+            let rule = f["rule_id"].as_str().unwrap_or("").to_string();
+            let file = f["file"]
+                .as_str()
+                .unwrap_or("")
+                .rsplit('/')
+                .next()
+                .unwrap_or("")
+                .to_string();
+            (rule, file)
+        })
+        .collect();
+
+    (output.status.success(), findings)
+}
+
+/// Gate #1: cross-file taint is preserved when scanning a *subset* of a larger
+/// tree, as long as both the source and sink files are listed. django_chain is
+/// a 3-file tree (views.py -> middleware.py -> queries.py); we list only two of
+/// them (views.py, queries.py) and still resolve the SQL-injection flow — the
+/// unlisted middleware.py passthrough hop does not break it. This proves the
+/// subset scan analyzes the listed files together (root context for path
+/// attribution), not each file in isolation.
+#[test]
+fn changed_files_from_preserves_cross_file_taint_among_listed_files() {
+    let (ok, findings) = scan_with_list(&django_chain_dir(), "views.py\nqueries.py\n", &[]);
+    assert!(ok || !findings.is_empty(), "scan should run");
+    assert!(
+        findings
+            .iter()
+            .any(|(rule, file)| rule == "py/taint-sql-injection" && file == "views.py"),
+        "cross-file taint flow should resolve across listed files; got {findings:?}"
+    );
+}
+
+/// Gate #1 corollary + engine limitation: listing ONLY the sink file (source
+/// unlisted) does NOT resolve the cross-file flow. This directly contradicts
+/// the original design memo's claim that root context preserves a flow whose
+/// source is in an unlisted file. The subset scan still returns only the
+/// listed file's own findings.
+#[test]
+fn changed_files_from_returns_only_listed_files_findings() {
+    let (_ok, findings) = scan_with_list(&django_chain_dir(), "queries.py\n", &[]);
+    // queries.py's own single-file finding is present...
+    assert!(
+        findings.iter().any(|(_, file)| file == "queries.py"),
+        "listed file's own findings should be present; got {findings:?}"
+    );
+    // ...but nothing from unlisted files, and the cross-file taint (attributed
+    // to the unlisted views.py source) is absent.
+    assert!(
+        findings.iter().all(|(_, file)| file == "queries.py"),
+        "only listed files should appear; got {findings:?}"
+    );
+    assert!(
+        !findings
+            .iter()
+            .any(|(rule, _)| rule == "py/taint-sql-injection"),
+        "cross-file taint must NOT resolve when the source file is unlisted; got {findings:?}"
+    );
+}
+
+/// Gate #2: an empty list scans nothing and exits 0 with zero findings — no
+/// fall-back to a full-tree scan.
+#[test]
+fn changed_files_from_empty_list_scans_nothing() {
+    let (ok, findings) = scan_with_list(&django_chain_dir(), "", &[]);
+    assert!(ok, "empty list should exit 0");
+    assert!(
+        findings.is_empty(),
+        "empty list should yield no findings; got {findings:?}"
+    );
+}
+
+/// Gate #2: a list whose entries are all missing (e.g. files a PR deleted) is
+/// treated the same as an empty list — zero findings, exit 0, no full-tree
+/// fall-back. Blank lines and `#` comments are ignored.
+#[test]
+fn changed_files_from_all_missing_paths_scans_nothing() {
+    let (ok, findings) = scan_with_list(
+        &django_chain_dir(),
+        "# a comment\n\ndoes/not/exist.py\nalso_missing.py\n",
+        &[],
+    );
+    assert!(ok, "all-missing list should exit 0");
+    assert!(
+        findings.is_empty(),
+        "all-missing list should yield no findings; got {findings:?}"
+    );
+}
+
+/// Gate #4: `--exclude` composes with `--changed-files-from` and actually
+/// excludes matching paths. Listing queries.py yields its single-file finding;
+/// adding `--exclude queries.py` removes it.
+#[test]
+fn changed_files_from_respects_exclude() {
+    let (_ok, baseline) = scan_with_list(&django_chain_dir(), "queries.py\n", &[]);
+    assert!(
+        baseline.iter().any(|(_, file)| file == "queries.py"),
+        "baseline should include queries.py finding; got {baseline:?}"
+    );
+
+    let (ok, excluded) = scan_with_list(
+        &django_chain_dir(),
+        "queries.py\n",
+        &["--exclude", "queries.py"],
+    );
+    assert!(ok, "excluded scan should exit 0");
+    assert!(
+        excluded.is_empty(),
+        "excluding queries.py should drop its finding; got {excluded:?}"
+    );
+}


### PR DESCRIPTION
## Problem (measured in prod, 41 days)
The app scans the **entire repo tree** on every PR. On large repos/monorepos that blows the 60s scan timeout — **468 scan-timeouts** (vs 17 clone-timeouts), **all concentrated in two installations: 0sec-labs (the `0sec` monorepo) and danielbodnar (large repos)**. A timeout aborts the whole delivery, so **~20% of PRs got NO review at all**. See `docs/findings-noise-investigation.md`.

## Approach (chosen: zero-regression)
**Full-tree scan first; diff-scope only on timeout.**
- The ~80% of PRs that scan in time keep **full whole-repo cross-file taint coverage** — no regression.
- When the full scan times out, fall back to a **diff-scoped scan of just the PR's changed files** (fast), using the full checkout as analysis root so cross-file taint *among the changed files* is preserved. Those PRs go from **no review → reviewed**.
- Bounded tradeoff, only on the fallback path: a cross-file flow whose source is in an *unchanged* file isn't analysed. Strictly better than the prior `timeout = nothing`.

## What's in it
- **New CLI flag `--changed-files-from <FILE>`** (`cli.rs`/`app.rs`): scan an explicit newline-delimited file list with repo root as context (reuses `scan_paths_with_root_with_notices`). Deleted-in-PR / empty list → 0 findings, no full-tree fallback. Additive; absent the flag behavior is unchanged.
- **App**: fetch changed files before the scan; run full scan; on `is_scan_timeout`, retry diff-scoped. Noise `--exclude` globs (`tests/fixtures`, `examples`, `vendor`, `node_modules`, `*.min.*`, `dist`, `build`) applied on **both** paths to cut time+noise. If the changed-files fetch fails → full-tree scan (safe fallback), logged.

## Tests
CLI integration (`tests/changed_files_from.rs`, 5) incl. **cross-file taint preserved when scanning a subset**; app unit tests for arg-building + `is_scan_timeout`. `cargo test --features github-app` green, clippy clean, fmt clean.

## CLI sanity (release)
Full: 3 files, 4 findings, 1.00s. Subset (2 of 3 files): 2 findings, 0.00s — cross-file `py/taint-sql-injection` (source+sink both listed) preserved; unlisted file's findings dropped.

Pairs with the configurable timeout (0sec-labs/foxguard#543) and the infra deploy (0sec-labs/0sec#1111).