### PR TITLE
ci(release): verify VS Code Marketplace propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,10 @@ jobs:
       - run: bash -n benchmarks/precision/run.sh
       - run: bash -n benchmarks/run.sh
       - run: bash -n scripts/linux-codeql-dirty-frag.sh
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: node --test scripts/verify-vscode-marketplace.test.mjs
       - run: bash -n scripts/release.sh
 
   precision-corpus-metadata:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,9 @@ jobs:
           fi
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Verify Marketplace propagation
+        run: VSCODE_MARKETPLACE_VERSION="${GITHUB_REF_NAME#v}" node ../scripts/verify-vscode-marketplace.mjs
+
 
   publish-ghcr-github-app:
     name: Publish foxguard-github-app image (GHCR)

--- a/scripts/verify-vscode-marketplace.mjs
+++ b/scripts/verify-vscode-marketplace.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_ENDPOINT =
+  "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=7.2-preview.1";
+
+export function marketplaceQuery(publisher, extension) {
+  return {
+    filters: [
+      {
+        criteria: [
+          {
+            filterType: 7,
+            value: `${publisher}.${extension}`,
+          },
+        ],
+      },
+    ],
+    // Include versions while omitting large asset payloads.
+    flags: 103,
+  };
+}
+
+export async function publishedVersions({
+  publisher,
+  extension,
+  endpoint = DEFAULT_ENDPOINT,
+  fetchFn = fetch,
+}) {
+  const response = await fetchFn(endpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json;api-version=7.2-preview.1;excludeUrls=true",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(marketplaceQuery(publisher, extension)),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Marketplace API returned HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const match = payload?.results?.[0]?.extensions?.find(
+    (item) =>
+      item.extensionName?.toLowerCase() === extension.toLowerCase() &&
+      item.publisher?.publisherName?.toLowerCase() === publisher.toLowerCase(),
+  );
+
+  if (!match) {
+    return [];
+  }
+
+  return [...new Set((match.versions ?? []).map((item) => item.version).filter(Boolean))];
+}
+
+export async function waitForMarketplaceVersion({
+  publisher,
+  extension,
+  version,
+  timeoutMs = 10 * 60 * 1000,
+  intervalMs = 15 * 1000,
+  endpoint = DEFAULT_ENDPOINT,
+  fetchFn = fetch,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  now = Date.now,
+  log = console.log,
+}) {
+  const deadline = now() + timeoutMs;
+  let attempt = 0;
+  let lastVersions = [];
+  let lastError;
+
+  do {
+    attempt += 1;
+    try {
+      lastVersions = await publishedVersions({ publisher, extension, endpoint, fetchFn });
+      lastError = undefined;
+      if (lastVersions.includes(version)) {
+        log(`Marketplace reports ${publisher}.${extension} ${version} (attempt ${attempt}).`);
+        return;
+      }
+      log(
+        `Waiting for ${publisher}.${extension} ${version}; currently visible: ${lastVersions.join(", ") || "none"}.`,
+      );
+    } catch (error) {
+      lastError = error;
+      log(`Marketplace query failed on attempt ${attempt}: ${error.message}`);
+    }
+
+    if (now() >= deadline) {
+      break;
+    }
+    await sleep(Math.min(intervalMs, Math.max(0, deadline - now())));
+  } while (now() <= deadline);
+
+  const detail = lastError
+    ? ` Last query error: ${lastError.message}.`
+    : ` Visible versions: ${lastVersions.join(", ") || "none"}.`;
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${publisher}.${extension} ${version}.${detail}`,
+  );
+}
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function main() {
+  await waitForMarketplaceVersion({
+    publisher: process.env.VSCODE_MARKETPLACE_PUBLISHER ?? "peaktwilight",
+    extension: process.env.VSCODE_MARKETPLACE_EXTENSION ?? "foxguard",
+    version: required("VSCODE_MARKETPLACE_VERSION"),
+    timeoutMs: Number(process.env.VSCODE_MARKETPLACE_TIMEOUT_MS ?? 10 * 60 * 1000),
+    intervalMs: Number(process.env.VSCODE_MARKETPLACE_INTERVAL_MS ?? 15 * 1000),
+    endpoint: process.env.VSCODE_MARKETPLACE_ENDPOINT ?? DEFAULT_ENDPOINT,
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-vscode-marketplace.test.mjs
+++ b/scripts/verify-vscode-marketplace.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  marketplaceQuery,
+  publishedVersions,
+  waitForMarketplaceVersion,
+} from "./verify-vscode-marketplace.mjs";
+
+function response(payload, { ok = true, status = 200 } = {}) {
+  return { ok, status, json: async () => payload };
+}
+
+function listing(...versions) {
+  return {
+    results: [
+      {
+        extensions: [
+          {
+            extensionName: "foxguard",
+            publisher: { publisherName: "PeakTwilight" },
+            versions: versions.map((version) => ({ version })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("queries the fully qualified extension name", () => {
+  assert.equal(
+    marketplaceQuery("peaktwilight", "foxguard").filters[0].criteria[0].value,
+    "peaktwilight.foxguard",
+  );
+});
+
+test("returns versions from the matching listing", async () => {
+  const versions = await publishedVersions({
+    publisher: "peaktwilight",
+    extension: "foxguard",
+    fetchFn: async () => response(listing("0.11.0", "0.10.0")),
+  });
+  assert.deepEqual(versions, ["0.11.0", "0.10.0"]);
+});
+
+test("polls until propagation completes", async () => {
+  let query = 0;
+  let clock = 0;
+  await waitForMarketplaceVersion({
+    publisher: "peaktwilight",
+    extension: "foxguard",
+    version: "0.11.0",
+    timeoutMs: 100,
+    intervalMs: 10,
+    fetchFn: async () => response(listing(++query === 1 ? "0.10.0" : "0.11.0")),
+    sleep: async (milliseconds) => {
+      clock += milliseconds;
+    },
+    now: () => clock,
+    log: () => {},
+  });
+  assert.equal(query, 2);
+});
+
+test("fails clearly when the requested version never appears", async () => {
+  let clock = 0;
+  await assert.rejects(
+    waitForMarketplaceVersion({
+      publisher: "peaktwilight",
+      extension: "foxguard",
+      version: "0.11.0",
+      timeoutMs: 20,
+      intervalMs: 10,
+      fetchFn: async () => response(listing("0.10.0")),
+      sleep: async (milliseconds) => {
+        clock += milliseconds;
+      },
+      now: () => clock,
+      log: () => {},
+    }),
+    /Timed out.*Visible versions: 0\.10\.0/,
+  );
+});
+
+test("reports Marketplace API failures", async () => {
+  await assert.rejects(
+    publishedVersions({
+      publisher: "peaktwilight",
+      extension: "foxguard",
+      fetchFn: async () => response({}, { ok: false, status: 503 }),
+    }),
+    /HTTP 503/,
+  );
+});


### PR DESCRIPTION
## Summary
- poll the public VS Code Marketplace Gallery API after `vsce publish`
- bound propagation verification to ten minutes with actionable timeout diagnostics
- exercise immediate publication, delayed propagation, timeout, and API failure paths in CI

## Why
`vsce publish` acceptance does not prove that the version is publicly discoverable. The v0.11.0 release was accepted at 19:54 UTC and became visible through the public Gallery API at 19:59 UTC. This check makes that eventual-consistency window explicit and prevents a green release from silently leaving users on the previous Marketplace version.

## Verification
- `node --test scripts/verify-vscode-marketplace.test.mjs`
- live public query: `VSCODE_MARKETPLACE_VERSION=0.11.0 VSCODE_MARKETPLACE_TIMEOUT_MS=5000 VSCODE_MARKETPLACE_INTERVAL_MS=100 node scripts/verify-vscode-marketplace.mjs`
- `git diff --check`
