### PR TITLE
fix(ci): restore Clippy and execute package regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           cache: npm
           cache-dependency-path: vscode-extension/package-lock.json
       - run: npm ci
-      - run: npm run compile
+      - run: npm test
 
   npm-package:
     name: npm Package
@@ -165,6 +165,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - run: npm test
       - run: npm pack --dry-run
 
   scripts:

--- a/src/fix/command_injection.rs
+++ b/src/fix/command_injection.rs
@@ -70,10 +70,9 @@ pub fn fix_javascript(
     // Rewrite exec -> execFile with separate args
     let new_func = if let Some(prefix) = func_text.strip_suffix("execSync") {
         format!("{prefix}execFileSync")
-    } else if let Some(prefix) = func_text.strip_suffix("exec") {
-        format!("{prefix}execFile")
     } else {
-        return None;
+        let prefix = func_text.strip_suffix("exec")?;
+        format!("{prefix}execFile")
     };
 
     let (cmd, cmd_args) = split_command_parts(&parts)?;

--- a/src/rules/generic_mode.rs
+++ b/src/rules/generic_mode.rs
@@ -405,10 +405,9 @@ fn parse_generic_comparison(comparison: &str) -> Option<(String, CmpOp, f64, boo
             let rhs = s[idx + op_str.len()..].trim();
             let (metavar_side, literal_str, literal_is_lhs) = if let Some(g) = capture_name(lhs) {
                 (g, rhs, false)
-            } else if let Some(g) = capture_name(rhs) {
-                (g, lhs, true)
             } else {
-                return None;
+                let g = capture_name(rhs)?;
+                (g, lhs, true)
             };
             let literal = parse_numeric(literal_str.trim())?;
             return Some((metavar_side, *op, literal, literal_is_lhs));

--- a/src/rules/ruby_taint.rs
+++ b/src/rules/ruby_taint.rs
@@ -948,11 +948,7 @@ fn leftmost_receiver_text<'a>(mut node: Node<'_>, source: &'a str) -> Option<&'a
             "identifier" | "constant" => return Some(node_text(node, source)),
             "call" => {
                 // Attribute access: call with receiver but no arguments.
-                if let Some(recv) = node.child_by_field_name("receiver") {
-                    node = recv;
-                } else {
-                    return None;
-                }
+                node = node.child_by_field_name("receiver")?;
             }
             _ => return None,
         }


### PR DESCRIPTION
Restores green `main` under Rust/Clippy 1.97 by applying the three new `question_mark` cleanups. Strengthens CI so the VS Code extension job runs its existing test suites and the npm launcher job runs its regression tests before packaging.\n\nValidated with Rust 1.97 fmt/clippy, VS Code `npm test`, npm launcher `npm test`, and `npm pack --dry-run`. Closes #523.