### PR TITLE
feat(precision): seal 0research negative controls v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,21 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-test-
       - run: cargo test --all-features
+      - name: Run sealed 0research negative controls
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo build --bin foxguard
+          ref=$(python3 benchmarks/fixed-negative-controls-v2/fixed_controls.py run \
+            --candidate-id "ci-${GITHUB_SHA}" \
+            --champion-binary target/debug/foxguard \
+            --challenger-binary target/debug/foxguard \
+            --champion-source-root . \
+            --challenger-source-root . \
+            --results-dir /tmp/foxguard-negative-controls/raw \
+            --output /tmp/foxguard-negative-controls/evidence.json)
+          python3 benchmarks/fixed-negative-controls-v2/fixed_controls.py verify \
+            --artifact /tmp/foxguard-negative-controls/evidence.json \
+            --ref "$ref"
 
   rule-inventory-check:
     name: Rule Inventory
@@ -198,7 +213,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: python3 benchmarks/precision/precision.py validate
-      - run: python3 benchmarks/precision/test_zero_research.py
+      - run: python3 -m unittest benchmarks/precision/test_zero_research.py benchmarks/precision/test_fixed_cases_v2.py
+      - run: python3 -m unittest discover -s benchmarks/fixed-negative-controls-v2 -p 'test_*.py'
 
   readme-version-refs:
     name: README Version Refs

--- a/benchmarks/fixed-negative-controls-v2/README.md
+++ b/benchmarks/fixed-negative-controls-v2/README.md
@@ -1,0 +1,41 @@
+# Fixed negative controls v2
+
+This is Foxguard's sealed, local negative-control lane for 0research promotion
+decisions. It is deliberately separate from `benchmarks/precision`: the
+networked OSS precision corpus remains a nightly diagnostic and backlog, while
+these cases exist independently of scanner output and therefore remain
+gradable when a false positive disappears.
+
+Each case is a pinned, known-safe fixture with an expected empty finding set.
+The runner executes the same ordered case set against champion and challenger,
+retains exact normalized findings, recomputes both scores from those findings,
+and binds the artifact to the manifest bytes, fixture bytes, evaluator bytes,
+source commit/tree identities, and executed binary bytes. Output is canonical
+JSON; the printed `foxguard-negative-controls-v2:sha256:...` reference hashes
+the exact retained bytes.
+
+Example after building both variants:
+
+```sh
+python3 benchmarks/fixed-negative-controls-v2/fixed_controls.py run \
+  --candidate-id foxguard_candidate_1 \
+  --champion-binary /path/to/champion/foxguard \
+  --challenger-binary /path/to/challenger/foxguard \
+  --champion-source-root /path/to/champion/source \
+  --challenger-source-root /path/to/challenger/source \
+  --results-dir /tmp/foxguard-controls/raw \
+  --output /tmp/foxguard-controls/evidence.json
+```
+
+Offline structural replay checks the sealed corpus, exact case coverage,
+per-case verdicts, recomputed scores, and optionally the retained-byte ref:
+
+```sh
+python3 benchmarks/fixed-negative-controls-v2/fixed_controls.py verify \
+  --artifact /tmp/foxguard-controls/evidence.json \
+  --ref "foxguard-negative-controls-v2:sha256:..."
+```
+
+The command fails when the challenger false-positive rate exceeds the champion
+rate. It does not claim vulnerability-discovery success; held-out vulnerable
+cases remain a separate 0research lane.

--- a/benchmarks/fixed-negative-controls-v2/fixed_controls.py
+++ b/benchmarks/fixed-negative-controls-v2/fixed_controls.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Run and verify Foxguard's sealed 0research negative-control lane."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import resource
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = ROOT / "manifest.json"
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY = "0sec-labs/foxguard"
+CONTRACT = "foxguard-fixed-negative-controls-v2"
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+MAX_REPORT_BYTES = 8 * 1024 * 1024
+MAX_FINDINGS = 10_000
+APPROVED_REMOTES = {
+    "https://github.com/0sec-labs/foxguard",
+    "https://github.com/0sec-labs/foxguard.git",
+    "git@github.com:0sec-labs/foxguard",
+    "git@github.com:0sec-labs/foxguard.git",
+    "ssh://git@github.com/0sec-labs/foxguard",
+    "ssh://git@github.com/0sec-labs/foxguard.git",
+}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def relative_files(root: Path) -> list[Path]:
+    paths = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"sealed fixture must not contain symlinks: {path}")
+        if path.is_file():
+            paths.append(path)
+    return sorted(paths, key=lambda path: path.relative_to(root).as_posix())
+
+
+def directory_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"foxguard-fixed-negative-control-directory-v2\0")
+    for path in relative_files(root):
+        relative = path.relative_to(root).as_posix().encode()
+        data = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def run_git(root: Path, *args: str) -> bytes:
+    process = subprocess.run(
+        ["git", "-C", str(root.resolve()), *args], capture_output=True
+    )  # noqa: S603
+    if process.returncode != 0:
+        raise ValueError(
+            f"git {' '.join(args)} failed for {root}: "
+            f"{process.stderr.decode(errors='replace').strip()}"
+        )
+    return process.stdout
+
+
+def source_tree_digest(root: Path) -> str:
+    names = run_git(
+        root, "ls-files", "--cached", "--others", "--exclude-standard", "-z"
+    ).split(b"\0")
+    digest = hashlib.sha256()
+    digest.update(b"foxguard-source-tree-v1\0")
+    for raw_name in sorted(name for name in names if name):
+        name = raw_name.decode("utf-8", errors="strict")
+        path = root / name
+        if path.is_symlink():
+            data = path.readlink().as_posix().encode()
+        elif path.is_file():
+            data = path.read_bytes()
+        else:
+            raise ValueError(f"tracked source path is not a file: {name}")
+        digest.update(len(raw_name).to_bytes(8, "big"))
+        digest.update(raw_name)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def producer_from_paths(source_root: Path, binary: Path) -> dict[str, str]:
+    remote = run_git(source_root, "remote", "get-url", "origin").decode().strip()
+    validate_approved_remote(remote)
+    commit_sha = run_git(source_root, "rev-parse", "HEAD").decode().strip()
+    return validate_producer({
+        "repository": REPOSITORY,
+        "commitSha": commit_sha,
+        "treeDigest": source_tree_digest(source_root),
+        "binaryDigest": sha256_file(binary),
+    }, "producer")
+
+
+def validate_approved_remote(remote: str) -> None:
+    if remote not in APPROVED_REMOTES:
+        raise ValueError("producer source root is not the approved Foxguard repository")
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict) or set(value) != {"cases", "id", "schemaVersion"}:
+        raise ValueError("manifest must contain exactly cases, id, and schemaVersion")
+    if (
+        value["schemaVersion"] != 2
+        or not isinstance(value["id"], str)
+        or not SAFE_ID_RE.fullmatch(value["id"])
+    ):
+        raise ValueError("manifest identity/schema is invalid")
+    cases = value["cases"]
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("manifest cases must be non-empty")
+    ids: list[str] = []
+    for index, item in enumerate(cases):
+        if not isinstance(item, dict) or set(item) != {"id", "knownNegative", "path"}:
+            raise ValueError(f"manifest case {index} has unsupported or missing fields")
+        if item["knownNegative"] is not True:
+            raise ValueError(f"manifest case {index} must be a known negative")
+        case_id = item["id"]
+        relative = item["path"]
+        if (
+            not isinstance(case_id, str)
+            or not SAFE_ID_RE.fullmatch(case_id)
+            or not isinstance(relative, str)
+        ):
+            raise ValueError(f"manifest case {index} identity is invalid")
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"manifest case {index} path must stay beneath the corpus")
+        fixture = (path.parent / candidate).resolve()
+        try:
+            fixture.relative_to(path.parent.resolve())
+        except ValueError as exc:
+            raise ValueError(f"manifest case {index} escapes the corpus") from exc
+        if not fixture.is_dir() or not relative_files(fixture):
+            raise ValueError(f"manifest case {index} fixture is missing or empty")
+        ids.append(case_id)
+    if ids != sorted(ids) or len(ids) != len(set(ids)):
+        raise ValueError("manifest case ids must be unique and sorted")
+    return value
+
+
+def corpus_binding(manifest_path: Path) -> dict[str, Any]:
+    manifest = load_manifest(manifest_path)
+    cases = []
+    for item in manifest["cases"]:
+        fixture = manifest_path.parent / item["path"]
+        cases.append({
+            "id": item["id"],
+            "fixtureDigest": directory_digest(fixture),
+        })
+    bound = {
+        "id": manifest["id"],
+        "manifestDigest": sha256_file(manifest_path),
+        "cases": cases,
+    }
+    return {
+        **bound,
+        "digest": sha256_bytes(
+            b"foxguard-fixed-negative-control-corpus-v2\0" + canonical_bytes(bound)
+        ),
+    }
+
+
+def validate_producer(value: dict[str, str], label: str) -> dict[str, str]:
+    expected = {"repository", "commitSha", "treeDigest", "binaryDigest"}
+    if set(value) != expected:
+        raise ValueError(f"{label} producer identity has unsupported or missing fields")
+    if value["repository"] != REPOSITORY:
+        raise ValueError(f"{label} producer repository is not approved")
+    if not SHA_RE.fullmatch(value["commitSha"]):
+        raise ValueError(f"{label} producer commitSha is invalid")
+    for key in ("treeDigest", "binaryDigest"):
+        if not DIGEST_RE.fullmatch(value[key]):
+            raise ValueError(f"{label} producer {key} is invalid")
+    return dict(value)
+
+
+def normalize_findings(report: Any, fixture: Path) -> list[dict[str, Any]]:
+    if not isinstance(report, dict) or not isinstance(report.get("findings"), list):
+        raise ValueError("Foxguard report must contain a findings array")
+    if len(report["findings"]) > MAX_FINDINGS:
+        raise ValueError("Foxguard report exceeds the finding-count limit")
+    normalized = []
+    for index, raw in enumerate(report["findings"]):
+        validate_native_finding(raw, f"finding {index}")
+        path = Path(str(raw.get("file", "")))
+        try:
+            file_name = path.resolve().relative_to(fixture.resolve()).as_posix()
+        except ValueError as exc:
+            raise ValueError(f"finding {index} path escapes its fixed case") from exc
+        normalized.append({
+            "column": int(raw.get("column", 0)),
+            "description": str(raw.get("description", "")),
+            "file": file_name,
+            "line": int(raw.get("line", 0)),
+            "ruleId": str(raw.get("rule_id", "")),
+            "severity": str(raw.get("severity", "")),
+            "snippet": re.sub(r"\s+", " ", str(raw.get("snippet", "")).strip()),
+        })
+    return sorted(
+        normalized,
+        key=lambda item: (
+            item["file"], item["line"], item["column"], item["ruleId"],
+            item["snippet"], item["severity"], item["description"],
+        ),
+    )
+
+
+def validate_native_finding(value: Any, label: str) -> None:
+    required = {
+        "column", "confidence", "cwe", "description", "end_column", "end_line",
+        "file", "line", "rule_id", "severity", "snippet",
+    }
+    if not isinstance(value, dict) or not required.issubset(value):
+        raise ValueError(f"{label} does not satisfy finding schema v1")
+    for key in ("line", "column", "end_line", "end_column"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 1:
+            raise ValueError(f"{label}.{key} is invalid")
+    confidence = value["confidence"]
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        raise ValueError(f"{label}.confidence is invalid")
+    if value["severity"] not in {"low", "medium", "high", "critical"}:
+        raise ValueError(f"{label}.severity is invalid")
+    if value["cwe"] is not None and not isinstance(value["cwe"], str):
+        raise ValueError(f"{label}.cwe is invalid")
+    for key in ("file", "rule_id", "description", "snippet"):
+        if not isinstance(value[key], str):
+            raise ValueError(f"{label}.{key} is invalid")
+
+
+def limit_child_files() -> None:
+    resource.setrlimit(resource.RLIMIT_FSIZE, (MAX_REPORT_BYTES, MAX_REPORT_BYTES))
+
+
+def read_capped(handle: Any, limit: int = 64 * 1024) -> str:
+    handle.seek(0)
+    value = handle.read(limit + 1)
+    if len(value) > limit:
+        return value[:limit].decode(errors="replace") + "\n[output truncated]"
+    return value.decode(errors="replace")
+
+
+def validate_normalized_findings(findings: Any, label: str) -> list[dict[str, Any]]:
+    expected = {"column", "description", "file", "line", "ruleId", "severity", "snippet"}
+    if not isinstance(findings, list):
+        raise ValueError(f"{label} findings must be an array")
+    values = []
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict) or set(finding) != expected:
+            raise ValueError(f"{label} finding {index} has unsupported or missing fields")
+        for key in ("line", "column"):
+            if isinstance(finding[key], bool) or not isinstance(finding[key], int) or finding[key] < 0:
+                raise ValueError(f"{label} finding {index} has invalid {key}")
+        for key in expected - {"line", "column"}:
+            if not isinstance(finding[key], str):
+                raise ValueError(f"{label} finding {index} has invalid {key}")
+        path = Path(finding["file"])
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"{label} finding {index} path is unsafe")
+        values.append(dict(finding))
+    ordered = sorted(
+        values,
+        key=lambda item: (
+            item["file"], item["line"], item["column"], item["ruleId"],
+            item["snippet"], item["severity"], item["description"],
+        ),
+    )
+    if values != ordered:
+        raise ValueError(f"{label} findings must be canonically sorted")
+    if len({canonical_bytes(item) for item in values}) != len(values):
+        raise ValueError(f"{label} findings must not contain duplicates")
+    return values
+
+
+def validate_native_report(report: Any, fixture: Path) -> list[dict[str, Any]]:
+    required = {
+        "config", "finding_counts", "finding_schema_version", "findings",
+        "scanner", "schema_version", "target", "timing",
+    }
+    if not isinstance(report, dict) or not required.issubset(report):
+        raise ValueError("Foxguard report is not a native versioned envelope")
+    if report["schema_version"] != "1.0.0" or report["finding_schema_version"] != "1.0.0":
+        raise ValueError("Foxguard report schema version is unsupported")
+    config = report["config"]
+    scanner = report["scanner"]
+    target = report["target"]
+    timing = report["timing"]
+    counts = report["finding_counts"]
+    if config != {"path": "/dev/null", "source": "explicit"}:
+        raise ValueError("Foxguard report config does not match the sealed invocation")
+    if (
+        not isinstance(scanner, dict)
+        or scanner.get("name") != "foxguard"
+        or scanner.get("command") != "scan"
+        or not isinstance(scanner.get("version"), str)
+        or not scanner["version"]
+    ):
+        raise ValueError("Foxguard report scanner identity is invalid")
+    if (
+        not isinstance(target, dict)
+        or target.get("kind") != "directory"
+        or target.get("changed_only") is not False
+        or not isinstance(target.get("files_scanned"), int)
+        or isinstance(target.get("files_scanned"), bool)
+        or target["files_scanned"] < 1
+        or Path(str(target.get("path", ""))).resolve() != fixture.resolve()
+    ):
+        raise ValueError("Foxguard report target does not match the sealed case")
+    if (
+        not isinstance(timing, dict)
+        or isinstance(timing.get("duration_ms"), bool)
+        or not isinstance(timing.get("duration_ms"), int)
+        or timing["duration_ms"] < 0
+    ):
+        raise ValueError("Foxguard report timing is invalid")
+    findings = normalize_findings(report, fixture)
+    by_severity = counts.get("by_severity") if isinstance(counts, dict) else None
+    severities = ("critical", "high", "low", "medium")
+    expected_counts = {severity: sum(item["severity"] == severity for item in findings) for severity in severities}
+    total = counts.get("total") if isinstance(counts, dict) else None
+    if total != len(findings) or by_severity != expected_counts:
+        raise ValueError("Foxguard report finding counts do not match findings")
+    return findings
+
+
+def scan_case(
+    binary: Path, fixture: Path, report_path: Path, timeout_seconds: int
+) -> list[dict[str, Any]]:
+    if report_path.exists() or report_path.is_symlink():
+        raise ValueError(f"refusing pre-existing report path: {report_path}")
+    command = [
+        str(binary.resolve()), "--config", "/dev/null", str(fixture.resolve()),
+        "-f", "json", "--output", str(report_path.resolve()),
+    ]
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        process = subprocess.Popen(  # noqa: S603
+            command, stdout=stdout, stderr=stderr, start_new_session=True,
+            preexec_fn=limit_child_files,
+        )
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            raise RuntimeError(f"Foxguard timed out for {fixture.name}") from exc
+        error_output = read_capped(stderr) or read_capped(stdout)
+    if process.returncode not in (0, 1):
+        raise RuntimeError(
+            f"Foxguard exited {process.returncode} for {fixture.name}: "
+            f"{error_output.strip()}"
+        )
+    if report_path.is_symlink() or not report_path.is_file():
+        raise RuntimeError(f"Foxguard did not write a report for {fixture.name}")
+    metadata = report_path.stat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_REPORT_BYTES:
+        raise RuntimeError(f"Foxguard report is not a bounded regular file for {fixture.name}")
+    findings = validate_native_report(json.loads(report_path.read_text()), fixture)
+    expected_exit = 1 if findings else 0
+    if process.returncode != expected_exit:
+        raise RuntimeError(f"Foxguard exit code does not match findings for {fixture.name}")
+    return findings
+
+
+def run_arm(
+    *, arm_id: str, binary: Path, producer: dict[str, str], manifest_path: Path,
+    results_dir: Path, timeout_seconds: int,
+) -> dict[str, Any]:
+    if not SAFE_ID_RE.fullmatch(arm_id):
+        raise ValueError("arm id must be a safe identifier")
+    producer = validate_producer(producer, arm_id)
+    actual_binary_digest = sha256_file(binary)
+    if actual_binary_digest != producer["binaryDigest"]:
+        raise ValueError(f"{arm_id} producer binaryDigest does not match executed bytes")
+    manifest = load_manifest(manifest_path)
+    cases = []
+    for item in manifest["cases"]:
+        fixture = manifest_path.parent / item["path"]
+        findings = scan_case(
+            binary, fixture, results_dir / f"{arm_id}-{item['id']}.json",
+            timeout_seconds,
+        )
+        cases.append({
+            "falsePositive": bool(findings),
+            "findings": findings,
+            "id": item["id"],
+            "knownNegative": True,
+            "verdict": "false_positive" if findings else "passed",
+        })
+    false_positives = sum(case["falsePositive"] for case in cases)
+    return {
+        "id": arm_id,
+        "producer": producer,
+        "cases": cases,
+        "score": {
+            "cases": len(cases),
+            "falsePositiveRate": false_positives / len(cases),
+            "inconclusiveRate": 0,
+        },
+    }
+
+
+def validate_artifact(value: Any, manifest_path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("artifact must be an object")
+    expected = {"arms", "candidateId", "contract", "corpus", "evaluatorDigest", "schemaVersion"}
+    if set(value) != expected or value.get("schemaVersion") != 2:
+        raise ValueError("artifact schema has unsupported or missing fields")
+    if value.get("contract") != CONTRACT:
+        raise ValueError("artifact contract discriminator is invalid")
+    if not isinstance(value.get("candidateId"), str) or not SAFE_ID_RE.fullmatch(value["candidateId"]):
+        raise ValueError("artifact candidateId must be a safe identifier")
+    corpus = corpus_binding(manifest_path)
+    if value.get("corpus") != corpus:
+        raise ValueError("artifact corpus does not match the sealed local bytes")
+    if value.get("evaluatorDigest") != evaluator_digest():
+        raise ValueError("artifact evaluator digest does not match")
+    arms = value.get("arms")
+    if not isinstance(arms, dict) or set(arms) != {"champion", "challenger"}:
+        raise ValueError("artifact must contain exactly champion and challenger arms")
+    case_ids = [case["id"] for case in corpus["cases"]]
+    for label in ("champion", "challenger"):
+        arm = arms[label]
+        if not isinstance(arm, dict) or set(arm) != {"cases", "id", "producer", "score"}:
+            raise ValueError(f"{label} arm has unsupported or missing fields")
+        if not isinstance(arm["id"], str) or not arm["id"].strip():
+            raise ValueError(f"{label} arm id must not be empty")
+        validate_producer(arm["producer"], label)
+        cases = arm["cases"]
+        if not isinstance(cases, list) or [case.get("id") for case in cases if isinstance(case, dict)] != case_ids:
+            raise ValueError(f"{label} exact case ids do not match the sealed corpus")
+        false_positives = 0
+        for index, case in enumerate(cases):
+            if set(case) != {"falsePositive", "findings", "id", "knownNegative", "verdict"}:
+                raise ValueError(f"{label} case {index} has unsupported or missing fields")
+            findings = validate_normalized_findings(case["findings"], f"{label} case {index}")
+            if case["knownNegative"] is not True:
+                raise ValueError(f"{label} case {index} is invalid")
+            expected_fp = bool(findings)
+            expected_verdict = "false_positive" if expected_fp else "passed"
+            if case["falsePositive"] is not expected_fp or case["verdict"] != expected_verdict:
+                raise ValueError(f"{label} case {index} verdict is not backed by findings")
+            false_positives += expected_fp
+        expected_score = {
+            "cases": len(cases),
+            "falsePositiveRate": false_positives / len(cases),
+            "inconclusiveRate": 0,
+        }
+        if arm["score"] != expected_score:
+            raise ValueError(f"{label} score is not recomputable from exact cases")
+    return value
+
+
+def evaluator_digest() -> str:
+    return sha256_bytes(
+        b"foxguard-fixed-negative-control-evaluator-v2\0"
+        + Path(__file__).resolve().read_bytes()
+    )
+
+
+def artifact_ref(path: Path) -> str:
+    return f"foxguard-negative-controls-v2:{sha256_file(path)}"
+
+
+def run_command(args: argparse.Namespace) -> int:
+    if args.timeout_seconds < 1:
+        raise ValueError("timeout seconds must be positive")
+    if args.results_dir.exists() and any(args.results_dir.iterdir()):
+        raise ValueError("results directory must be absent or empty")
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    if args.champion_id == args.challenger_id:
+        raise ValueError("champion and challenger ids must differ")
+    champion_producer = producer_from_paths(args.champion_source_root, args.champion_binary)
+    challenger_producer = producer_from_paths(args.challenger_source_root, args.challenger_binary)
+    value = {
+        "schemaVersion": 2,
+        "contract": CONTRACT,
+        "candidateId": args.candidate_id,
+        "corpus": corpus_binding(args.manifest),
+        "evaluatorDigest": evaluator_digest(),
+        "arms": {
+            "champion": run_arm(
+                arm_id=args.champion_id, binary=args.champion_binary,
+                producer=champion_producer,
+                manifest_path=args.manifest, results_dir=args.results_dir,
+                timeout_seconds=args.timeout_seconds,
+            ),
+            "challenger": run_arm(
+                arm_id=args.challenger_id, binary=args.challenger_binary,
+                producer=challenger_producer,
+                manifest_path=args.manifest, results_dir=args.results_dir,
+                timeout_seconds=args.timeout_seconds,
+            ),
+        },
+    }
+    if producer_from_paths(args.champion_source_root, args.champion_binary) != champion_producer:
+        raise ValueError("champion producer bytes changed during evaluation")
+    if producer_from_paths(args.challenger_source_root, args.challenger_binary) != challenger_producer:
+        raise ValueError("challenger producer bytes changed during evaluation")
+    validate_artifact(value, args.manifest)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(canonical_bytes(value))
+    print(artifact_ref(args.output))
+    champion = value["arms"]["champion"]["score"]["falsePositiveRate"]
+    challenger = value["arms"]["challenger"]["score"]["falsePositiveRate"]
+    if challenger != 0:
+        print("::error::challenger must have zero fixed-case false positives", file=sys.stderr)
+        return 1
+    return 0
+
+
+def verify_command(args: argparse.Namespace) -> int:
+    value = json.loads(args.artifact.read_text())
+    validate_artifact(value, args.manifest)
+    if args.ref and args.ref != artifact_ref(args.artifact):
+        raise ValueError("artifact reference does not match retained bytes")
+    print(artifact_ref(args.artifact))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run")
+    run.add_argument("--candidate-id", required=True)
+    run.add_argument("--champion-id", default="champion")
+    run.add_argument("--challenger-id", default="challenger")
+    run.add_argument("--champion-binary", required=True, type=Path)
+    run.add_argument("--challenger-binary", required=True, type=Path)
+    run.add_argument("--champion-source-root", required=True, type=Path)
+    run.add_argument("--challenger-source-root", required=True, type=Path)
+    run.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    run.add_argument("--results-dir", type=Path, required=True)
+    run.add_argument("--output", type=Path, required=True)
+    run.add_argument("--timeout-seconds", type=int, default=120)
+    run.set_defaults(func=run_command)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", required=True, type=Path)
+    verify.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    verify.add_argument("--ref")
+    verify.set_defaults(func=verify_command)
+    args = parser.parse_args()
+    try:
+        return int(args.func(args))
+    except (ValueError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/fixed-negative-controls-v2/fixtures/safe-go-crypto-random/token.go
+++ b/benchmarks/fixed-negative-controls-v2/fixtures/safe-go-crypto-random/token.go
@@ -1,0 +1,14 @@
+package token
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+func New() (string, error) {
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}

--- a/benchmarks/fixed-negative-controls-v2/fixtures/safe-js-parameterized-query/query.js
+++ b/benchmarks/fixed-negative-controls-v2/fixtures/safe-js-parameterized-query/query.js
@@ -1,0 +1,3 @@
+export async function accountByEmail(database, email) {
+  return database.query("SELECT id FROM accounts WHERE email = $1", [email]);
+}

--- a/benchmarks/fixed-negative-controls-v2/fixtures/safe-js-static-path/static-path.js
+++ b/benchmarks/fixed-negative-controls-v2/fixtures/safe-js-static-path/static-path.js
@@ -1,0 +1,9 @@
+import path from "node:path";
+
+const assetRoot = path.join(import.meta.dirname, "public");
+
+export function assetPath(name) {
+  const allowed = new Set(["logo.svg", "main.css"]);
+  if (!allowed.has(name)) throw new Error("unknown asset");
+  return path.join(assetRoot, name);
+}

--- a/benchmarks/fixed-negative-controls-v2/fixtures/safe-python-sha256/digest.py
+++ b/benchmarks/fixed-negative-controls-v2/fixtures/safe-python-sha256/digest.py
@@ -1,0 +1,5 @@
+import hashlib
+
+
+def content_digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()

--- a/benchmarks/fixed-negative-controls-v2/manifest.json
+++ b/benchmarks/fixed-negative-controls-v2/manifest.json
@@ -1,0 +1,26 @@
+{
+  "cases": [
+    {
+      "id": "safe-go-crypto-random-v1",
+      "knownNegative": true,
+      "path": "fixtures/safe-go-crypto-random"
+    },
+    {
+      "id": "safe-js-parameterized-query-v1",
+      "knownNegative": true,
+      "path": "fixtures/safe-js-parameterized-query"
+    },
+    {
+      "id": "safe-js-static-path-v1",
+      "knownNegative": true,
+      "path": "fixtures/safe-js-static-path"
+    },
+    {
+      "id": "safe-python-sha256-v1",
+      "knownNegative": true,
+      "path": "fixtures/safe-python-sha256"
+    }
+  ],
+  "id": "foxguard-fixed-negative-controls-v2",
+  "schemaVersion": 2
+}

--- a/benchmarks/fixed-negative-controls-v2/test_fixed_controls.py
+++ b/benchmarks/fixed-negative-controls-v2/test_fixed_controls.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import shutil
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("fixed_controls.py")
+SPEC = importlib.util.spec_from_file_location("fixed_controls", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+fixed = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fixed)
+
+
+DIGEST = f"sha256:{'1' * 64}"
+SHA = "a" * 40
+
+
+def identity() -> dict[str, str]:
+    return {
+        "repository": "0sec-labs/foxguard",
+        "commitSha": SHA,
+        "treeDigest": DIGEST,
+        "binaryDigest": DIGEST,
+    }
+
+
+def artifact() -> dict:
+    corpus = fixed.corpus_binding(fixed.DEFAULT_MANIFEST)
+    cases = [
+        {
+            "falsePositive": False,
+            "findings": [],
+            "id": case["id"],
+            "knownNegative": True,
+            "verdict": "passed",
+        }
+        for case in corpus["cases"]
+    ]
+    arm = {
+        "id": "variant",
+        "producer": identity(),
+        "cases": cases,
+        "score": {"cases": len(cases), "falsePositiveRate": 0.0, "inconclusiveRate": 0},
+    }
+    return {
+        "schemaVersion": 2,
+        "contract": fixed.CONTRACT,
+        "candidateId": "foxguard_candidate_1",
+        "corpus": corpus,
+        "evaluatorDigest": fixed.evaluator_digest(),
+        "arms": {"champion": copy.deepcopy(arm), "challenger": copy.deepcopy(arm)},
+    }
+
+
+def finding() -> dict:
+    return {
+        "column": 1,
+        "description": "finding",
+        "file": "fixture.py",
+        "line": 1,
+        "ruleId": "py/example",
+        "severity": "medium",
+        "snippet": "value",
+    }
+class FixedControlTests(unittest.TestCase):
+    def test_clean_exact_case_artifact_validates(self) -> None:
+        self.assertEqual(fixed.validate_artifact(artifact())["schemaVersion"], 2)
+
+    def test_case_substitution_fails_even_when_totals_match(self) -> None:
+        value = artifact()
+        value["arms"]["challenger"]["cases"][0]["id"] = "substituted"
+        with self.assertRaisesRegex(ValueError, "exact case ids"):
+            fixed.validate_artifact(value)
+
+    def test_forged_aggregate_fails(self) -> None:
+        value = artifact()
+        value["arms"]["challenger"]["cases"][0]["findings"] = [finding()]
+        with self.assertRaisesRegex(ValueError, "verdict is not backed"):
+            fixed.validate_artifact(value)
+
+    def test_recomputed_false_positive_rate_is_required(self) -> None:
+        value = artifact()
+        case = value["arms"]["challenger"]["cases"][0]
+        case["findings"] = [finding()]
+        case["falsePositive"] = True
+        case["verdict"] = "false_positive"
+        with self.assertRaisesRegex(ValueError, "score is not recomputable"):
+            fixed.validate_artifact(value)
+
+    def test_manifest_byte_change_breaks_corpus_binding(self) -> None:
+        value = artifact()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.json"
+            original = json.loads(fixed.DEFAULT_MANIFEST.read_text())
+            original["id"] = "replacement"
+            manifest.write_text(json.dumps(original))
+            shutil.copytree(fixed.DEFAULT_MANIFEST.parent / "fixtures", root / "fixtures")
+            with self.assertRaisesRegex(ValueError, "sealed local bytes"):
+                fixed.validate_artifact(value, manifest)
+
+    def test_wrong_producer_repository_fails(self) -> None:
+        value = artifact()
+        value["arms"]["champion"]["producer"]["repository"] = "attacker/repo"
+        with self.assertRaisesRegex(ValueError, "not approved"):
+                fixed.validate_artifact(value)
+
+    def test_lookalike_remote_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "approved Foxguard repository"):
+            fixed.validate_approved_remote(
+                "https://attacker.example/0sec-labs/foxguard.git"
+            )
+
+    def test_unsafe_finding_path_fails_offline(self) -> None:
+        value = artifact()
+        finding = {
+            "column": 1,
+            "description": "forged",
+            "file": "../outside.py",
+            "line": 1,
+            "ruleId": "py/example",
+            "severity": "medium",
+            "snippet": "value",
+        }
+        case = value["arms"]["challenger"]["cases"][0]
+        case.update({"findings": [finding], "falsePositive": True, "verdict": "false_positive"})
+        value["arms"]["challenger"]["score"]["falsePositiveRate"] = 0.25
+        with self.assertRaisesRegex(ValueError, "path is unsafe"):
+            fixed.validate_artifact(value)
+
+    def test_artifact_reference_binds_exact_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifact.json"
+            path.write_bytes(fixed.canonical_bytes(artifact()))
+            before = fixed.artifact_ref(path)
+            path.write_bytes(path.read_bytes() + b" ")
+            self.assertNotEqual(before, fixed.artifact_ref(path))
+
+    def test_fixture_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "outside").write_text("secret")
+            (root / "fixture").mkdir()
+            (root / "fixture" / "link").symlink_to(root / "outside")
+            with self.assertRaisesRegex(ValueError, "must not contain symlinks"):
+                fixed.directory_digest(root / "fixture")
+
+    def test_preexisting_report_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "report.json"
+            report.write_text('{"findings": []}')
+            with self.assertRaisesRegex(ValueError, "pre-existing report"):
+                fixed.scan_case(Path("/usr/bin/true"), root, report, 1)
+
+    def test_exit_code_must_match_finding_presence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "fixture"
+            fixture.mkdir()
+            (fixture / "safe.py").write_text("value = 1\n")
+            report = root / "report.json"
+            native = {
+                "config": {"path": "/dev/null", "source": "explicit"},
+                "finding_counts": {
+                    "by_severity": {"critical": 0, "high": 0, "low": 0, "medium": 1},
+                    "total": 1,
+                },
+                "finding_schema_version": "1.0.0",
+                "findings": [{
+                    "column": 1,
+                    "confidence": 1.0,
+                    "cwe": None,
+                    "description": "finding",
+                    "end_column": 2,
+                    "end_line": 1,
+                    "file": str(fixture / "safe.py"),
+                    "line": 1,
+                    "rule_id": "py/example",
+                    "severity": "medium",
+                    "snippet": "value",
+                }],
+                "scanner": {"command": "scan", "name": "foxguard", "version": "test"},
+                "schema_version": "1.0.0",
+                "target": {
+                    "changed_only": False,
+                    "files_scanned": 1,
+                    "kind": "directory",
+                    "path": str(fixture),
+                },
+                "timing": {"duration_ms": 1},
+            }
+            binary = root / "fake.py"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json,sys\n"
+                f"value={native!r}\n"
+                "open(sys.argv[-1], 'w').write(json.dumps(value))\n"
+            )
+            os.chmod(binary, 0o755)
+            with self.assertRaisesRegex(RuntimeError, "exit code does not match"):
+                fixed.scan_case(binary, fixture, report, 5)
+
+    def test_canonical_output_is_deterministic(self) -> None:
+        self.assertEqual(fixed.canonical_bytes(artifact()), fixed.canonical_bytes(artifact()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/precision/README.md
+++ b/benchmarks/precision/README.md
@@ -31,10 +31,44 @@ is deliberately small enough for local and scheduled CI runs:
 | echo | Go | `.` excluding `*_test.go` | Production framework code with Go rules |
 | juice-shop | JavaScript | `routes` | Intentionally vulnerable route handlers |
 
-The current blessed snapshot covers 48 findings: 16 true positives,
-32 false positives, and 0 unsure labels. Reviewed precision is 33.3%;
-reviewed noise is 66.7%. Treat this as a regression baseline and backlog map,
+The current blessed snapshot covers 36 findings: 16 true positives,
+20 false positives, and 0 unsure labels. Reviewed precision is 44.4%;
+reviewed noise is 55.6%. Treat this as a regression baseline and backlog map,
 not as a global precision claim.
+
+## 0research fixed negative cases
+
+`negative-controls-v2.json` selects the 20 reviewed false-positive identities
+as immutable negative cases. `fixed_cases_v2.py` grades each selected case even
+when its old finding disappears, retains exact per-case evidence, rejects new
+unreviewed findings, recomputes metrics, and binds both executed variants to
+their source-tree and binary digests. This schema-v2 evidence is suitable for
+a future Foxguard-specific 0brain consumer; it must not be disguised as the
+currently pwnkit-specific tournament contract.
+
+The small sealed fixture corpus in `../fixed-negative-controls-v2/` runs in PR
+CI as a reliable local smoke lane. The 20-case pinned OSS lane remains a
+nightly or candidate-evaluation lane because it requires networked checkouts.
+Its `project` command executes both bound binaries itself; caller-supplied
+findings are not accepted. Each arm retains a scan receipt binding the exact
+precision runner, executed binary, and canonical findings:
+
+```sh
+python3 benchmarks/precision/fixed_cases_v2.py project \
+  --candidate-id foxguard_candidate_1 \
+  --champion-source-root /path/to/champion/source \
+  --challenger-source-root /path/to/challenger/source \
+  --champion-binary /path/to/champion/foxguard \
+  --challenger-binary /path/to/challenger/foxguard \
+  --workdir /path/to/pinned-corpus-clones \
+  --results-dir /tmp/foxguard-reviewed-controls/raw \
+  --output /tmp/foxguard-reviewed-controls/evidence.json
+```
+
+The reviewed OSS pair uses contract discriminator
+`foxguard-reviewed-negative-controls-v2`; the bounded local smoke artifact uses
+`foxguard-fixed-negative-controls-v2`. Consumers must select the exact contract,
+not dispatch on `schemaVersion` alone.
 
 ## Labels
 

--- a/benchmarks/precision/fixed_cases_v2.py
+++ b/benchmarks/precision/fixed_cases_v2.py
@@ -1,0 +1,872 @@
+#!/usr/bin/env python3
+"""Project the reviewed OSS false positives as exact fixed cases.
+
+Unlike the legacy aggregate adapter, a selected case exists whether or not a
+scanner emits its old finding. Absence is therefore a passing negative control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import resource
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_CASES = ROOT / "negative-controls-v2.json"
+DEFAULT_LABELS = ROOT / "labels.jsonl"
+DEFAULT_CORPUS = ROOT / "corpus.toml"
+DEFAULT_EVALUATOR = ROOT / "precision.py"
+REPOSITORY = "0sec-labs/foxguard"
+CONTRACT = "foxguard-reviewed-negative-controls-v2"
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+MAX_FINDINGS_BYTES = 16 * 1024 * 1024
+MAX_RAW_REPORT_BYTES = 16 * 1024 * 1024
+MAX_RAW_FINDINGS = 20_000
+MAX_WRAPPER_FILE_BYTES = 32 * 1024 * 1024
+APPROVED_REMOTES = {
+    "https://github.com/0sec-labs/foxguard",
+    "https://github.com/0sec-labs/foxguard.git",
+    "git@github.com:0sec-labs/foxguard",
+    "git@github.com:0sec-labs/foxguard.git",
+    "ssh://git@github.com/0sec-labs/foxguard",
+    "ssh://git@github.com/0sec-labs/foxguard.git",
+}
+FINDING_KEYS = {
+    "column", "duplicate_index", "file", "id", "justification", "label",
+    "line", "repo", "rule_id", "severity", "snippet",
+}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def digest_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def digest_file(path: Path) -> str:
+    return digest_bytes(path.read_bytes())
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def load_labels(path: Path) -> dict[str, dict[str, Any]]:
+    labels: dict[str, dict[str, Any]] = {}
+    required = {"file", "id", "justification", "label", "line", "repo", "rule_id"}
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict) or set(value) != required:
+            raise ValueError(f"labels row {line_number} has unsupported or missing fields")
+        case_id = value["id"]
+        if (
+            not isinstance(case_id, str)
+            or not SAFE_ID_RE.fullmatch(case_id)
+            or case_id in labels
+        ):
+            raise ValueError(f"labels row {line_number} has an invalid or duplicate id")
+        if value["label"] not in {"true_positive", "false_positive", "unsure"}:
+            raise ValueError(f"labels row {line_number} has an invalid label")
+        if isinstance(value["line"], bool) or not isinstance(value["line"], int) or value["line"] < 1:
+            raise ValueError(f"labels row {line_number} has an invalid line")
+        for key in required - {"line"}:
+            if not isinstance(value[key], str) or not value[key].strip():
+                raise ValueError(f"labels row {line_number} has an invalid {key}")
+        labels[case_id] = value
+    return labels
+
+
+def load_case_manifest(path: Path) -> dict[str, Any]:
+    value = load_json_object(path, "case manifest")
+    if set(value) != {"caseIds", "id", "schemaVersion"} or value.get("schemaVersion") != 2:
+        raise ValueError("case manifest schema has unsupported or missing fields")
+    ids = value.get("caseIds")
+    if not isinstance(value.get("id"), str) or not SAFE_ID_RE.fullmatch(value["id"]):
+        raise ValueError("case manifest id must be a safe identifier")
+    if (
+        not isinstance(ids, list)
+        or not ids
+        or any(not isinstance(item, str) or not SAFE_ID_RE.fullmatch(item) for item in ids)
+    ):
+        raise ValueError("case manifest caseIds must be safe identifiers")
+    if ids != sorted(ids) or len(ids) != len(set(ids)):
+        raise ValueError("case manifest caseIds must be unique and sorted")
+    return value
+
+
+def corpus_binding(
+    cases_path: Path = DEFAULT_CASES,
+    labels_path: Path = DEFAULT_LABELS,
+    corpus_path: Path = DEFAULT_CORPUS,
+) -> dict[str, Any]:
+    manifest = load_case_manifest(cases_path)
+    labels = load_labels(labels_path)
+    definitions = []
+    for case_id in manifest["caseIds"]:
+        if case_id not in labels:
+            raise ValueError(f"fixed case {case_id} is missing its reviewed label")
+        definition = labels[case_id]
+        if definition["label"] != "false_positive":
+            raise ValueError(f"fixed case {case_id} is not a reviewed false positive")
+        definitions.append(dict(definition))
+    base = {
+        "id": manifest["id"],
+        "caseIds": list(manifest["caseIds"]),
+        "caseDefinitions": definitions,
+        "caseManifestDigest": digest_file(cases_path),
+        "reviewedLabelsDigest": digest_file(labels_path),
+        "precisionCorpusDigest": digest_file(corpus_path),
+    }
+    return {
+        **base,
+        "digest": digest_bytes(b"foxguard-reviewed-negative-corpus-v2\0" + canonical_bytes(base)),
+    }
+
+
+def evaluator_digest(
+    projector_path: Path | None = None,
+    evaluator_path: Path = DEFAULT_EVALUATOR,
+) -> str:
+    projector = projector_path or Path(__file__).resolve()
+    return digest_bytes(
+        b"foxguard-reviewed-negative-evaluator-v2\0"
+        + evaluator_path.read_bytes() + b"\0" + projector.read_bytes()
+    )
+
+
+def producer_identity(
+    *, commit_sha: str, tree_digest: str, binary_digest: str,
+) -> dict[str, str]:
+    value = {
+        "repository": REPOSITORY,
+        "commitSha": commit_sha,
+        "treeDigest": tree_digest,
+        "binaryDigest": binary_digest,
+    }
+    return validate_producer(value)
+
+
+def run_git(root: Path, *args: str) -> bytes:
+    process = subprocess.run(
+        ["git", "-C", str(root.resolve()), *args], capture_output=True
+    )  # noqa: S603
+    if process.returncode != 0:
+        raise ValueError(
+            f"git {' '.join(args)} failed for {root}: "
+            f"{process.stderr.decode(errors='replace').strip()}"
+        )
+    return process.stdout
+
+
+def source_tree_digest(root: Path) -> str:
+    names = run_git(
+        root, "ls-files", "--cached", "--others", "--exclude-standard", "-z"
+    ).split(b"\0")
+    digest = hashlib.sha256()
+    digest.update(b"foxguard-source-tree-v1\0")
+    for raw_name in sorted(name for name in names if name):
+        name = raw_name.decode("utf-8", errors="strict")
+        path = root / name
+        if path.is_symlink():
+            data = path.readlink().as_posix().encode()
+        elif path.is_file():
+            data = path.read_bytes()
+        else:
+            raise ValueError(f"tracked source path is not a file: {name}")
+        digest.update(len(raw_name).to_bytes(8, "big"))
+        digest.update(raw_name)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def checkout_content_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"foxguard-corpus-checkout-v1\0")
+    paths = sorted(
+        (path for path in root.rglob("*") if ".git" not in path.relative_to(root).parts),
+        key=lambda path: path.relative_to(root).as_posix(),
+    )
+    for path in paths:
+        relative = path.relative_to(root).as_posix().encode()
+        if path.is_symlink():
+            data = path.readlink().as_posix().encode()
+        elif path.is_file():
+            data = path.read_bytes()
+        else:
+            continue
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def corpus_repositories(corpus_path: Path) -> list[dict[str, str]]:
+    with corpus_path.open("rb") as handle:
+        value = tomllib.load(handle)
+    repositories = []
+    for index, item in enumerate(value.get("repos", [])):
+        if not isinstance(item, dict):
+            raise ValueError(f"corpus repo {index} must be an object")
+        name, url, commit = item.get("name"), item.get("url"), item.get("ref")
+        scan_subdir = item.get("scan_subdir", ".")
+        if (
+            not isinstance(name, str)
+            or not SAFE_ID_RE.fullmatch(name)
+            or not isinstance(url, str)
+            or not url.startswith("https://")
+            or not isinstance(commit, str)
+            or not SHA_RE.fullmatch(commit)
+            or not isinstance(scan_subdir, str)
+            or Path(scan_subdir).is_absolute()
+            or ".." in Path(scan_subdir).parts
+        ):
+            raise ValueError(f"corpus repo {index} identity is invalid")
+        repositories.append({
+            "id": name, "url": url, "commitSha": commit,
+            "scanSubdir": scan_subdir,
+        })
+    if not repositories or len({item["id"] for item in repositories}) != len(repositories):
+        raise ValueError("corpus repositories must be non-empty and unique")
+    return sorted(repositories, key=lambda item: item["id"])
+
+
+def require_clean_checkout(root: Path, label: str) -> None:
+    status = run_git(root, "status", "--porcelain=v1", "--untracked-files=all")
+    if status:
+        raise ValueError(f"{label} corpus checkout is dirty")
+
+
+def materialize_corpus(
+    *, arm_id: str, cache_workdir: Path, isolated_workdir: Path,
+    corpus_path: Path, timeout_seconds: int,
+) -> list[dict[str, str]]:
+    if isolated_workdir.exists():
+        raise ValueError(f"isolated corpus directory already exists: {isolated_workdir}")
+    isolated_workdir.mkdir(parents=True)
+    attestations = []
+    for repository in corpus_repositories(corpus_path):
+        source = cache_workdir / repository["id"]
+        target = isolated_workdir / repository["id"]
+        if not (source / ".git").exists():
+            raise ValueError(f"missing cached corpus repository: {source}")
+        remote = run_git(source, "remote", "get-url", "origin").decode().strip()
+        if remote.removesuffix(".git") != repository["url"].removesuffix(".git"):
+            raise ValueError(f"cached corpus remote does not match for {repository['id']}")
+        process = subprocess.run(  # noqa: S603
+            ["git", "clone", "--shared", "--no-checkout", str(source.resolve()), str(target)],
+            capture_output=True, text=True, timeout=timeout_seconds,
+        )
+        if process.returncode != 0:
+            raise ValueError(
+                f"failed to isolate {arm_id} corpus repo {repository['id']}: "
+                f"{process.stderr.strip()}"
+            )
+        run_git(target, "checkout", "--detach", repository["commitSha"])
+        actual = run_git(target, "rev-parse", "HEAD").decode().strip()
+        if actual != repository["commitSha"]:
+            raise ValueError(f"isolated corpus commit does not match for {repository['id']}")
+        require_clean_checkout(target, f"{arm_id}/{repository['id']}")
+        attestations.append({
+            "id": repository["id"],
+            "commitSha": actual,
+            "treeDigest": checkout_content_digest(target),
+        })
+    return attestations
+
+
+def validate_checkout_attestations(
+    value: Any, corpus_path: Path,
+) -> list[dict[str, str]]:
+    repositories = corpus_repositories(corpus_path)
+    if not isinstance(value, list) or len(value) != len(repositories):
+        raise ValueError("scan receipt corpus checkout coverage does not match")
+    normalized = []
+    for index, (item, repository) in enumerate(zip(value, repositories, strict=True)):
+        if not isinstance(item, dict) or set(item) != {"commitSha", "id", "treeDigest"}:
+            raise ValueError(f"scan receipt corpus checkout {index} is invalid")
+        if (
+            item["id"] != repository["id"]
+            or item["commitSha"] != repository["commitSha"]
+            or not isinstance(item["treeDigest"], str)
+            or not DIGEST_RE.fullmatch(item["treeDigest"])
+        ):
+            raise ValueError(f"scan receipt corpus checkout {index} does not match manifest")
+        normalized.append(dict(item))
+    return normalized
+
+
+def validate_native_finding(value: Any, label: str, repository_root: Path) -> dict[str, Any]:
+    required = {
+        "column", "confidence", "cwe", "description", "end_column", "end_line",
+        "file", "line", "rule_id", "severity", "snippet",
+    }
+    if not isinstance(value, dict) or not required.issubset(value):
+        raise ValueError(f"{label} does not satisfy finding schema v1")
+    for key in ("line", "column", "end_line", "end_column"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 1:
+            raise ValueError(f"{label}.{key} is invalid")
+    confidence = value["confidence"]
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        raise ValueError(f"{label}.confidence is invalid")
+    if value["severity"] not in {"low", "medium", "high", "critical"}:
+        raise ValueError(f"{label}.severity is invalid")
+    if value["cwe"] is not None and not isinstance(value["cwe"], str):
+        raise ValueError(f"{label}.cwe is invalid")
+    for key in ("file", "rule_id", "description", "snippet"):
+        if not isinstance(value[key], str):
+            raise ValueError(f"{label}.{key} is invalid")
+    path = Path(value["file"])
+    try:
+        relative = path.resolve().relative_to(repository_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"{label}.file escapes the pinned repository") from exc
+    semantic = dict(value)
+    semantic["file"] = relative
+    return semantic
+
+
+def validate_native_report(
+    path: Path, repository: dict[str, str], repository_root: Path,
+) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"missing regular native report for {repository['id']}")
+    metadata = path.stat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_RAW_REPORT_BYTES:
+        raise ValueError(f"native report for {repository['id']} exceeds the size limit")
+    report = load_json_object(path, f"native report {repository['id']}")
+    required = {
+        "config", "finding_counts", "finding_schema_version", "findings",
+        "scanner", "schema_version", "target", "timing",
+    }
+    if not required.issubset(report):
+        raise ValueError(f"native report {repository['id']} is missing envelope fields")
+    if report["schema_version"] != "1.0.0" or report["finding_schema_version"] != "1.0.0":
+        raise ValueError(f"native report {repository['id']} schema is unsupported")
+    if report["config"] != {"path": "/dev/null", "source": "explicit"}:
+        raise ValueError(f"native report {repository['id']} config does not match")
+    scanner = report["scanner"]
+    if (
+        not isinstance(scanner, dict)
+        or scanner.get("name") != "foxguard"
+        or scanner.get("command") != "scan"
+        or not isinstance(scanner.get("version"), str)
+        or not scanner["version"]
+    ):
+        raise ValueError(f"native report {repository['id']} scanner identity is invalid")
+    target = report["target"]
+    expected_target = (repository_root / repository["scanSubdir"]).resolve()
+    if (
+        not isinstance(target, dict)
+        or target.get("kind") != "directory"
+        or target.get("changed_only") is not False
+        or isinstance(target.get("files_scanned"), bool)
+        or not isinstance(target.get("files_scanned"), int)
+        or target["files_scanned"] < 1
+        or Path(str(target.get("path", ""))).resolve() != expected_target
+    ):
+        raise ValueError(f"native report {repository['id']} target does not match")
+    raw_findings = report["findings"]
+    if not isinstance(raw_findings, list) or len(raw_findings) > MAX_RAW_FINDINGS:
+        raise ValueError(f"native report {repository['id']} findings are invalid")
+    findings = [
+        validate_native_finding(value, f"{repository['id']}.findings[{index}]", repository_root)
+        for index, value in enumerate(raw_findings)
+    ]
+    counts = report["finding_counts"]
+    severities = ("critical", "high", "low", "medium")
+    expected_by_severity = {
+        severity: sum(finding["severity"] == severity for finding in findings)
+        for severity in severities
+    }
+    if (
+        not isinstance(counts, dict)
+        or counts.get("total") != len(findings)
+        or counts.get("by_severity") != expected_by_severity
+    ):
+        raise ValueError(f"native report {repository['id']} counts do not match findings")
+    semantic = {
+        "findingSchemaVersion": report["finding_schema_version"],
+        "findings": findings,
+        "scannerVersion": scanner["version"],
+        "schemaVersion": report["schema_version"],
+    }
+    return {
+        "id": repository["id"],
+        "semanticDigest": digest_bytes(
+            b"foxguard-native-report-v1\0" + canonical_bytes(semantic)
+        ),
+    }
+
+
+def validate_native_report_attestations(value: Any, corpus_path: Path) -> list[dict[str, str]]:
+    repositories = corpus_repositories(corpus_path)
+    if not isinstance(value, list) or len(value) != len(repositories):
+        raise ValueError("scan receipt native report coverage does not match")
+    normalized = []
+    for index, (item, repository) in enumerate(zip(value, repositories, strict=True)):
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"id", "semanticDigest"}
+            or item["id"] != repository["id"]
+            or not isinstance(item["semanticDigest"], str)
+            or not DIGEST_RE.fullmatch(item["semanticDigest"])
+        ):
+            raise ValueError(f"scan receipt native report {index} is invalid")
+        normalized.append(dict(item))
+    return normalized
+
+
+def producer_from_paths(source_root: Path, binary: Path) -> dict[str, str]:
+    remote = run_git(source_root, "remote", "get-url", "origin").decode().strip()
+    validate_approved_remote(remote)
+    return producer_identity(
+        commit_sha=run_git(source_root, "rev-parse", "HEAD").decode().strip(),
+        tree_digest=source_tree_digest(source_root),
+        binary_digest=digest_file(binary),
+    )
+
+
+def validate_approved_remote(remote: str) -> None:
+    if remote not in APPROVED_REMOTES:
+        raise ValueError("producer source root is not the approved Foxguard repository")
+
+
+def validate_producer(value: Any) -> dict[str, str]:
+    expected = {"repository", "commitSha", "treeDigest", "binaryDigest"}
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError("producer has unsupported or missing fields")
+    if value["repository"] != REPOSITORY:
+        raise ValueError("producer repository is not approved")
+    if not isinstance(value["commitSha"], str) or not SHA_RE.fullmatch(value["commitSha"]):
+        raise ValueError("producer commitSha must be a full lowercase SHA")
+    for key in ("treeDigest", "binaryDigest"):
+        if not isinstance(value[key], str) or not DIGEST_RE.fullmatch(value[key]):
+            raise ValueError(f"producer {key} must be a sha256 digest")
+    return dict(value)
+
+
+def normalize_finding(value: Any, index: int) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != FINDING_KEYS:
+        raise ValueError(f"finding {index} has unsupported or missing fields")
+    for key in ("line", "column", "duplicate_index"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 0:
+            raise ValueError(f"finding {index} has invalid {key}")
+    for key in FINDING_KEYS - {"line", "column", "duplicate_index"}:
+        if value[key] is not None and not isinstance(value[key], str):
+            raise ValueError(f"finding {index} has invalid {key}")
+    if not value["id"]:
+        raise ValueError(f"finding {index} id must not be empty")
+    return dict(value)
+
+
+def load_findings(path: Path, labels: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, list):
+        raise ValueError("findings artifact must be an array")
+    findings = [normalize_finding(item, index) for index, item in enumerate(value)]
+    findings.sort(key=lambda item: item["id"])
+    ids = [item["id"] for item in findings]
+    if len(ids) != len(set(ids)):
+        raise ValueError("findings artifact contains duplicate ids")
+    validate_finding_labels(findings, labels)
+    return findings
+
+
+def validate_finding_labels(
+    findings: list[dict[str, Any]], labels: dict[str, dict[str, Any]]
+) -> None:
+    for finding in findings:
+        label = labels.get(finding["id"])
+        if label is None:
+            raise ValueError(f"unknown emitted finding {finding['id']} is unreviewed")
+        for source, target in (("repo", "repo"), ("rule_id", "rule_id"), ("file", "file"), ("line", "line")):
+            if finding[source] != label[target]:
+                raise ValueError(f"finding {finding['id']} does not match its reviewed identity")
+        if finding["label"] != label["label"] or finding["justification"] != label["justification"]:
+            raise ValueError(f"finding {finding['id']} label evidence does not match")
+
+
+def score(cases: list[dict[str, Any]]) -> dict[str, int | float]:
+    count = len(cases)
+    false_positives = sum(case["falsePositive"] for case in cases)
+    return {
+        "cases": count,
+        "falsePositives": false_positives,
+        "inconclusive": 0,
+        "falsePositiveRate": false_positives / count,
+        "inconclusiveRate": 0,
+    }
+
+
+def make_scan_receipt(
+    findings: list[dict[str, Any]], producer: dict[str, str], corpus: dict[str, Any],
+    corpus_checkouts: list[dict[str, str]],
+    native_reports: list[dict[str, str]],
+    evaluator_path: Path = DEFAULT_EVALUATOR,
+) -> dict[str, Any]:
+    return {
+        "binaryDigest": producer["binaryDigest"],
+        "commitSha": producer["commitSha"],
+        "corpusDigest": corpus["digest"],
+        "corpusCheckouts": corpus_checkouts,
+        "evaluatorDigest": evaluator_digest(),
+        "exitCode": 0,
+        "findingsDigest": digest_bytes(
+            b"foxguard-precision-findings-v2\0" + canonical_bytes(findings)
+        ),
+        "nativeReports": native_reports,
+        "runner": "benchmarks/precision/precision.py",
+        "runnerDigest": digest_file(evaluator_path),
+        "treeDigest": producer["treeDigest"],
+    }
+
+
+def build_arm(
+    *, arm_id: str, findings_path: Path, producer: dict[str, str],
+    scan_receipt: dict[str, Any],
+    cases_path: Path = DEFAULT_CASES, labels_path: Path = DEFAULT_LABELS,
+    corpus_path: Path = DEFAULT_CORPUS,
+) -> dict[str, Any]:
+    if not SAFE_ID_RE.fullmatch(arm_id):
+        raise ValueError("arm id must be a safe identifier")
+    corpus = corpus_binding(cases_path, labels_path, corpus_path)
+    labels = load_labels(labels_path)
+    findings = load_findings(findings_path, labels)
+    by_id = {finding["id"]: finding for finding in findings}
+    cases = []
+    for case_id in corpus["caseIds"]:
+        finding = by_id.get(case_id)
+        cases.append({
+            "falsePositive": finding is not None,
+            "finding": finding,
+            "id": case_id,
+            "knownNegative": True,
+            "verdict": "false_positive" if finding is not None else "passed",
+        })
+    checkouts = validate_checkout_attestations(scan_receipt.get("corpusCheckouts"), corpus_path)
+    native_reports = validate_native_report_attestations(
+        scan_receipt.get("nativeReports"), corpus_path
+    )
+    expected_receipt = make_scan_receipt(
+        findings, producer, corpus, checkouts, native_reports
+    )
+    if scan_receipt != expected_receipt:
+        raise ValueError("scan receipt does not bind the executed runner, binary, and findings")
+    return {
+        "id": arm_id,
+        "producer": validate_producer(producer),
+        "observedFindings": findings,
+        "semanticReportDigest": digest_bytes(
+            b"foxguard-semantic-findings-v2\0" + canonical_bytes(findings)
+        ),
+        "scanReceipt": scan_receipt,
+        "cases": cases,
+        "score": score(cases),
+    }
+
+
+def validate_arm(
+    arm: Any, corpus: dict[str, Any], labels: dict[str, dict[str, Any]],
+    corpus_path: Path, label: str,
+) -> None:
+    expected = {
+        "cases", "id", "observedFindings", "producer", "scanReceipt", "score",
+        "semanticReportDigest",
+    }
+    if not isinstance(arm, dict) or set(arm) != expected:
+        raise ValueError(f"{label} arm has unsupported or missing fields")
+    if not isinstance(arm["id"], str) or not SAFE_ID_RE.fullmatch(arm["id"]):
+        raise ValueError(f"{label} arm id must be a safe identifier")
+    producer = validate_producer(arm["producer"])
+    findings = [normalize_finding(item, index) for index, item in enumerate(arm["observedFindings"])]
+    if findings != sorted(findings, key=lambda item: item["id"]):
+        raise ValueError(f"{label} observed findings must be sorted")
+    ids = [finding["id"] for finding in findings]
+    if len(ids) != len(set(ids)) or any(case_id not in labels for case_id in ids):
+        raise ValueError(f"{label} observed findings are duplicate or unreviewed")
+    validate_finding_labels(findings, labels)
+    receipt = arm["scanReceipt"]
+    if not isinstance(receipt, dict):
+        raise ValueError(f"{label} scan receipt must be an object")
+    checkouts = validate_checkout_attestations(receipt.get("corpusCheckouts"), corpus_path)
+    native_reports = validate_native_report_attestations(
+        receipt.get("nativeReports"), corpus_path
+    )
+    if receipt != make_scan_receipt(
+        findings, producer, corpus, checkouts, native_reports
+    ):
+        raise ValueError(f"{label} scan receipt does not bind runner, binary, and findings")
+    semantic_digest = digest_bytes(b"foxguard-semantic-findings-v2\0" + canonical_bytes(findings))
+    if arm["semanticReportDigest"] != semantic_digest:
+        raise ValueError(f"{label} semantic report digest does not match findings")
+    cases = arm["cases"]
+    if not isinstance(cases, list) or [case.get("id") for case in cases if isinstance(case, dict)] != corpus["caseIds"]:
+        raise ValueError(f"{label} exact case ids do not match")
+    by_id = {finding["id"]: finding for finding in findings}
+    for index, case in enumerate(cases):
+        if set(case) != {"falsePositive", "finding", "id", "knownNegative", "verdict"}:
+            raise ValueError(f"{label} case {index} has unsupported or missing fields")
+        expected_finding = by_id.get(case["id"])
+        expected_fp = expected_finding is not None
+        if (
+            case["knownNegative"] is not True
+            or case["finding"] != expected_finding
+            or case["falsePositive"] is not expected_fp
+            or case["verdict"] != ("false_positive" if expected_fp else "passed")
+        ):
+            raise ValueError(f"{label} case {index} is not backed by exact findings")
+    if arm["score"] != score(cases):
+        raise ValueError(f"{label} score is not recomputable")
+
+
+def build_pair(
+    *, candidate_id: str, champion: dict[str, Any], challenger: dict[str, Any],
+    cases_path: Path = DEFAULT_CASES, labels_path: Path = DEFAULT_LABELS,
+    corpus_path: Path = DEFAULT_CORPUS,
+) -> dict[str, Any]:
+    if not SAFE_ID_RE.fullmatch(candidate_id):
+        raise ValueError("candidate id must be a safe identifier")
+    value = {
+        "schemaVersion": 2,
+        "contract": CONTRACT,
+        "candidateId": candidate_id,
+        "corpus": corpus_binding(cases_path, labels_path, corpus_path),
+        "evaluatorDigest": evaluator_digest(),
+        "arms": {"champion": champion, "challenger": challenger},
+    }
+    return validate_pair(value, cases_path, labels_path, corpus_path)
+
+
+def validate_pair(
+    value: Any, cases_path: Path = DEFAULT_CASES,
+    labels_path: Path = DEFAULT_LABELS, corpus_path: Path = DEFAULT_CORPUS,
+) -> dict[str, Any]:
+    expected = {"arms", "candidateId", "contract", "corpus", "evaluatorDigest", "schemaVersion"}
+    if not isinstance(value, dict) or set(value) != expected or value.get("schemaVersion") != 2:
+        raise ValueError("pair schema has unsupported or missing fields")
+    if value.get("contract") != CONTRACT:
+        raise ValueError("pair contract discriminator is invalid")
+    if not isinstance(value["candidateId"], str) or not SAFE_ID_RE.fullmatch(value["candidateId"]):
+        raise ValueError("pair candidate id must be a safe identifier")
+    corpus = corpus_binding(cases_path, labels_path, corpus_path)
+    if value["corpus"] != corpus:
+        raise ValueError("pair corpus does not match sealed case bytes")
+    if value["evaluatorDigest"] != evaluator_digest():
+        raise ValueError("pair evaluator digest does not match")
+    if not isinstance(value["arms"], dict) or set(value["arms"]) != {"champion", "challenger"}:
+        raise ValueError("pair must contain exactly champion and challenger arms")
+    labels = load_labels(labels_path)
+    validate_arm(value["arms"]["champion"], corpus, labels, corpus_path, "champion")
+    validate_arm(value["arms"]["challenger"], corpus, labels, corpus_path, "challenger")
+    return value
+
+
+def artifact_ref(path: Path) -> str:
+    return f"foxguard-reviewed-negative-controls-v2:{digest_file(path)}"
+
+
+def limit_wrapper_files() -> None:
+    resource.setrlimit(
+        resource.RLIMIT_FSIZE,
+        (MAX_WRAPPER_FILE_BYTES, MAX_WRAPPER_FILE_BYTES),
+    )
+
+
+def read_capped(handle: Any, limit: int = 64 * 1024) -> str:
+    handle.seek(0)
+    value = handle.read(limit + 1)
+    if len(value) > limit:
+        return value[:limit].decode(errors="replace") + "\n[output truncated]"
+    return value.decode(errors="replace")
+
+
+def run_precision_scan(
+    *, arm_id: str, binary: Path, producer: dict[str, str], results_root: Path,
+    source_root: Path, cache_workdir: Path, cases_path: Path, corpus_path: Path,
+    labels_path: Path, timeout_seconds: int,
+) -> tuple[Path, dict[str, Any]]:
+    if timeout_seconds < 1:
+        raise ValueError("timeout seconds must be positive")
+    results_dir = results_root / arm_id
+    if results_dir.exists():
+        raise ValueError(f"scan results directory already exists: {results_dir}")
+    results_root.mkdir(parents=True, exist_ok=True)
+    isolated_workdir = results_root / "corpus" / arm_id
+    checkout_attestations = materialize_corpus(
+        arm_id=arm_id,
+        cache_workdir=cache_workdir,
+        isolated_workdir=isolated_workdir,
+        corpus_path=corpus_path,
+        timeout_seconds=timeout_seconds,
+    )
+    command = [
+        sys.executable,
+        str(DEFAULT_EVALUATOR),
+        "run",
+        "--foxguard",
+        str(binary.resolve()),
+        "--manifest",
+        str(corpus_path.resolve()),
+        "--labels",
+        str(labels_path.resolve()),
+        "--results-dir",
+        str(results_dir.resolve()),
+        "--workdir",
+        str(isolated_workdir.resolve()),
+    ]
+    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+        process = subprocess.Popen(  # noqa: S603
+            command, stdout=stdout_file, stderr=stderr_file,
+            start_new_session=True, preexec_fn=limit_wrapper_files,
+        )
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            raise ValueError(f"{arm_id} precision scan timed out") from exc
+        stdout = read_capped(stdout_file)
+        stderr = read_capped(stderr_file)
+    if process.returncode != 0:
+        raise ValueError(
+            f"{arm_id} precision scan failed with {process.returncode}: "
+            f"{stderr.strip() or stdout.strip()}"
+        )
+    findings_path = results_dir / "findings.json"
+    if findings_path.is_symlink() or not findings_path.is_file():
+        raise ValueError(f"{arm_id} precision scan did not retain a regular findings artifact")
+    metadata = findings_path.stat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_FINDINGS_BYTES:
+        raise ValueError(f"{arm_id} findings artifact exceeds the size limit")
+    findings = load_findings(findings_path, load_labels(labels_path))
+    native_reports = [
+        validate_native_report(
+            results_dir / f"{repository['id']}.foxguard.json",
+            repository,
+            isolated_workdir / repository["id"],
+        )
+        for repository in corpus_repositories(corpus_path)
+    ]
+    for attestation in checkout_attestations:
+        checkout = isolated_workdir / attestation["id"]
+        require_clean_checkout(checkout, f"{arm_id}/{attestation['id']} post-scan")
+        if checkout_content_digest(checkout) != attestation["treeDigest"]:
+            raise ValueError(f"{arm_id} scan mutated corpus repo {attestation['id']}")
+    if producer_from_paths(source_root, binary) != producer:
+        raise ValueError(f"{arm_id} producer bytes changed during evaluation")
+    corpus = corpus_binding(cases_path, labels_path, corpus_path)
+    return findings_path, make_scan_receipt(
+        findings, producer, corpus, checkout_attestations, native_reports
+    )
+
+
+def project(args: argparse.Namespace) -> int:
+    if args.champion_id == args.challenger_id:
+        raise ValueError("champion and challenger ids must differ")
+    if args.results_dir.exists() and any(args.results_dir.iterdir()):
+        raise ValueError("results directory must be absent or empty")
+    champion_producer = producer_from_paths(args.champion_source_root, args.champion_binary)
+    challenger_producer = producer_from_paths(args.challenger_source_root, args.challenger_binary)
+    kwargs = {"cases_path": args.cases, "labels_path": args.labels, "corpus_path": args.corpus}
+    champion_findings, champion_receipt = run_precision_scan(
+        arm_id=args.champion_id, binary=args.champion_binary, producer=champion_producer,
+        results_root=args.results_dir, source_root=args.champion_source_root,
+        cache_workdir=args.workdir, cases_path=args.cases,
+        corpus_path=args.corpus,
+        labels_path=args.labels, timeout_seconds=args.timeout_seconds,
+    )
+    challenger_findings, challenger_receipt = run_precision_scan(
+        arm_id=args.challenger_id, binary=args.challenger_binary, producer=challenger_producer,
+        results_root=args.results_dir, source_root=args.challenger_source_root,
+        cache_workdir=args.workdir, cases_path=args.cases,
+        corpus_path=args.corpus,
+        labels_path=args.labels, timeout_seconds=args.timeout_seconds,
+    )
+    value = build_pair(
+        candidate_id=args.candidate_id,
+        champion=build_arm(
+            arm_id=args.champion_id, findings_path=champion_findings,
+            producer=champion_producer, scan_receipt=champion_receipt, **kwargs,
+        ),
+        challenger=build_arm(
+            arm_id=args.challenger_id, findings_path=challenger_findings,
+            producer=challenger_producer, scan_receipt=challenger_receipt, **kwargs,
+        ),
+        **kwargs,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(canonical_bytes(value))
+    print(artifact_ref(args.output))
+    before = value["arms"]["champion"]["score"]["falsePositiveRate"]
+    after = value["arms"]["challenger"]["score"]["falsePositiveRate"]
+    if after > before:
+        print("::error::challenger reviewed fixed-case false-positive rate regressed", file=sys.stderr)
+        return 1
+    return 0
+
+
+def verify(args: argparse.Namespace) -> int:
+    validate_pair(load_json_object(args.artifact, "pair"), args.cases, args.labels, args.corpus)
+    ref = artifact_ref(args.artifact)
+    if args.ref is not None and args.ref != ref:
+        raise ValueError("pair reference does not match retained bytes")
+    print(ref)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    project_parser = subparsers.add_parser("project")
+    project_parser.add_argument("--candidate-id", required=True)
+    project_parser.add_argument("--champion-id", default="champion")
+    project_parser.add_argument("--challenger-id", default="challenger")
+    for arm in ("champion", "challenger"):
+        project_parser.add_argument(f"--{arm}-source-root", required=True, type=Path)
+        project_parser.add_argument(f"--{arm}-binary", required=True, type=Path)
+    project_parser.add_argument("--output", required=True, type=Path)
+    project_parser.add_argument("--results-dir", required=True, type=Path)
+    project_parser.add_argument("--workdir", required=True, type=Path)
+    project_parser.add_argument("--timeout-seconds", type=int, default=1800)
+    project_parser.set_defaults(func=project)
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--artifact", required=True, type=Path)
+    verify_parser.add_argument("--ref")
+    verify_parser.set_defaults(func=verify)
+    for subparser in (project_parser, verify_parser):
+        subparser.add_argument("--cases", type=Path, default=DEFAULT_CASES)
+        subparser.add_argument("--labels", type=Path, default=DEFAULT_LABELS)
+        subparser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    args = parser.parse_args()
+    try:
+        return int(args.func(args))
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/precision/negative-controls-v2.json
+++ b/benchmarks/precision/negative-controls-v2.json
@@ -1,0 +1,26 @@
+{
+  "caseIds": [
+    "0bd72769cb34b5a26d6c",
+    "10d7816dc58fcea16601",
+    "11109ce9c8ed62527296",
+    "22e0bd5b21d922c2a570",
+    "2cdbd5c77a8692973742",
+    "2d38edb5e23f2536aaf4",
+    "3066268b81c21e30ff08",
+    "31f2bd3379eca7707974",
+    "37ab25c93ab6b4dcec3a",
+    "53fb0df303901b505308",
+    "55f523d5c4f944f2b9d1",
+    "756c9ccb52629123adb3",
+    "86c147a722d8251bca23",
+    "88824f58ed94658e15e8",
+    "97a8b3f2029a5a2f3224",
+    "9f995cd16c3db0a5ca5b",
+    "dc510257d6269955ff93",
+    "dee6a804fa26391f9a92",
+    "e9368de99e6e661c543f",
+    "ef56fda8ee6aa4250ddb"
+  ],
+  "id": "foxguard-reviewed-false-positives-v2",
+  "schemaVersion": 2
+}

--- a/benchmarks/precision/precision.py
+++ b/benchmarks/precision/precision.py
@@ -12,8 +12,10 @@ import argparse
 import hashlib
 import json
 import re
+import resource
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -41,6 +43,8 @@ DEFAULT_EXPECTED = PRECISION_DIR / "expected.json"
 DEFAULT_RESULTS = PRECISION_DIR / "results"
 DEFAULT_WORKDIR = PRECISION_DIR / "clones"
 LABELS = {"true_positive", "false_positive", "unsure"}
+MAX_CAPTURE_BYTES = 1024 * 1024
+MAX_SCANNER_FILE_BYTES = 16 * 1024 * 1024
 
 
 @dataclass
@@ -91,23 +95,53 @@ class NormalizedFinding:
     justification: str | None = None
 
 
-def run_process(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def child_file_limit(max_file_bytes: int) -> Any:
+    def apply_limit() -> None:
+        resource.setrlimit(resource.RLIMIT_FSIZE, (max_file_bytes, max_file_bytes))
+
+    return apply_limit
+
+
+def read_capture(handle: Any) -> tuple[str, bool]:
+    handle.seek(0)
+    value = handle.read(MAX_CAPTURE_BYTES + 1)
+    exceeded = len(value) > MAX_CAPTURE_BYTES
+    if exceeded:
+        value = value[:MAX_CAPTURE_BYTES]
+    return value.decode(errors="replace"), exceeded
+
+
+def run_process(
+    args: list[str], cwd: Path | None = None, max_file_bytes: int | None = None,
+) -> subprocess.CompletedProcess[str]:
     try:
         # Commands come from the pinned corpus manifest or the explicit
         # --foxguard binary path, never from scanned repository contents.
-        return subprocess.run(  # noqa: S603  # foxguard: ignore[py/no-command-injection]
-            args,
-            cwd=cwd,
-            text=True,
-            capture_output=True,
-        )
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            process = subprocess.run(  # noqa: S603  # foxguard: ignore[py/no-command-injection]
+                args,
+                cwd=cwd,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                preexec_fn=child_file_limit(max_file_bytes) if max_file_bytes else None,
+            )
+            stdout, stdout_exceeded = read_capture(stdout_file)
+            stderr, stderr_exceeded = read_capture(stderr_file)
+            returncode = process.returncode
+            if stdout_exceeded or stderr_exceeded:
+                returncode = 2
+                stderr += "\nerror: subprocess output exceeded the capture limit\n"
+            return subprocess.CompletedProcess(args, returncode, stdout, stderr)
     except OSError as exc:
         command = args[0] if args else "<empty command>"
         raise SystemExit(f"error: failed to run {command!r}: {exc}") from exc
 
 
-def run_cmd(args: list[str], cwd: Path | None = None, allow_findings: bool = False) -> str:
-    proc = run_process(args, cwd=cwd)
+def run_cmd(
+    args: list[str], cwd: Path | None = None, allow_findings: bool = False,
+    max_file_bytes: int | None = None,
+) -> str:
+    proc = run_process(args, cwd=cwd, max_file_bytes=max_file_bytes)
     if proc.returncode == 0 or (allow_findings and proc.returncode == 1):
         return proc.stdout
     sys.stderr.write(proc.stdout)
@@ -246,7 +280,10 @@ def scan_repo(repo: RepoEntry, repo_dir: Path, foxguard: Path, results_dir: Path
     ]
     for pattern in repo.exclude:
         args.extend(["--exclude", pattern])
-    run_cmd(args, allow_findings=True)
+    run_cmd(args, allow_findings=True, max_file_bytes=MAX_SCANNER_FILE_BYTES)
+
+    if not out_path.is_file() or out_path.stat().st_size > MAX_SCANNER_FILE_BYTES:
+        raise SystemExit(f"error: scanner report is missing or exceeds {MAX_SCANNER_FILE_BYTES} bytes")
 
     report = json.loads(out_path.read_text())
     raw_findings = report.get("findings", [])

--- a/benchmarks/precision/test_fixed_cases_v2.py
+++ b/benchmarks/precision/test_fixed_cases_v2.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import subprocess
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("fixed_cases_v2.py")
+SPEC = importlib.util.spec_from_file_location("fixed_cases_v2", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+fixed = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fixed)
+
+
+DIGEST = f"sha256:{'1' * 64}"
+
+
+def producer() -> dict[str, str]:
+    return fixed.producer_identity(commit_sha="a" * 40, tree_digest=DIGEST, binary_digest=DIGEST)
+
+
+def reviewed_findings() -> list[dict]:
+    labels = fixed.load_labels(fixed.DEFAULT_LABELS)
+    rows = []
+    for case_id in fixed.load_case_manifest(fixed.DEFAULT_CASES)["caseIds"]:
+        label = labels[case_id]
+        rows.append({
+            "column": 1,
+            "duplicate_index": 1,
+            "file": label["file"],
+            "id": case_id,
+            "justification": label["justification"],
+            "label": label["label"],
+            "line": label["line"],
+            "repo": label["repo"],
+            "rule_id": label["rule_id"],
+            "severity": "medium",
+            "snippet": "fixture",
+        })
+    return rows
+
+
+def write_findings(root: Path, name: str, rows: list[dict]) -> Path:
+    path = root / name
+    path.write_text(json.dumps(rows))
+    return path
+
+
+def build_arm(path: Path, arm_id: str = "arm") -> dict:
+    identity = producer()
+    findings = fixed.load_findings(path, fixed.load_labels(fixed.DEFAULT_LABELS))
+    corpus = fixed.corpus_binding()
+    checkouts = [
+        {"id": item["id"], "commitSha": item["commitSha"], "treeDigest": DIGEST}
+        for item in fixed.corpus_repositories(fixed.DEFAULT_CORPUS)
+    ]
+    native_reports = [
+        {"id": item["id"], "semanticDigest": DIGEST}
+        for item in fixed.corpus_repositories(fixed.DEFAULT_CORPUS)
+    ]
+    return fixed.build_arm(
+        arm_id=arm_id,
+        findings_path=path,
+        producer=identity,
+        scan_receipt=fixed.make_scan_receipt(
+            findings, identity, corpus, checkouts, native_reports
+        ),
+    )
+
+
+class FixedOssCaseTests(unittest.TestCase):
+    def test_lookalike_remote_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "approved Foxguard repository"):
+            fixed.validate_approved_remote(
+                "https://attacker.example/0sec-labs/foxguard.git"
+            )
+
+    def test_removing_known_false_positive_lowers_rate_and_stays_gradeable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            champion_rows = reviewed_findings()
+            challenger_rows = champion_rows[1:]
+            champion = build_arm(write_findings(root, "champion.json", champion_rows), "champion")
+            challenger = build_arm(write_findings(root, "challenger.json", challenger_rows), "challenger")
+            pair = fixed.build_pair(candidate_id="candidate", champion=champion, challenger=challenger)
+            self.assertEqual(pair["arms"]["champion"]["score"]["falsePositiveRate"], 1.0)
+            self.assertEqual(pair["arms"]["challenger"]["score"]["falsePositiveRate"], 0.95)
+
+    def test_same_total_with_substituted_case_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_findings(Path(directory), "empty.json", [])
+            arm = build_arm(path)
+            pair = fixed.build_pair(candidate_id="candidate", champion=arm, challenger=copy.deepcopy(arm))
+            pair["arms"]["challenger"]["cases"][0]["id"] = "substituted"
+            with self.assertRaisesRegex(ValueError, "exact case ids"):
+                fixed.validate_pair(pair)
+
+    def test_unknown_finding_fails_closed(self) -> None:
+        row = reviewed_findings()[0]
+        row["id"] = "unknown"
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_findings(Path(directory), "unknown.json", [row])
+            with self.assertRaisesRegex(ValueError, "unreviewed"):
+                build_arm(path)
+
+    def test_tampered_metric_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_findings(Path(directory), "empty.json", [])
+            arm = build_arm(path)
+            pair = fixed.build_pair(candidate_id="candidate", champion=arm, challenger=copy.deepcopy(arm))
+            pair["arms"]["challenger"]["score"]["falsePositiveRate"] = 0.5
+            with self.assertRaisesRegex(ValueError, "score is not recomputable"):
+                fixed.validate_pair(pair)
+
+    def test_tampered_scan_receipt_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_findings(Path(directory), "empty.json", [])
+            arm = build_arm(path)
+            pair = fixed.build_pair(candidate_id="candidate", champion=arm, challenger=copy.deepcopy(arm))
+            pair["arms"]["challenger"]["scanReceipt"]["binaryDigest"] = f"sha256:{'2' * 64}"
+            with self.assertRaisesRegex(ValueError, "scan receipt"):
+                fixed.validate_pair(pair)
+
+    def test_tampered_finding_identity_is_rejected_offline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            findings = write_findings(root, "findings.json", reviewed_findings()[:1])
+            arm = build_arm(findings)
+            pair = fixed.build_pair(candidate_id="candidate", champion=arm, challenger=copy.deepcopy(arm))
+            for location in (
+                pair["arms"]["challenger"]["observedFindings"][0],
+                pair["arms"]["challenger"]["cases"][0]["finding"],
+            ):
+                location["file"] = "substituted.py"
+            pair["arms"]["challenger"]["semanticReportDigest"] = fixed.digest_bytes(
+                b"foxguard-semantic-findings-v2\0"
+                + fixed.canonical_bytes(pair["arms"]["challenger"]["observedFindings"])
+            )
+            with self.assertRaisesRegex(ValueError, "reviewed identity"):
+                fixed.validate_pair(pair)
+
+    def test_case_manifest_byte_change_breaks_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            findings = write_findings(root, "empty.json", [])
+            arm = build_arm(findings)
+            pair = fixed.build_pair(candidate_id="candidate", champion=arm, challenger=copy.deepcopy(arm))
+            cases = json.loads(fixed.DEFAULT_CASES.read_text())
+            cases["id"] = "changed"
+            changed = root / "cases.json"
+            changed.write_text(json.dumps(cases))
+            with self.assertRaisesRegex(ValueError, "sealed case bytes"):
+                fixed.validate_pair(pair, cases_path=changed)
+
+    def test_semantic_order_is_canonical(self) -> None:
+        rows = reviewed_findings()[:2]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = build_arm(write_findings(root, "first.json", rows))
+            second = build_arm(write_findings(root, "second.json", list(reversed(rows))))
+            self.assertEqual(first, second)
+
+    def test_isolated_corpus_uses_committed_bytes_and_detects_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cache = root / "cache" / "repo"
+            cache.mkdir(parents=True)
+            subprocess.run(["git", "init", "-q", str(cache)], check=True)
+            subprocess.run(["git", "-C", str(cache), "config", "user.email", "test@example.com"], check=True)
+            subprocess.run(["git", "-C", str(cache), "config", "user.name", "Test"], check=True)
+            (cache / "safe.py").write_text("committed = True\n")
+            subprocess.run(["git", "-C", str(cache), "add", "safe.py"], check=True)
+            subprocess.run(["git", "-C", str(cache), "commit", "-q", "-m", "fixture"], check=True)
+            commit = subprocess.check_output(
+                ["git", "-C", str(cache), "rev-parse", "HEAD"], text=True
+            ).strip()
+            remote = "https://example.com/repo.git"
+            subprocess.run(["git", "-C", str(cache), "remote", "add", "origin", remote], check=True)
+            (cache / "safe.py").write_text("dirty = True\n")
+            corpus = root / "corpus.toml"
+            corpus.write_text(
+                "[[repos]]\n"
+                'name = "repo"\n'
+                f'url = "{remote}"\n'
+                f'ref = "{commit}"\n'
+                'language = "python"\n'
+            )
+            isolated = root / "isolated"
+            attestations = fixed.materialize_corpus(
+                arm_id="champion",
+                cache_workdir=root / "cache",
+                isolated_workdir=isolated,
+                corpus_path=corpus,
+                timeout_seconds=30,
+            )
+            self.assertEqual((isolated / "repo" / "safe.py").read_text(), "committed = True\n")
+            self.assertEqual(attestations[0]["commitSha"], commit)
+            (isolated / "repo" / "safe.py").write_text("mutated = True\n")
+            with self.assertRaisesRegex(ValueError, "dirty"):
+                fixed.require_clean_checkout(isolated / "repo", "challenger/repo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a sealed four-case local negative-control lane for pull-request CI
- add a 20-case reviewed OSS false-positive lane whose cases remain gradeable when findings disappear
- retain exact per-case outcomes, producer/source/binary identity, native-report semantics, isolated corpus checkout attestations, and content-addressed replay refs
- fail closed on unknown findings, dirty or mutated targets, malformed/stale reports, unsafe paths and IDs, timeouts, oversized output, and metric/case substitution
- distinguish the two schema-v2 contracts explicitly for a future Foxguard-specific 0brain consumer

## Why

The legacy aggregate adapter treated emitted findings as cases. Removing a known false positive therefore made the label stale instead of recording an improvement, and equal aggregate totals could hide case substitution. The new contracts make negative cases independent, exact, bounded, and replayable.

## Validation

- 16 precision/adapter tests
- 13 sealed local-control tests
- full `cargo test --all-features`
- `cargo fmt --check`
- precision metadata validation
- real four-case champion/challenger execution and offline replay: 0% / 0%
- two isolated full 20-case scans and offline replay: 20/20 current reviewed false positives in both baseline arms
- independent final review: no remaining P0/P1 blockers

## Integration boundary

This lands the Foxguard producer contracts only. 0brain must gain an exact Foxguard consumer and CI policy before these artifacts can authorize promotion; they are not represented as pwnkit tournaments.
