### PR TITLE
docs(contract): record 0sec native finding ingestion

### DIFF
--- a/docs/finding-contract.md
+++ b/docs/finding-contract.md
@@ -19,7 +19,7 @@ that predate the native envelope.
 | GitHub App | Reads native `findings`; retains legacy bare-array compatibility |
 | VS Code extension | Reads native `findings`; retains legacy bare-array compatibility |
 | GitHub Action | Uses terminal output for the summary and SARIF for code scanning; it does not parse native findings |
-| 0sec monorepo | Pins Foxguard as a submodule and validates its release; it does not currently ingest native Foxguard findings directly |
+| 0sec monorepo | Pins the latest healthy Foxguard `main` commit through an automated pull request, adapts native v1 findings into its ingest contract, and exercises release binary → HTTP ingest → tenant-scoped persistence in CI |
 
 The canonical full-field fixture is
 [`tests/contracts/native-report-v1.json`](../tests/contracts/native-report-v1.json).


### PR DESCRIPTION
## What changed

Updates the finding-contract consumer inventory to reflect the merged Foxguard-to-0sec integration: healthy-main submodule updates, native v1 adaptation, and release-binary-to-HTTP-persistence E2E coverage.

## Why

The existing row still described the pre-integration state and incorrectly said 0sec did not ingest native Foxguard findings.

## Validation

- `git diff --check`
- Documentation is aligned with the live 0sec updater and `Foxguard to 0sec E2E` workflow

This genuine upstream change also allows the newly enabled Actions PR permission to be verified through the normal automated submodule updater.