### PR TITLE
feat(precision): export 0research control evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: python3 benchmarks/precision/precision.py validate
+      - run: python3 benchmarks/precision/test_zero_research.py
 
   readme-version-refs:
     name: README Version Refs

--- a/benchmarks/precision/precision.py
+++ b/benchmarks/precision/precision.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from zero_research import control_corpus_digest, control_evaluator_digest
+
 try:
     import tomllib  # type: ignore[import-not-found]
 except ModuleNotFoundError:  # Python < 3.11
@@ -617,6 +619,10 @@ def run(args: argparse.Namespace) -> int:
 
     all_findings, missing, stale = apply_labels(all_findings, labels)
     metrics = build_metrics(all_findings, repos)
+    metrics["negative_control_corpus_digest"] = control_corpus_digest(
+        args.manifest, args.labels
+    )
+    metrics["evaluator_digest"] = control_evaluator_digest(Path(__file__).resolve())
     metrics["duration_s"] = round(time.perf_counter() - start, 3)
     metrics["missing_labels"] = len(missing)
     metrics["stale_labels"] = len(stale)

--- a/benchmarks/precision/test_zero_research.py
+++ b/benchmarks/precision/test_zero_research.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("zero_research.py")
+SPEC = importlib.util.spec_from_file_location("zero_research", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+zero_research = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(zero_research)
+
+
+def summary(*, tp: int, fp: int, unsure: int = 0) -> dict:
+    reviewed = tp + fp
+    labeled = reviewed + unsure
+    return {
+        "schema_version": 1,
+        "aggregate": {
+            "total": labeled,
+            "labeled": labeled,
+            "reviewed": reviewed,
+            "true_positive": tp,
+            "false_positive": fp,
+            "unsure": unsure,
+            "reviewed_noise_rate": fp / reviewed,
+        },
+        "missing_labels": 0,
+        "stale_labels": 0,
+        "negative_control_corpus_digest": zero_research.control_corpus_digest(),
+        "evaluator_digest": zero_research.control_evaluator_digest(),
+    }
+
+
+class ZeroResearchAdapterTests(unittest.TestCase):
+    def test_builds_separate_negative_control_fragment(self) -> None:
+        fragment = zero_research.build_negative_control_fragment(
+            candidate_id="imp_foxguard_123",
+            champion_summary=summary(tp=10, fp=10),
+            challenger_summary=summary(tp=15, fp=5),
+            evidence_refs=["artifact:champion.json", "artifact:challenger.json"],
+        )
+        self.assertEqual(
+            fragment["negativeControls"]["champion"]["falsePositiveRate"], 0.5
+        )
+        self.assertEqual(
+            fragment["negativeControls"]["challenger"]["falsePositiveRate"], 0.25
+        )
+        self.assertEqual(
+            set(fragment["negativeControls"]["champion"]),
+            {"cases", "falsePositiveRate", "inconclusiveRate"},
+        )
+        self.assertNotIn("heldOut", fragment)
+        self.assertEqual(
+            fragment["evaluatorDigestBefore"], fragment["evaluatorDigestAfter"]
+        )
+
+    def test_load_rejects_label_drift(self) -> None:
+        value = summary(tp=1, fp=1)
+        value["stale_labels"] = 1
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "summary.json"
+            path.write_text(json.dumps(value))
+            with self.assertRaisesRegex(ValueError, "label drift"):
+                zero_research.load_summary(path)
+
+    def test_load_rejects_unlabeled_findings(self) -> None:
+        value = summary(tp=1, fp=1)
+        value["aggregate"]["total"] = 3
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "summary.json"
+            path.write_text(json.dumps(value))
+            with self.assertRaisesRegex(ValueError, "every emitted finding"):
+                zero_research.load_summary(path)
+
+    def test_digest_changes_when_evaluator_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "corpus.toml"
+            labels = root / "labels.jsonl"
+            evaluator = root / "precision.py"
+            manifest.write_text("corpus")
+            labels.write_text("labels")
+            evaluator.write_text("v1")
+            corpus_digest = zero_research.control_corpus_digest(manifest, labels)
+            first_evaluator_digest = zero_research.control_evaluator_digest(evaluator)
+            champion = summary(tp=1, fp=1)
+            challenger = summary(tp=1, fp=1)
+            for value in (champion, challenger):
+                value["negative_control_corpus_digest"] = corpus_digest
+                value["evaluator_digest"] = first_evaluator_digest
+            first = zero_research.build_negative_control_fragment(
+                candidate_id="imp_foxguard_123",
+                champion_summary=champion,
+                challenger_summary=challenger,
+                manifest_path=manifest,
+                labels_path=labels,
+                evaluator_path=evaluator,
+                evidence_refs=["artifact:result.json"],
+            )
+            evaluator.write_text("v2")
+            second_evaluator_digest = zero_research.control_evaluator_digest(evaluator)
+            for value in (champion, challenger):
+                value["evaluator_digest"] = second_evaluator_digest
+            second = zero_research.build_negative_control_fragment(
+                candidate_id="imp_foxguard_123",
+                champion_summary=champion,
+                challenger_summary=challenger,
+                manifest_path=manifest,
+                labels_path=labels,
+                evaluator_path=evaluator,
+                evidence_refs=["artifact:result.json"],
+            )
+            self.assertNotEqual(
+                first["evaluatorDigestBefore"], second["evaluatorDigestBefore"]
+            )
+
+    def test_labels_are_attested_as_corpus_not_evaluator(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "corpus.toml"
+            labels = root / "labels.jsonl"
+            evaluator = root / "precision.py"
+            manifest.write_text("corpus")
+            labels.write_text("labels-v1")
+            evaluator.write_text("evaluator")
+            corpus_before = zero_research.control_corpus_digest(manifest, labels)
+            evaluator_before = zero_research.control_evaluator_digest(evaluator)
+            labels.write_text("labels-v2")
+            self.assertNotEqual(
+                corpus_before,
+                zero_research.control_corpus_digest(manifest, labels),
+            )
+            self.assertEqual(
+                evaluator_before,
+                zero_research.control_evaluator_digest(evaluator),
+            )
+
+    def test_rejects_summary_from_different_evaluator(self) -> None:
+        challenger = summary(tp=2, fp=1)
+        challenger["evaluator_digest"] = "sha256:different"
+        with self.assertRaisesRegex(ValueError, "challenger summary evaluator digest"):
+            zero_research.build_negative_control_fragment(
+                candidate_id="imp_foxguard_123",
+                champion_summary=summary(tp=1, fp=1),
+                challenger_summary=challenger,
+                evidence_refs=["artifact:result.json"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/precision/zero_research.py
+++ b/benchmarks/precision/zero_research.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Project foxguard precision summaries into a 0research control result.
+
+The labeled OSS precision corpus is a negative-control evaluator.  It must not
+be conflated with the held-out vulnerable corpus used to measure research
+success.  This adapter emits only the negative-control fragment that 0brain
+composes into an ImprovementExperimentResult.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+PRECISION_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = PRECISION_DIR / "corpus.toml"
+DEFAULT_LABELS = PRECISION_DIR / "labels.jsonl"
+DEFAULT_EVALUATOR = PRECISION_DIR / "precision.py"
+
+
+def digest_files(domain: str, paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    digest.update(domain.encode())
+    digest.update(b"\0")
+    for path in paths:
+        digest.update(path.name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def control_corpus_digest(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    labels_path: Path = DEFAULT_LABELS,
+) -> str:
+    return digest_files(
+        "foxguard-negative-control-corpus-v1",
+        [manifest_path, labels_path],
+    )
+
+
+def control_evaluator_digest(
+    evaluator_path: Path = DEFAULT_EVALUATOR,
+) -> str:
+    return digest_files(
+        "foxguard-negative-control-evaluator-v1",
+        [evaluator_path, Path(__file__).resolve()],
+    )
+
+
+def load_summary(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise ValueError(f"{path}: expected precision summary schema_version 1")
+    aggregate = value.get("aggregate")
+    if not isinstance(aggregate, dict):
+        raise ValueError(f"{path}: aggregate must be an object")
+    if value.get("missing_labels", 0) != 0 or value.get("stale_labels", 0) != 0:
+        raise ValueError(f"{path}: label drift makes the control result ungradeable")
+    required = (
+        "total",
+        "labeled",
+        "reviewed",
+        "true_positive",
+        "false_positive",
+        "unsure",
+        "reviewed_noise_rate",
+    )
+    if any(not isinstance(aggregate.get(key), (int, float)) for key in required):
+        raise ValueError(f"{path}: aggregate metrics are incomplete")
+    if aggregate["total"] != aggregate["labeled"]:
+        raise ValueError(f"{path}: every emitted finding must be labeled")
+    if aggregate["labeled"] <= 0:
+        raise ValueError(f"{path}: negative control must contain labeled findings")
+    if aggregate["reviewed"] != (
+        aggregate["true_positive"] + aggregate["false_positive"]
+    ):
+        raise ValueError(f"{path}: reviewed count is internally inconsistent")
+    if aggregate["labeled"] != aggregate["reviewed"] + aggregate["unsure"]:
+        raise ValueError(f"{path}: labeled count is internally inconsistent")
+    noise = float(aggregate["reviewed_noise_rate"])
+    if not 0 <= noise <= 1:
+        raise ValueError(f"{path}: reviewed_noise_rate must be in [0, 1]")
+    return value
+
+
+def control_score(summary: dict[str, Any]) -> dict[str, int | float]:
+    aggregate = summary["aggregate"]
+    return {
+        "cases": int(aggregate["labeled"]),
+        "falsePositiveRate": float(aggregate["reviewed_noise_rate"]),
+        "inconclusiveRate": float(aggregate["unsure"] / aggregate["labeled"]),
+    }
+
+
+def build_negative_control_fragment(
+    *,
+    candidate_id: str,
+    champion_summary: dict[str, Any],
+    challenger_summary: dict[str, Any],
+    manifest_path: Path = DEFAULT_MANIFEST,
+    labels_path: Path = DEFAULT_LABELS,
+    evaluator_path: Path = DEFAULT_EVALUATOR,
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    if not candidate_id.strip():
+        raise ValueError("candidate_id must not be empty")
+    if not evidence_refs or any(not ref.strip() for ref in evidence_refs):
+        raise ValueError("evidence_refs must contain non-empty references")
+    corpus_digest = control_corpus_digest(manifest_path, labels_path)
+    evaluator_digest = control_evaluator_digest(evaluator_path)
+    for label, summary in (
+        ("champion", champion_summary),
+        ("challenger", challenger_summary),
+    ):
+        if summary.get("negative_control_corpus_digest") != corpus_digest:
+            raise ValueError(f"{label} summary corpus digest does not match")
+        if summary.get("evaluator_digest") != evaluator_digest:
+            raise ValueError(f"{label} summary evaluator digest does not match")
+    return {
+        "schemaVersion": 1,
+        "candidateId": candidate_id,
+        "negativeControlCorpusDigest": corpus_digest,
+        "evaluatorDigestBefore": evaluator_digest,
+        "evaluatorDigestAfter": evaluator_digest,
+        "negativeControls": {
+            "champion": control_score(champion_summary),
+            "challenger": control_score(challenger_summary),
+        },
+        "evidenceRefs": evidence_refs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Export foxguard precision comparison for 0research"
+    )
+    parser.add_argument("--candidate-id", required=True)
+    parser.add_argument("--champion-summary", type=Path, required=True)
+    parser.add_argument("--challenger-summary", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--labels", type=Path, default=DEFAULT_LABELS)
+    parser.add_argument("--evaluator", type=Path, default=DEFAULT_EVALUATOR)
+    parser.add_argument("--evidence-ref", action="append", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    fragment = build_negative_control_fragment(
+        candidate_id=args.candidate_id,
+        champion_summary=load_summary(args.champion_summary),
+        challenger_summary=load_summary(args.challenger_summary),
+        manifest_path=args.manifest,
+        labels_path=args.labels,
+        evaluator_path=args.evaluator,
+        evidence_refs=args.evidence_ref,
+    )
+    rendered = json.dumps(fragment, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Exports foxguard precision summaries as the dedicated 0research negativeControls champion/challenger fragment.
- Content-addresses the pinned corpus and labels separately from evaluator code.
- Rejects label drift, unlabeled findings, inconsistent counts, and mismatched corpus/evaluator attestations.
- Adds the adapter tests to foxguard CI.

## Why

False-positive evidence must come from an independently pinned negative-control corpus, not be inferred from the vulnerable held-out capability corpus. This provides the precision seam consumed by 0brain.

## Safety and impact

The adapter emits only cases, falsePositiveRate, and inconclusiveRate for controls and never fabricates held-out capability results.

## Verification

- Adapter tests: 6 passed.
- Precision metadata: 4 repositories / 36 labels valid.
- Python compilation and `git diff --check` passed.