### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "foxguard"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxguard"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "A security scanner as fast as a linter, written in Rust. 200+ built-in rules across 12 source languages."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Prebuilt installs verify release binaries against `checksums.txt`. Release binar
 **GitHub Action:**
 
 ```yaml
-- uses: 0sec-labs/foxguard/action@v0.11.0
+- uses: 0sec-labs/foxguard/action@v0.12.0
   with:
     path: .
     severity: medium
@@ -59,7 +59,7 @@ Prebuilt installs verify release binaries against `checksums.txt`. Release binar
 ```yaml
 repos:
   - repo: https://github.com/0sec-labs/foxguard
-    rev: v0.11.0
+    rev: v0.12.0
     hooks:
       - id: foxguard
 ```

--- a/RELEASE_NOTES_v0.12.0.md
+++ b/RELEASE_NOTES_v0.12.0.md
@@ -1,0 +1,82 @@
+# foxguard v0.12.0 — stable finding interchange and quieter Python reviews
+
+This release gives Foxguard findings an explicit, tested interchange contract, connects that contract to 0sec's cross-tool ingestion path, hardens GitHub App pull-request admission, and removes false command-injection alerts for provably safe Python subprocess argument vectors.
+
+```sh
+npx foxguard@latest .
+```
+
+## Highlights
+
+### Versioned native finding contract
+
+- Native JSON now reports `finding_schema_version: "1.0.0"` independently of the report envelope's `schema_version`.
+- The v1 finding shape is documented in `docs/finding-contract.md`, provided as `schemas/finding-v1.schema.json`, and pinned by a full-field golden fixture shared by Rust and VS Code tests.
+- Native JSON, SARIF, the GitHub App, and the VS Code extension are tested against the same finding semantics. Existing integrations that still return a legacy bare finding array remain supported.
+- Breaking changes to required finding fields, types, or meanings now require a new major finding-schema version instead of silently rewriting v1.
+
+### 0sec cross-tool integration
+
+- The 0sec monorepo now pins a healthy Foxguard source commit, adapts native v1 findings into its ingest contract, and exercises release binary → HTTP ingest → tenant-scoped persistence in CI.
+- Source and release gates remain intentionally separate: the submodule contract validates the exact source pin and release ancestry, while cross-tool E2E downloads the declared release binary. Unreleased source changes therefore cannot silently redefine released evidence.
+
+### GitHub App hardening
+
+- Pull-request work now enters a bounded queue: 128 pending jobs and four workers by default, configurable with positive `FOXGUARD_PR_QUEUE_CAPACITY` and `FOXGUARD_PR_WORKERS` values.
+- Replayed GitHub delivery IDs are deduplicated. Concurrent updates for the same repository and pull request coalesce, and the newest head receives a follow-up scan instead of racing an active scan or being lost.
+- Queue overload is acknowledged and logged without blocking webhook handling.
+- Release CI smoke-tests GitHub App container startup and its health endpoint before publishing the image; the Rust suite separately pins webhook-signature behavior.
+
+### Python subprocess argv precision
+
+- `py/no-command-injection` now recognizes shell-free `subprocess` calls whose argument-vector provenance is statically proven within the sink's lexical scope and whose executable head is constant.
+- Typed method builders are bound to their receiver class, while unsafe mutation, aliasing, unknown calls, dynamic `shell` values, cross-scope collisions, and non-constant executable heads invalidate the proof and remain findings.
+- Regression fixtures cover the safe builder shape that caused a false positive in a real 0verse review and 17 unsafe near-misses.
+
+### Packaging and integration reliability
+
+- The npm launcher cache is keyed by target platform, preventing a binary selected for one platform from being reused on another.
+- The VS Code extension centralizes and tests supported-file detection.
+- The GitHub Action reports terminal finding counts accurately.
+- Release automation runs Node tests and verifies that a published VS Code Marketplace version becomes visible after `vsce` publication.
+
+## Compatibility
+
+- The CLI and configuration remain backward compatible.
+- Native finding contract: `1.0.0`.
+- Legacy bare-array finding consumers remain supported.
+- GitHub App queue defaults are suitable for existing deployments; operators can override them through environment variables.
+
+## Verification
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `npm ci && npm run build` in `www`
+- `npm ci && npm run compile` in `vscode-extension`
+- `npm pack --dry-run` in `packages/npm`
+- Version alignment across Cargo, npm, VS Code extension, VS Code lockfile, and README release pins
+
+## Upgrade
+
+```sh
+npx foxguard@latest .
+# or
+curl -fsSL https://foxguard.dev/install.sh | sh
+# or
+cargo install foxguard
+```
+
+GitHub Action and pre-commit users can pin `v0.12.0`:
+
+```yaml
+- uses: 0sec-labs/foxguard/action@v0.12.0
+```
+
+```yaml
+repos:
+  - repo: https://github.com/0sec-labs/foxguard
+    rev: v0.12.0
+    hooks:
+      - id: foxguard
+```

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxguard",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A security scanner as fast as a linter, written in Rust. 200+ built-in rules across 12 source languages.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foxguard",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foxguard",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "foxguard",
   "displayName": "foxguard",
   "description": "A security scanner as fast as a linter, written in Rust.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publisher": "peaktwilight",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Foxguard's stable finding-v1 contract, bounded GitHub App dispatch, and Python argv precision fixes are ready for a coordinated v0.12.0 release across Cargo, npm, VS Code Marketplace, GitHub Releases, and GHCR.

## What

- align Cargo, npm, VS Code, lockfile, README action/pre-commit pins at `0.12.0`
- add accurate v0.12.0 release notes
- preserve compatibility and distinguish the native finding contract version from the package release version

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- website build
- VS Code compile/tests and `vsce package`
- npm launcher tests and dry pack
- Cargo package verification
- Marketplace verifier 5/5
- Action count tests 3/3
- exact version alignment and `git diff --check`

The bundled v0.9 pre-commit scanner was bypassed because the root package-version lockfile edit re-reports unchanged transitive RSA/ring PQ findings; no dependency edge changed. Current all-feature checks are green.
