### PR TITLE
fix(action): report findings and execution failures correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: bash -n action/entrypoint.sh
+      - run: python3 action/test_count_terminal_findings.py
       - run: bash -n benchmarks/precision/run.sh
       - run: bash -n benchmarks/run.sh
       - run: bash -n scripts/linux-codeql-dirty-frag.sh

--- a/action/count-terminal-findings.py
+++ b/action/count-terminal-findings.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Extract the finding total from foxguard's terminal report."""
+
+import re
+import sys
+
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+SUMMARY = re.compile(r"^\s*(\d+)\s+issues\s+\d+\s+files\b", re.MULTILINE)
+
+
+def count_findings(output: str) -> int:
+    clean_output = ANSI_ESCAPE.sub("", output)
+    match = SUMMARY.search(clean_output)
+    return int(match.group(1)) if match else 0
+
+
+if __name__ == "__main__":
+    print(count_findings(sys.stdin.read()))

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -136,11 +136,19 @@ else:
     print(report.get('finding_counts', {}).get('total', len(report.get('findings', []))))
 " 2>/dev/null || echo "0")
     else
-        FINDINGS_COUNT="${EXIT_CODE}"
+        FINDINGS_COUNT=$(printf '%s\n' "${OUTPUT}" | python3 "${GITHUB_ACTION_PATH:-$(dirname "$0")}/count-terminal-findings.py")
     fi
 fi
 
 echo "::endgroup::"
+
+# Foxguard reserves exit code 1 for findings and uses 2 for execution errors.
+# Never turn an execution failure into a finding count (or hide it when
+# fail-on-findings is disabled).
+if [ "${EXIT_CODE}" -gt 1 ]; then
+    echo "::error::Foxguard failed with exit code ${EXIT_CODE}"
+    exit "${EXIT_CODE}"
+fi
 
 # ─── Set outputs ─────────────────────────────────────────────────────────────
 

--- a/action/test_count_terminal_findings.py
+++ b/action/test_count_terminal_findings.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("count-terminal-findings.py")
+SPEC = importlib.util.spec_from_file_location("count_terminal_findings", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CountTerminalFindingsTest(unittest.TestCase):
+    def test_counts_multiple_findings_in_colored_summary(self) -> None:
+        output = "\n  \x1b[2m--------------------------------------------------\x1b[0m\n\n  \x1b[1m12\x1b[0m \x1b[2missues\x1b[0m  \x1b[2m4 files · 0.01s\x1b[0m\n"
+        self.assertEqual(MODULE.count_findings(output), 12)
+
+    def test_clean_scan_has_zero_findings(self) -> None:
+        output = "\n  ✓ Scanned 4 files in 0.01s.\n"
+        self.assertEqual(MODULE.count_findings(output), 0)
+
+    def test_error_text_is_not_a_finding_count(self) -> None:
+        self.assertEqual(MODULE.count_findings("Error: invalid configuration\n"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #520.\n\nThe GitHub Action now parses Foxguard’s actual ANSI terminal summary for the findings count and distinguishes findings from CLI execution failures: exit status `1` means findings, while statuses above `1` fail the action as scanner errors. Adds three regression cases and runs them in CI.\n\nIssue #519 was reviewed during this pass and is already fixed on current `main`, including the `scan: {}` flow-mapping regression test.