### PR TITLE
fix: scan Kotlin and C files in VS Code

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -97,6 +97,9 @@
         "id": "kotlin"
       },
       {
+        "id": "c"
+      },
+      {
         "id": "haskell"
       }
     ]
@@ -105,7 +108,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "test": "tsc -p ./ && node out/extractFindings.test.js"
+    "test": "tsc -p ./ && node out/extractFindings.test.js && node out/supportedFiles.test.js"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3,6 +3,7 @@ import { spawn } from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
+import { isSupportedFile } from "./supportedFiles";
 
 /** Mirrors the JSON output of `foxguard --format json`. */
 interface Finding {
@@ -150,20 +151,6 @@ function extractFindings(parsed: ReportEnvelope | Finding[]): Finding[] {
   }
   return parsed.findings ?? [];      // versioned envelope
 }
-
-/** File extensions foxguard supports. */
-const SUPPORTED_EXTENSIONS = new Set([
-  ".js", ".jsx", ".mjs", ".cjs",
-  ".ts", ".tsx", ".mts", ".cts",
-  ".py", ".pyw",
-  ".go",
-  ".rb", ".rake",
-  ".java",
-  ".php",
-  ".rs",
-  ".cs",
-  ".swift",
-]);
 
 const SEVERITY_ORDER: Record<string, number> = {
   low: 0, medium: 1, high: 2, critical: 3,
@@ -648,11 +635,6 @@ function setStatusDone(count: number): void {
 // ---------------------------------------------------------------------------
 // Core scanning logic
 // ---------------------------------------------------------------------------
-
-function isSupportedFile(filePath: string): boolean {
-  const ext = path.extname(filePath).toLowerCase();
-  return SUPPORTED_EXTENSIONS.has(ext);
-}
 
 function mapSeverity(severity: string): vscode.DiagnosticSeverity {
   switch (severity) {

--- a/vscode-extension/src/supportedFiles.test.ts
+++ b/vscode-extension/src/supportedFiles.test.ts
@@ -1,0 +1,23 @@
+import * as assert from "assert";
+
+import { isSupportedFile } from "./supportedFiles";
+
+for (const filePath of [
+  "Example.kt",
+  "Example.kts",
+  "native/module.c",
+  "native/include/module.h",
+]) {
+  assert.strictEqual(isSupportedFile(filePath), true, `${filePath} should be supported`);
+}
+
+for (const filePath of [
+  "notes.txt",
+  "native/module.cpp",
+]) {
+  assert.strictEqual(isSupportedFile(filePath), false, `${filePath} should not be supported`);
+}
+
+assert.strictEqual(isSupportedFile("SRC/APP.KT"), true, "extension matching should be case-insensitive");
+
+console.log("All supportedFiles tests passed.");

--- a/vscode-extension/src/supportedFiles.ts
+++ b/vscode-extension/src/supportedFiles.ts
@@ -1,0 +1,22 @@
+import * as path from "path";
+
+/** File extensions foxguard supports for single-file editor scans. */
+const SUPPORTED_EXTENSIONS = new Set([
+  ".js", ".jsx", ".mjs", ".cjs",
+  ".ts", ".tsx", ".mts", ".cts",
+  ".py", ".pyw",
+  ".go",
+  ".rb", ".rake",
+  ".java",
+  ".php",
+  ".rs",
+  ".cs",
+  ".swift",
+  ".kt", ".kts",
+  ".c", ".h",
+]);
+
+export function isSupportedFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_EXTENSIONS.has(ext);
+}


### PR DESCRIPTION
Closes #522.

## Summary
- add Kotlin and C extensions to the VS Code single-file scan gate
- add C to the extension language contribution list
- cover the gate with a small Node test

## Tests
- npm test