### PR TITLE
feat(precision): add held-out capability evidence contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
       - run: python3 benchmarks/precision/precision.py validate
       - run: python3 -m unittest benchmarks/precision/test_zero_research.py benchmarks/precision/test_fixed_cases_v2.py
       - run: python3 -m unittest discover -s benchmarks/fixed-negative-controls-v2 -p 'test_*.py'
+      - run: python3 -m unittest discover -s benchmarks/held-out-capability-v1 -p 'test_*.py'
 
   readme-version-refs:
     name: README Version Refs

--- a/benchmarks/held-out-capability-v1/README.md
+++ b/benchmarks/held-out-capability-v1/README.md
@@ -1,0 +1,56 @@
+# Held-out capability evidence v1
+
+This producer compares exact Foxguard binaries against a private, independently
+reviewed known-positive corpus. It is deliberately separate from the fixed
+negative-control lanes: positive evidence measures newly detected capability,
+while the existing lanes continue to gate false positives and regressions.
+
+Promotion evidence requires all of the following:
+
+- a root-owned manifest with no group/other write bit (normally `0640`) and
+  root-owned fixtures that the evaluator cannot modify;
+- at least four sorted, content-addressed, known-positive cases;
+- exact normalized expected findings and an independent oracle digest per case;
+- a non-calibration corpus; and
+- non-overlapping 95% Wilson intervals favoring the challenger.
+
+The public precision fixtures may be used to test this evaluator only when the
+manifest is marked `calibration: true`. Calibration evidence can never pass the
+capability gate.
+
+This artifact is evidence only: its draft-PR, merge, and publication authority
+flags are always false. Only the 0brain composite gate may later authorize a
+private draft PR after it also verifies both negative lanes, the exact executed
+source change, trusted controller/build receipts, and the exact CI check set.
+
+Direct binary execution in this module is deliberately calibration-only and
+must use a public/non-secret corpus. A non-calibration run is refused: real
+held-out execution belongs to the controller's dedicated unprivileged sandbox
+broker, where the candidate cannot read the manifest/oracle, mutate fixtures,
+reach the network, or access sibling/controller state. Retain its manifest,
+fixtures, raw reports, evidence, executed-change descriptor, and signatures in
+the private evidence root. Nothing here publishes, discloses, or uploads them.
+
+`source_change.py` separately binds the candidate to clean base/head commits,
+Git tree OIDs, content-tree digests, canonical full-index binary patch bytes,
+the allowed changed paths (`src/rules/**` plus tests), both executed binaries,
+the exact build argv and Rust inputs, and a successful CI receipt for the exact
+head. Verification reapplies the retained patch to an isolated temporary Git
+index and requires the resulting tree to equal the recorded head tree.
+
+The descriptor records the supplied CI receipt and binary/build claims but
+marks both `ciVerified` and `buildVerified` false. It proves their identities,
+not their truth. Only 0brain may upgrade those provenance gates after checking
+signed controller build receipts and the exact GitHub check set.
+
+```sh
+python3 held_out.py calibrate \
+  --candidate-id "$CANDIDATE_ID" \
+  --champion-binary "$CHAMPION_BINARY" \
+  --challenger-binary "$CHALLENGER_BINARY" \
+  --champion-source-root "$CHAMPION_SOURCE" \
+  --challenger-source-root "$CHALLENGER_SOURCE" \
+  --manifest "$PRIVATE_MANIFEST" \
+  --results-dir "$PRIVATE_OUTPUT/raw" \
+  --output "$PRIVATE_OUTPUT/evidence.json"
+```

--- a/benchmarks/held-out-capability-v1/held_out.py
+++ b/benchmarks/held-out-capability-v1/held_out.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Produce and verify sealed, held-out Foxguard capability evidence."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import math
+import os
+import re
+import resource
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+CONTRACT = "foxguard-held-out-capability-v1"
+REPOSITORY = "0sec-labs/foxguard"
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+MAX_REPORT_BYTES = 8 * 1024 * 1024
+MAX_FINDINGS = 10_000
+MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+APPROVED_REMOTES = {
+    "https://github.com/0sec-labs/foxguard",
+    "https://github.com/0sec-labs/foxguard.git",
+    "git@github.com:0sec-labs/foxguard",
+    "git@github.com:0sec-labs/foxguard.git",
+    "ssh://git@github.com/0sec-labs/foxguard",
+    "ssh://git@github.com/0sec-labs/foxguard.git",
+}
+FINDING_FIELDS = {
+    "column", "description", "file", "line", "ruleId", "severity", "snippet",
+}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def write_new_private(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def read_stable_report(path: Path) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > MAX_REPORT_BYTES:
+            raise RuntimeError(f"Foxguard report is not a bounded regular file: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            data = handle.read(MAX_REPORT_BYTES + 1)
+        after = os.fstat(descriptor)
+        if len(data) > MAX_REPORT_BYTES or (before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_ino, after.st_size, after.st_mtime_ns):
+            raise RuntimeError(f"Foxguard report changed while it was being read: {path}")
+        return data
+    finally:
+        os.close(descriptor)
+
+
+def relative_files(root: Path) -> list[Path]:
+    files = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"held-out fixture must not contain symlinks: {path}")
+        if path.is_file():
+            files.append(path)
+    return sorted(files, key=lambda path: path.relative_to(root).as_posix())
+
+
+def directory_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"foxguard-held-out-capability-directory-v1\0")
+    for path in relative_files(root):
+        name = path.relative_to(root).as_posix().encode()
+        data = path.read_bytes()
+        digest.update(len(name).to_bytes(8, "big") + name)
+        digest.update(len(data).to_bytes(8, "big") + data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def require_private_manifest(path: Path) -> None:
+    lexical = Path(os.path.abspath(path))
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError("held-out manifest path does not exist") from exc
+    if lexical != resolved:
+        raise ValueError("held-out manifest path must be canonical and contain no symlink components")
+    metadata = path.lstat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("held-out manifest must be a regular file")
+    if metadata.st_uid != 0 or metadata.st_mode & 0o027:
+        raise ValueError("held-out manifest must be root-owned, group-readable at most, and never group/other writable")
+    current = lexical.parent
+    while True:
+        parent_metadata = current.stat()
+        if parent_metadata.st_uid != 0 or parent_metadata.st_mode & 0o022:
+            raise ValueError(f"held-out corpus ancestor must be root-owned and non-writable by the evaluator: {current}")
+        if current == current.parent:
+            break
+        current = current.parent
+
+
+def read_manifest_bytes(path: Path, *, require_trusted: bool) -> bytes:
+    if require_trusted:
+        require_private_manifest(path)
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > MAX_MANIFEST_BYTES:
+            raise ValueError("held-out manifest must be a bounded regular file")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            data = handle.read(MAX_MANIFEST_BYTES + 1)
+        after = os.fstat(descriptor)
+        if len(data) > MAX_MANIFEST_BYTES or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise ValueError("held-out manifest changed while it was being read")
+        return data
+    finally:
+        os.close(descriptor)
+
+
+def require_immutable_fixture(root: Path) -> None:
+    paths = [root, *sorted(root.rglob("*"))]
+    for path in paths:
+        metadata = path.stat()
+        if metadata.st_uid != 0 or metadata.st_mode & 0o022:
+            raise ValueError(f"held-out fixture must be root-owned and immutable to the evaluator: {path}")
+
+
+def validate_finding(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != FINDING_FIELDS:
+        raise ValueError(f"{label} has unsupported or missing fields")
+    for key in ("line", "column"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 1:
+            raise ValueError(f"{label}.{key} is invalid")
+    for key in FINDING_FIELDS - {"line", "column"}:
+        if not isinstance(value[key], str):
+            raise ValueError(f"{label}.{key} is invalid")
+    if value["severity"] not in {"low", "medium", "high", "critical"}:
+        raise ValueError(f"{label}.severity is invalid")
+    path = Path(value["file"])
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{label}.file is unsafe")
+    return dict(value)
+
+
+def canonical_findings(values: Any, label: str) -> list[dict[str, Any]]:
+    if not isinstance(values, list) or not values:
+        raise ValueError(f"{label} must be a non-empty array")
+    findings = [validate_finding(value, f"{label} {index}") for index, value in enumerate(values)]
+    ordered = sorted(findings, key=lambda item: canonical_bytes(item))
+    if findings != ordered or len({canonical_bytes(item) for item in findings}) != len(findings):
+        raise ValueError(f"{label} must be unique and canonically sorted")
+    return findings
+
+
+def load_manifest(path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
+    value = json.loads(read_manifest_bytes(path, require_trusted=require_trusted))
+    expected = {"calibration", "cases", "id", "requireSignificance", "schemaVersion"}
+    if not isinstance(value, dict) or set(value) != expected or value["schemaVersion"] != 1:
+        raise ValueError("manifest schema has unsupported or missing fields")
+    if not isinstance(value["id"], str) or not SAFE_ID_RE.fullmatch(value["id"]):
+        raise ValueError("manifest id is invalid")
+    if not isinstance(value["calibration"], bool) or value["requireSignificance"] is not True:
+        raise ValueError("manifest must explicitly require significance")
+    cases = value["cases"]
+    if not isinstance(cases, list) or len(cases) < 4:
+        raise ValueError("held-out capability corpus requires at least four cases")
+    ids = []
+    for index, case in enumerate(cases):
+        fields = {"expectedFindings", "fixtureDigest", "id", "knownPositive", "oracleRef", "path"}
+        if not isinstance(case, dict) or set(case) != fields:
+            raise ValueError(f"manifest case {index} has unsupported or missing fields")
+        if case["knownPositive"] is not True or not DIGEST_RE.fullmatch(str(case["oracleRef"])):
+            raise ValueError(f"manifest case {index} lacks an independent positive oracle")
+        case_id, relative = case["id"], case["path"]
+        if not isinstance(case_id, str) or not SAFE_ID_RE.fullmatch(case_id) or not isinstance(relative, str):
+            raise ValueError(f"manifest case {index} identity is invalid")
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"manifest case {index} path is unsafe")
+        fixture = (path.parent / candidate).resolve()
+        try:
+            fixture.relative_to(path.parent.resolve())
+        except ValueError as exc:
+            raise ValueError(f"manifest case {index} escapes the corpus") from exc
+        if not fixture.is_dir() or not relative_files(fixture):
+            raise ValueError(f"manifest case {index} fixture is missing or empty")
+        if require_trusted:
+            require_immutable_fixture(fixture)
+        if case["fixtureDigest"] != directory_digest(fixture):
+            raise ValueError(f"manifest case {index} fixture digest does not match bytes")
+        canonical_findings(case["expectedFindings"], f"manifest case {index} expectedFindings")
+        ids.append(case_id)
+    if ids != sorted(ids) or len(ids) != len(set(ids)):
+        raise ValueError("manifest case ids must be unique and sorted")
+    return value
+
+
+def corpus_binding(path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
+    manifest = load_manifest(path, require_trusted=require_trusted)
+    bound = {
+        "calibration": manifest["calibration"],
+        "id": manifest["id"],
+        "manifestDigest": sha256_bytes(read_manifest_bytes(path, require_trusted=require_trusted)),
+        "cases": [
+            {"fixtureDigest": case["fixtureDigest"], "id": case["id"], "oracleRef": case["oracleRef"]}
+            for case in manifest["cases"]
+        ],
+    }
+    return {**bound, "digest": sha256_bytes(b"foxguard-held-out-capability-corpus-v1\0" + canonical_bytes(bound))}
+
+
+def run_git(root: Path, *args: str) -> bytes:
+    process = subprocess.run(["git", "-C", str(root.resolve()), *args], capture_output=True)
+    if process.returncode:
+        raise ValueError(process.stderr.decode(errors="replace").strip())
+    return process.stdout
+
+
+def producer_from_paths(source_root: Path, binary: Path) -> dict[str, str]:
+    remote = run_git(source_root, "remote", "get-url", "origin").decode().strip()
+    if remote not in APPROVED_REMOTES:
+        raise ValueError("source root is not the approved Foxguard repository")
+    commit = run_git(source_root, "rev-parse", "HEAD").decode().strip()
+    tree = run_git(source_root, "rev-parse", "HEAD^{tree}").decode().strip()
+    return validate_producer({
+        "repository": REPOSITORY, "commitSha": commit, "gitTreeOid": tree,
+        "binaryDigest": sha256_file(binary),
+    }, "producer")
+
+
+def validate_producer(value: Any, label: str) -> dict[str, str]:
+    fields = {"binaryDigest", "commitSha", "gitTreeOid", "repository"}
+    if not isinstance(value, dict) or set(value) != fields or value["repository"] != REPOSITORY:
+        raise ValueError(f"{label} producer identity is invalid")
+    if not SHA_RE.fullmatch(value["commitSha"]) or not SHA_RE.fullmatch(value["gitTreeOid"]):
+        raise ValueError(f"{label} source identity is invalid")
+    if not DIGEST_RE.fullmatch(value["binaryDigest"]):
+        raise ValueError(f"{label} binary digest is invalid")
+    return dict(value)
+
+
+def normalize_native_findings(report: Any, fixture: Path) -> list[dict[str, Any]]:
+    envelope = {
+        "config", "finding_counts", "finding_schema_version", "findings",
+        "scanner", "schema_version", "target", "timing",
+    }
+    if (
+        not isinstance(report, dict)
+        or not envelope.issubset(report)
+        or report.get("schema_version") != "1.0.0"
+        or report.get("finding_schema_version") != "1.0.0"
+    ):
+        raise ValueError("Foxguard report schema is unsupported")
+    if report["config"] != {"path": "/dev/null", "source": "explicit"}:
+        raise ValueError("Foxguard report config does not match the sealed invocation")
+    scanner, target, timing = report["scanner"], report["target"], report["timing"]
+    if (
+        not isinstance(scanner, dict)
+        or scanner.get("name") != "foxguard"
+        or scanner.get("command") != "scan"
+        or not isinstance(scanner.get("version"), str)
+        or not scanner["version"]
+    ):
+        raise ValueError("Foxguard scanner identity is invalid")
+    if (
+        not isinstance(target, dict)
+        or target.get("kind") != "directory"
+        or target.get("changed_only") is not False
+        or isinstance(target.get("files_scanned"), bool)
+        or not isinstance(target.get("files_scanned"), int)
+        or target["files_scanned"] < 1
+        or Path(str(target.get("path", ""))).resolve() != fixture.resolve()
+    ):
+        raise ValueError("Foxguard report target does not match the held-out case")
+    if (
+        not isinstance(timing, dict)
+        or isinstance(timing.get("duration_ms"), bool)
+        or not isinstance(timing.get("duration_ms"), int)
+        or timing["duration_ms"] < 0
+    ):
+        raise ValueError("Foxguard report timing is invalid")
+    raw_findings = report.get("findings")
+    if not isinstance(raw_findings, list) or len(raw_findings) > MAX_FINDINGS:
+        raise ValueError("Foxguard findings are invalid or unbounded")
+    normalized = []
+    for index, raw in enumerate(raw_findings):
+        required = {
+            "column", "confidence", "cwe", "description", "end_column", "end_line",
+            "file", "line", "rule_id", "severity", "snippet",
+        }
+        if not isinstance(raw, dict) or not required.issubset(raw):
+            raise ValueError(f"native finding {index} is invalid")
+        for key in ("line", "column", "end_line", "end_column"):
+            if isinstance(raw[key], bool) or not isinstance(raw[key], int) or raw[key] < 1:
+                raise ValueError(f"native finding {index}.{key} is invalid")
+        confidence = raw["confidence"]
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+            raise ValueError(f"native finding {index}.confidence is invalid")
+        try:
+            name = Path(str(raw["file"])).resolve().relative_to(fixture.resolve()).as_posix()
+        except ValueError as exc:
+            raise ValueError(f"native finding {index} escapes its fixture") from exc
+        normalized.append(validate_finding({
+            "column": raw["column"], "description": str(raw["description"]), "file": name,
+            "line": raw["line"], "ruleId": str(raw["rule_id"]),
+            "severity": str(raw["severity"]),
+            "snippet": re.sub(r"\s+", " ", str(raw["snippet"]).strip()),
+        }, f"native finding {index}"))
+    normalized = sorted(normalized, key=lambda item: canonical_bytes(item))
+    if len({canonical_bytes(item) for item in normalized}) != len(normalized):
+        raise ValueError("Foxguard report contains duplicate normalized findings")
+    counts = report["finding_counts"]
+    severities = ("critical", "high", "low", "medium")
+    expected_counts = {
+        severity: sum(item["severity"] == severity for item in normalized)
+        for severity in severities
+    }
+    if (
+        not isinstance(counts, dict)
+        or counts.get("total") != len(normalized)
+        or counts.get("by_severity") != expected_counts
+    ):
+        raise ValueError("Foxguard report counts do not match its findings")
+    return normalized
+
+
+def limit_child_files() -> None:
+    resource.setrlimit(resource.RLIMIT_FSIZE, (MAX_REPORT_BYTES, MAX_REPORT_BYTES))
+
+
+def scan_case(binary: Path, fixture: Path, report_path: Path, timeout_seconds: int) -> tuple[bytes, int]:
+    if report_path.exists() or report_path.is_symlink():
+        raise ValueError(f"refusing pre-existing report path: {report_path}")
+    command = [str(binary.resolve()), "--config", "/dev/null", str(fixture.resolve()), "-f", "json", "--output", str(report_path.resolve())]
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        process = subprocess.Popen(  # foxguard: ignore[py/no-command-injection]
+            command, stdout=stdout, stderr=stderr, start_new_session=True,
+            preexec_fn=limit_child_files,
+        )
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            raise RuntimeError(f"Foxguard timed out for {fixture.name}") from exc
+    if process.returncode not in (0, 1) or not report_path.is_file() or report_path.is_symlink():
+        raise RuntimeError(f"Foxguard failed to produce a valid report for {fixture.name}")
+    report_bytes = read_stable_report(report_path)
+    try:
+        report = json.loads(report_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError("native report JSON is invalid") from exc
+    findings = normalize_native_findings(report, fixture)
+    if process.returncode != (1 if findings else 0):
+        raise RuntimeError(f"Foxguard exit code does not match findings for {fixture.name}")
+    return report_bytes, process.returncode
+
+
+def wilson_interval(successes: int, trials: int, z: float = 1.959963984540054) -> list[float]:
+    if trials < 1 or successes < 0 or successes > trials:
+        raise ValueError("invalid Wilson interval inputs")
+    p = successes / trials
+    denominator = 1 + z * z / trials
+    centre = (p + z * z / (2 * trials)) / denominator
+    margin = z * math.sqrt((p * (1 - p) + z * z / (4 * trials)) / trials) / denominator
+    return [centre - margin, centre + margin]
+
+
+def invocation_digest(binary_digest: str, fixture_digest: str, case_id: str) -> str:
+    basis = {
+        "binaryDigest": binary_digest,
+        "caseId": case_id,
+        "config": {"path": "/dev/null", "source": "explicit"},
+        "fixtureDigest": fixture_digest,
+        "format": "json",
+        "operation": "scan-directory",
+    }
+    return sha256_bytes(b"foxguard-held-out-invocation-v1\0" + canonical_bytes(basis))
+
+
+def make_case(
+    item: dict[str, Any], report_bytes: bytes, binary_digest: str,
+    exit_code: int, fixture: Path,
+) -> dict[str, Any]:
+    if not report_bytes or len(report_bytes) > MAX_REPORT_BYTES:
+        raise ValueError("native report bytes are empty or unbounded")
+    try:
+        report = json.loads(report_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError("native report JSON is invalid") from exc
+    findings = normalize_native_findings(report, fixture)
+    if exit_code != (1 if findings else 0):
+        raise ValueError("recorded exit code does not match native findings")
+    expected = canonical_findings(item["expectedFindings"], "expectedFindings")
+    matched = all(finding in findings for finding in expected)
+    return {
+        "detected": matched, "expectedFindings": expected, "findings": findings,
+        "execution": {
+            "binaryDigest": binary_digest,
+            "exitCode": exit_code,
+            "fixtureDigest": item["fixtureDigest"],
+            "invocationDigest": invocation_digest(binary_digest, item["fixtureDigest"], item["id"]),
+            "reportDigest": sha256_bytes(report_bytes),
+        },
+        "id": item["id"], "knownPositive": True,
+        "nativeReport": {"encoding": "base64", "value": base64.b64encode(report_bytes).decode()},
+        "verdict": "detected" if matched else "missed",
+    }
+
+
+def score(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    detected = sum(case["detected"] is True for case in cases)
+    return {"cases": len(cases), "detected": detected, "detectionRate": detected / len(cases), "wilson95": wilson_interval(detected, len(cases))}
+
+
+def evaluate_arm(*, arm_id: str, binary: Path, producer: dict[str, str], manifest_path: Path, results_dir: Path, timeout_seconds: int, require_trusted: bool = True) -> dict[str, Any]:
+    if not SAFE_ID_RE.fullmatch(arm_id):
+        raise ValueError("arm id must be a safe identifier")
+    producer = validate_producer(producer, arm_id)
+    if sha256_file(binary) != producer["binaryDigest"]:
+        raise ValueError(f"{arm_id} binary bytes do not match producer identity")
+    manifest = load_manifest(manifest_path, require_trusted=require_trusted)
+    if manifest["calibration"] is not True:
+        raise ValueError("direct execution is calibration-only; production execution requires the controller sandbox broker")
+    cases = []
+    for item in manifest["cases"]:
+        fixture = manifest_path.parent / item["path"]
+        report_bytes, exit_code = scan_case(
+            binary, fixture, results_dir / f"{arm_id}-{item['id']}.json", timeout_seconds,
+        )
+        cases.append(make_case(
+            item, report_bytes, producer["binaryDigest"], exit_code, fixture,
+        ))
+    return {"cases": cases, "id": arm_id, "producer": producer, "score": score(cases)}
+
+
+def evaluator_digest() -> str:
+    return sha256_bytes(b"foxguard-held-out-capability-evaluator-v1\0" + Path(__file__).read_bytes())
+
+
+def validate_artifact(value: Any, manifest_path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
+    fields = {"arms", "authority", "candidateId", "contract", "corpus", "decision", "evaluatorDigest", "schemaVersion"}
+    if not isinstance(value, dict) or set(value) != fields or value["schemaVersion"] != 1 or value["contract"] != CONTRACT:
+        raise ValueError("artifact schema or contract is invalid")
+    if not isinstance(value["candidateId"], str) or not SAFE_ID_RE.fullmatch(value["candidateId"]):
+        raise ValueError("candidateId is invalid")
+    corpus = corpus_binding(manifest_path, require_trusted=require_trusted)
+    if value["corpus"] != corpus or value["evaluatorDigest"] != evaluator_digest():
+        raise ValueError("artifact does not bind the local corpus and evaluator")
+    manifest = load_manifest(manifest_path, require_trusted=require_trusted)
+    ids = [case["id"] for case in manifest["cases"]]
+    arms = value["arms"]
+    if not isinstance(arms, dict) or set(arms) != {"champion", "challenger"}:
+        raise ValueError("artifact must contain exactly two arms")
+    if value["authority"] != {"draftPr": False, "merge": False, "publish": False}:
+        raise ValueError("capability evidence must not carry promotion or publication authority")
+    if (
+        isinstance(arms["champion"], dict)
+        and isinstance(arms["challenger"], dict)
+        and arms["champion"].get("producer") == arms["challenger"].get("producer")
+    ):
+        raise ValueError("champion and challenger producer identities must differ")
+    for label in ("champion", "challenger"):
+        arm = arms[label]
+        if not isinstance(arm, dict) or set(arm) != {"cases", "id", "producer", "score"}:
+            raise ValueError(f"{label} arm schema is invalid")
+        if not isinstance(arm["id"], str) or not SAFE_ID_RE.fullmatch(arm["id"]):
+            raise ValueError(f"{label} arm id is invalid")
+        validate_producer(arm["producer"], label)
+        if [case.get("id") for case in arm["cases"] if isinstance(case, dict)] != ids:
+            raise ValueError(f"{label} exact case ids do not match the held-out corpus")
+        rebuilt = []
+        for index, (case, item) in enumerate(zip(arm["cases"], manifest["cases"])):
+            expected_fields = {"detected", "execution", "expectedFindings", "findings", "id", "knownPositive", "nativeReport", "verdict"}
+            if not isinstance(case, dict) or set(case) != expected_fields or case["knownPositive"] is not True:
+                raise ValueError(f"{label} case {index} schema is invalid")
+            native = case["nativeReport"]
+            if not isinstance(native, dict) or set(native) != {"encoding", "value"} or native["encoding"] != "base64":
+                raise ValueError(f"{label} case {index} native report encoding is invalid")
+            try:
+                report_bytes = base64.b64decode(native["value"], validate=True)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(f"{label} case {index} native report encoding is invalid") from exc
+            execution = case["execution"]
+            if not isinstance(execution, dict) or set(execution) != {"binaryDigest", "exitCode", "fixtureDigest", "invocationDigest", "reportDigest"}:
+                raise ValueError(f"{label} case {index} execution receipt is invalid")
+            rebuilt.append(make_case(
+                item, report_bytes, arm["producer"]["binaryDigest"],
+                execution["exitCode"], manifest_path.parent / item["path"],
+            ))
+        if arm["cases"] != rebuilt or arm["score"] != score(rebuilt):
+            raise ValueError(f"{label} verdict or score is not recomputable")
+    if arms["champion"]["id"] == arms["challenger"]["id"]:
+        raise ValueError("champion and challenger arm ids must differ")
+    champion_upper = arms["champion"]["score"]["wilson95"][1]
+    challenger_lower = arms["challenger"]["score"]["wilson95"][0]
+    significant = challenger_lower > champion_upper
+    expected_decision = {
+        "capabilityGatePassed": significant and not corpus["calibration"],
+        "reason": "significant_improvement" if significant and not corpus["calibration"] else ("calibration_only" if corpus["calibration"] else "not_significant"),
+        "significant": significant,
+    }
+    if value["decision"] != expected_decision:
+        raise ValueError("promotion decision is not recomputable")
+    return value
+
+
+def artifact_ref(path: Path) -> str:
+    return f"foxguard-held-out-capability-v1:{sha256_file(path)}"
+
+
+def run_command(args: argparse.Namespace) -> int:
+    if args.champion_id == args.challenger_id or args.timeout_seconds < 1:
+        raise ValueError("arm ids must differ and timeout must be positive")
+    if args.results_dir.exists() and any(args.results_dir.iterdir()):
+        raise ValueError("results directory must be absent or empty")
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    manifest = load_manifest(args.manifest, require_trusted=False)
+    if manifest["calibration"] is not True:
+        raise ValueError("direct execution is calibration-only; production execution requires the controller sandbox broker")
+    champion = producer_from_paths(args.champion_source_root, args.champion_binary)
+    challenger = producer_from_paths(args.challenger_source_root, args.challenger_binary)
+    arms = {
+        "champion": evaluate_arm(arm_id=args.champion_id, binary=args.champion_binary, producer=champion, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False),
+        "challenger": evaluate_arm(arm_id=args.challenger_id, binary=args.challenger_binary, producer=challenger, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False),
+    }
+    significant = arms["challenger"]["score"]["wilson95"][0] > arms["champion"]["score"]["wilson95"][1]
+    calibration = manifest["calibration"]
+    value = {
+        "schemaVersion": 1, "contract": CONTRACT, "candidateId": args.candidate_id,
+        "corpus": corpus_binding(args.manifest, require_trusted=False), "evaluatorDigest": evaluator_digest(), "arms": arms,
+        "authority": {"draftPr": False, "merge": False, "publish": False},
+        "decision": {"capabilityGatePassed": significant and not calibration, "reason": "significant_improvement" if significant and not calibration else ("calibration_only" if calibration else "not_significant"), "significant": significant},
+    }
+    if producer_from_paths(args.champion_source_root, args.champion_binary) != champion or producer_from_paths(args.challenger_source_root, args.challenger_binary) != challenger:
+        raise ValueError("producer bytes changed during evaluation")
+    validate_artifact(value, args.manifest, require_trusted=False)
+    write_new_private(args.output, canonical_bytes(value))
+    print(artifact_ref(args.output))
+    return 0
+
+
+def verify_command(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest, require_trusted=False)
+    if manifest["calibration"] is not True:
+        raise ValueError("this verifier is calibration-only; production verification belongs to the controller composite")
+    validate_artifact(json.loads(args.artifact.read_text()), args.manifest, require_trusted=False)
+    if args.ref and args.ref != artifact_ref(args.artifact):
+        raise ValueError("artifact reference does not match retained bytes")
+    print(artifact_ref(args.artifact))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("calibrate")
+    run.add_argument("--candidate-id", required=True)
+    run.add_argument("--champion-id", default="champion")
+    run.add_argument("--challenger-id", default="challenger")
+    run.add_argument("--champion-binary", required=True, type=Path)
+    run.add_argument("--challenger-binary", required=True, type=Path)
+    run.add_argument("--champion-source-root", required=True, type=Path)
+    run.add_argument("--challenger-source-root", required=True, type=Path)
+    run.add_argument("--manifest", required=True, type=Path)
+    run.add_argument("--results-dir", required=True, type=Path)
+    run.add_argument("--output", required=True, type=Path)
+    run.add_argument("--timeout-seconds", type=int, default=120)
+    run.set_defaults(func=run_command)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--artifact", required=True, type=Path)
+    verify.add_argument("--manifest", required=True, type=Path)
+    verify.add_argument("--ref")
+    verify.set_defaults(func=verify_command)
+    args = parser.parse_args()
+    try:
+        return int(args.func(args))
+    except (ValueError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/held-out-capability-v1/source_change.py
+++ b/benchmarks/held-out-capability-v1/source_change.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Bind a Foxguard candidate to the exact source change and executed binaries."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT = "foxguard-executed-source-change-v1"
+REPOSITORY = "0sec-labs/foxguard"
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+MAX_PATCH_BYTES = 2 * 1024 * 1024
+BUILD_ARGV = ["cargo", "build", "--locked", "--release", "--bin", "foxguard"]
+APPROVED_REMOTES = {
+    "https://github.com/0sec-labs/foxguard",
+    "https://github.com/0sec-labs/foxguard.git",
+    "git@github.com:0sec-labs/foxguard",
+    "git@github.com:0sec-labs/foxguard.git",
+    "ssh://git@github.com/0sec-labs/foxguard",
+    "ssh://git@github.com/0sec-labs/foxguard.git",
+}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def write_new_private(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def git(root: Path, *args: str, input_bytes: bytes | None = None, env: dict[str, str] | None = None) -> bytes:
+    process = subprocess.run(
+        ["git", "-C", str(root.resolve()), *args], input=input_bytes,
+        capture_output=True, env=env,
+    )
+    if process.returncode:
+        raise ValueError(
+            f"git {' '.join(args)} failed: {process.stderr.decode(errors='replace').strip()}"
+        )
+    return process.stdout
+
+
+def approved_checkout(root: Path) -> None:
+    remote = git(root, "remote", "get-url", "origin").decode().strip()
+    if remote not in APPROVED_REMOTES:
+        raise ValueError("source root is not the approved Foxguard repository")
+    if git(root, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise ValueError("source checkout must be clean")
+
+
+def commit_identity_at(root: Path, ref: str) -> dict[str, str]:
+    commit_sha = git(root, "rev-parse", ref).decode().strip()
+    tree_oid = git(root, "rev-parse", f"{ref}^{{tree}}").decode().strip()
+    records = git(root, "ls-tree", "-r", "-z", "--full-tree", ref)
+    return {
+        "commitSha": commit_sha,
+        "contentTreeDigest": sha256_bytes(b"foxguard-git-content-tree-v1\0" + records),
+        "gitTreeOid": tree_oid,
+    }
+
+
+def commit_identity(root: Path) -> dict[str, str]:
+    return commit_identity_at(root, "HEAD")
+
+
+def validate_path(path: str) -> None:
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts or not path:
+        raise ValueError(f"changed path is unsafe: {path}")
+    if not (path.startswith("src/rules/") or path.startswith("tests/")):
+        raise ValueError(f"changed path is outside the first Foxguard profile: {path}")
+
+
+def tree_mode(root: Path, ref: str, path: str) -> str | None:
+    record = git(root, "ls-tree", "-z", ref, "--", path)
+    if not record:
+        return None
+    header, separator, recorded_path = record.rstrip(b"\0").partition(b"\t")
+    if not separator or recorded_path.decode("utf-8", errors="strict") != path:
+        raise ValueError(f"git returned an invalid tree record for {path}")
+    mode, object_type, _object_id = header.decode("ascii").split(" ")
+    if object_type != "blob" or mode not in {"100644", "100755"}:
+        raise ValueError(f"candidate paths must remain regular Git blobs: {path}")
+    return mode
+
+
+def changed_entries(root: Path, base: str, head: str) -> list[dict[str, str]]:
+    raw = [item for item in git(
+        root, "diff", "--name-status", "--no-renames", "-z", base, head,
+    ).split(b"\0") if item]
+    if len(raw) % 2:
+        raise ValueError("git returned an invalid changed-path stream")
+    entries = []
+    for index in range(0, len(raw), 2):
+        status = raw[index].decode("ascii", errors="strict")
+        path = raw[index + 1].decode("utf-8", errors="strict")
+        if status not in {"A", "D", "M"}:
+            raise ValueError(f"unsupported candidate path status: {status}")
+        validate_path(path)
+        base_mode = tree_mode(root, base, path)
+        head_mode = tree_mode(root, head, path)
+        if (
+            (status == "A" and (base_mode is not None or head_mode is None))
+            or (status == "D" and (base_mode is None or head_mode is not None))
+            or (status == "M" and (base_mode is None or head_mode is None))
+        ):
+            raise ValueError(f"candidate status does not match tree objects: {path}")
+        entries.append({"path": path, "status": status})
+    entries.sort(key=lambda item: item["path"])
+    paths = [entry["path"] for entry in entries]
+    if not paths or not any(path.startswith("src/rules/") for path in paths):
+        raise ValueError("candidate must change at least one src/rules path")
+    return entries
+
+
+def patch_bytes(root: Path, base: str, head: str) -> bytes:
+    value = git(
+        root, "diff", "--no-ext-diff", "--no-textconv", "--no-renames",
+        "--binary", "--full-index", base, head,
+    )
+    if not value or len(value) > MAX_PATCH_BYTES:
+        raise ValueError("candidate patch must be non-empty and bounded")
+    return value
+
+
+def applied_tree_oid(root: Path, base: str, patch: bytes) -> str:
+    with tempfile.TemporaryDirectory() as directory:
+        index = Path(directory) / "index"
+        env = dict(os.environ)
+        env["GIT_INDEX_FILE"] = str(index)
+        git(root, "read-tree", base, env=env)
+        git(root, "apply", "--cached", "--whitespace=nowarn", "-", input_bytes=patch, env=env)
+        return git(root, "write-tree", env=env).decode().strip()
+
+
+def load_ci_receipt(path: Path, head: dict[str, str]) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    fields = {"conclusion", "headCommitSha", "headTreeOid", "repository", "runId", "workflowRef"}
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValueError("CI receipt schema is invalid")
+    if (
+        value["repository"] != REPOSITORY
+        or value["conclusion"] != "success"
+        or value["headCommitSha"] != head["commitSha"]
+        or value["headTreeOid"] != head["gitTreeOid"]
+        or not isinstance(value["runId"], str)
+        or not value["runId"].isdigit()
+        or not isinstance(value["workflowRef"], str)
+        or value["workflowRef"] != f"0sec-labs/foxguard/.github/workflows/ci.yml@{head['commitSha']}"
+    ):
+        raise ValueError("CI receipt is not a successful exact-head Foxguard run")
+    return value
+
+
+def toolchain_identity(root: Path) -> dict[str, str]:
+    process = subprocess.run(["rustc", "--version", "--verbose"], capture_output=True)
+    if process.returncode:
+        raise ValueError("rustc toolchain identity is unavailable")
+    return {
+        "cargoLockDigest": sha256_file(root / "Cargo.lock"),
+        "cargoTomlDigest": sha256_file(root / "Cargo.toml"),
+        "rustcVerboseDigest": sha256_bytes(process.stdout),
+    }
+
+
+def validate_identity(value: Any, label: str) -> dict[str, str]:
+    fields = {"commitSha", "contentTreeDigest", "gitTreeOid"}
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValueError(f"{label} identity schema is invalid")
+    if not SHA_RE.fullmatch(value["commitSha"]) or not SHA_RE.fullmatch(value["gitTreeOid"]):
+        raise ValueError(f"{label} git identity is invalid")
+    if not DIGEST_RE.fullmatch(value["contentTreeDigest"]):
+        raise ValueError(f"{label} content tree digest is invalid")
+    return dict(value)
+
+
+def validate_descriptor(value: Any, *, repository_root: Path | None = None) -> dict[str, Any]:
+    fields = {
+        "base", "binaryDigests", "buildArgv", "candidateChangeDigest", "candidateId",
+        "ciReceipt", "contract", "head", "patch", "provenance", "repository", "schemaVersion", "toolchain",
+    }
+    if not isinstance(value, dict) or set(value) != fields or value["schemaVersion"] != 1 or value["contract"] != CONTRACT:
+        raise ValueError("executed-change descriptor schema or contract is invalid")
+    if value["repository"] != REPOSITORY or not isinstance(value["candidateId"], str) or not SAFE_ID_RE.fullmatch(value["candidateId"]):
+        raise ValueError("executed-change descriptor identity is invalid")
+    if value["provenance"] != {"buildVerified": False, "ciVerified": False}:
+        raise ValueError("source descriptor must not claim trusted build or CI provenance")
+    base = validate_identity(value["base"], "base")
+    head = validate_identity(value["head"], "head")
+    if base["commitSha"] == head["commitSha"]:
+        raise ValueError("base and head commits must differ")
+    patch = value["patch"]
+    patch_fields = {"changedPaths", "changes", "digest", "encoding", "format", "value"}
+    if not isinstance(patch, dict) or set(patch) != patch_fields or patch["encoding"] != "base64" or patch["format"] != "git-binary-full-index-v1":
+        raise ValueError("patch schema is invalid")
+    try:
+        raw_patch = base64.b64decode(patch["value"], validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ValueError("patch encoding is invalid") from exc
+    if not raw_patch or len(raw_patch) > MAX_PATCH_BYTES or patch["digest"] != sha256_bytes(raw_patch):
+        raise ValueError("patch digest or size is invalid")
+    paths = patch["changedPaths"]
+    if (
+        not isinstance(paths, list)
+        or not all(isinstance(path, str) for path in paths)
+        or paths != sorted(set(paths))
+        or not any(path.startswith("src/rules/") for path in paths)
+    ):
+        raise ValueError("changed paths are invalid")
+    for path in paths:
+        validate_path(path)
+    changes = patch["changes"]
+    if (
+        not isinstance(changes, list)
+        or changes != sorted(changes, key=lambda item: item.get("path", "") if isinstance(item, dict) else "")
+        or any(not isinstance(item, dict) or set(item) != {"path", "status"} or item["status"] not in {"A", "D", "M"} for item in changes)
+        or [item["path"] for item in changes] != paths
+    ):
+        raise ValueError("changed path/status entries are invalid")
+    binaries = value["binaryDigests"]
+    if not isinstance(binaries, dict) or set(binaries) != {"challenger", "champion"} or not all(DIGEST_RE.fullmatch(str(item)) for item in binaries.values()):
+        raise ValueError("binary digests are invalid")
+    argv = value["buildArgv"]
+    if argv != BUILD_ARGV:
+        raise ValueError("build argv must match the fixed Foxguard release build")
+    toolchain = value["toolchain"]
+    if not isinstance(toolchain, dict) or set(toolchain) != {"cargoLockDigest", "cargoTomlDigest", "rustcVerboseDigest"} or not all(DIGEST_RE.fullmatch(str(item)) for item in toolchain.values()):
+        raise ValueError("toolchain identity is invalid")
+    receipt = value["ciReceipt"]
+    receipt_fields = {"conclusion", "headCommitSha", "headTreeOid", "repository", "runId", "workflowRef"}
+    if (
+        not isinstance(receipt, dict)
+        or set(receipt) != receipt_fields
+        or receipt["conclusion"] != "success"
+        or receipt["repository"] != REPOSITORY
+        or receipt["headCommitSha"] != head["commitSha"]
+        or receipt["headTreeOid"] != head["gitTreeOid"]
+        or not isinstance(receipt["runId"], str)
+        or not receipt["runId"].isdigit()
+        or not isinstance(receipt["workflowRef"], str)
+        or receipt["workflowRef"] != f"0sec-labs/foxguard/.github/workflows/ci.yml@{head['commitSha']}"
+    ):
+        raise ValueError("CI receipt does not bind the exact head")
+    change_basis = {
+        "base": base,
+        "head": head,
+        "patchDigest": patch["digest"],
+        "changedPaths": paths,
+        "changes": changes,
+    }
+    expected_change_digest = sha256_bytes(b"foxguard-executed-source-change-v1\0" + canonical_bytes(change_basis))
+    if value["candidateChangeDigest"] != expected_change_digest:
+        raise ValueError("candidate change digest is not recomputable")
+    if repository_root is not None:
+        approved_checkout(repository_root)
+        if commit_identity(repository_root) != base:
+            raise ValueError("verification checkout does not match descriptor base")
+        ancestor = subprocess.run(
+            ["git", "-C", str(repository_root.resolve()), "merge-base", "--is-ancestor", base["commitSha"], head["commitSha"]],
+            capture_output=True,
+        )
+        if ancestor.returncode != 0:
+            raise ValueError("descriptor head is not a descendant of its base")
+        if commit_identity_at(repository_root, head["commitSha"]) != head:
+            raise ValueError("descriptor head identity does not match repository objects")
+        if (
+            sha256_bytes(git(repository_root, "show", f"{head['commitSha']}:Cargo.toml")) != toolchain["cargoTomlDigest"]
+            or sha256_bytes(git(repository_root, "show", f"{head['commitSha']}:Cargo.lock")) != toolchain["cargoLockDigest"]
+        ):
+            raise ValueError("Cargo input digests do not match the exact head")
+        if changed_entries(repository_root, base["commitSha"], head["commitSha"]) != changes:
+            raise ValueError("changed path/status entries do not match repository objects")
+        if patch_bytes(repository_root, base["commitSha"], head["commitSha"]) != raw_patch:
+            raise ValueError("patch bytes do not match repository objects")
+        if applied_tree_oid(repository_root, base["commitSha"], raw_patch) != head["gitTreeOid"]:
+            raise ValueError("retained patch does not reproduce the exact head tree")
+    return value
+
+
+def build_descriptor(args: argparse.Namespace) -> dict[str, Any]:
+    approved_checkout(args.base_source_root)
+    approved_checkout(args.head_source_root)
+    base = commit_identity(args.base_source_root)
+    head = commit_identity(args.head_source_root)
+    ancestor = subprocess.run(
+        ["git", "-C", str(args.base_source_root.resolve()), "merge-base", "--is-ancestor", base["commitSha"], head["commitSha"]],
+        capture_output=True,
+    )
+    if ancestor.returncode != 0:
+        raise ValueError("candidate head must descend from its base")
+    changes = changed_entries(args.base_source_root, base["commitSha"], head["commitSha"])
+    paths = [item["path"] for item in changes]
+    patch = patch_bytes(args.base_source_root, base["commitSha"], head["commitSha"])
+    if applied_tree_oid(args.base_source_root, base["commitSha"], patch) != head["gitTreeOid"]:
+        raise ValueError("patch does not reproduce the exact head tree")
+    patch_digest = sha256_bytes(patch)
+    change_basis = {
+        "base": base, "head": head, "patchDigest": patch_digest,
+        "changedPaths": paths, "changes": changes,
+    }
+    value = {
+        "schemaVersion": 1,
+        "contract": CONTRACT,
+        "candidateId": args.candidate_id,
+        "repository": REPOSITORY,
+        "provenance": {"buildVerified": False, "ciVerified": False},
+        "base": base,
+        "head": head,
+        "patch": {
+            "changedPaths": paths,
+            "changes": changes,
+            "digest": patch_digest,
+            "encoding": "base64",
+            "format": "git-binary-full-index-v1",
+            "value": base64.b64encode(patch).decode(),
+        },
+        "candidateChangeDigest": sha256_bytes(b"foxguard-executed-source-change-v1\0" + canonical_bytes(change_basis)),
+        "binaryDigests": {
+            "champion": sha256_file(args.champion_binary),
+            "challenger": sha256_file(args.challenger_binary),
+        },
+        "buildArgv": BUILD_ARGV,
+        "toolchain": toolchain_identity(args.head_source_root),
+        "ciReceipt": load_ci_receipt(args.ci_receipt, head),
+    }
+    return validate_descriptor(value, repository_root=args.base_source_root)
+
+
+def artifact_ref(path: Path) -> str:
+    return f"foxguard-executed-source-change-v1:{sha256_file(path)}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("build")
+    build.add_argument("--candidate-id", required=True)
+    build.add_argument("--base-source-root", required=True, type=Path)
+    build.add_argument("--head-source-root", required=True, type=Path)
+    build.add_argument("--champion-binary", required=True, type=Path)
+    build.add_argument("--challenger-binary", required=True, type=Path)
+    build.add_argument("--ci-receipt", required=True, type=Path)
+    build.add_argument("--output", required=True, type=Path)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--artifact", required=True, type=Path)
+    verify.add_argument("--base-source-root", required=True, type=Path)
+    verify.add_argument("--ref")
+    args = parser.parse_args()
+    try:
+        if args.command == "build":
+            value = build_descriptor(args)
+            write_new_private(args.output, canonical_bytes(value))
+            print(artifact_ref(args.output))
+        else:
+            validate_descriptor(json.loads(args.artifact.read_text()), repository_root=args.base_source_root)
+            if args.ref and args.ref != artifact_ref(args.artifact):
+                raise ValueError("artifact reference does not match retained bytes")
+            print(artifact_ref(args.artifact))
+        return 0
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/held-out-capability-v1/test_held_out.py
+++ b/benchmarks/held-out-capability-v1/test_held_out.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("held_out.py")
+SPEC = importlib.util.spec_from_file_location("held_out", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+held = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(held)
+
+DIGEST = f"sha256:{'1' * 64}"
+SHA = "a" * 40
+
+
+def finding() -> dict:
+    return {
+        "column": 1,
+        "description": "known vulnerability",
+        "file": "fixture.py",
+        "line": 1,
+        "ruleId": "python/known-vulnerability",
+        "severity": "high",
+        "snippet": "dangerous(value)",
+    }
+
+
+def identity() -> dict:
+    return {
+        "binaryDigest": DIGEST,
+        "commitSha": SHA,
+        "gitTreeOid": SHA,
+        "repository": held.REPOSITORY,
+    }
+
+
+def challenger_identity() -> dict:
+    value = identity()
+    value["binaryDigest"] = f"sha256:{'2' * 64}"
+    value["commitSha"] = "b" * 40
+    value["gitTreeOid"] = "b" * 40
+    return value
+
+
+def native_report(fixture: Path, *, detected: bool = True) -> dict:
+    value = {
+        "config": {"path": "/dev/null", "source": "explicit"},
+        "finding_counts": {
+            "by_severity": {"critical": 0, "high": 1, "low": 0, "medium": 0},
+            "total": 1,
+        },
+        "finding_schema_version": "1.0.0",
+        "findings": [{
+            "column": 1,
+            "confidence": 1.0,
+            "cwe": "CWE-1",
+            "description": "known vulnerability",
+            "end_column": 17,
+            "end_line": 1,
+            "file": str(fixture / "fixture.py"),
+            "line": 1,
+            "rule_id": "python/known-vulnerability",
+            "severity": "high",
+            "snippet": "dangerous(value)",
+        }],
+        "scanner": {"command": "scan", "name": "foxguard", "version": "test"},
+        "schema_version": "1.0.0",
+        "target": {
+            "changed_only": False,
+            "files_scanned": 1,
+            "kind": "directory",
+            "path": str(fixture),
+        },
+        "timing": {"duration_ms": 1},
+    }
+    if not detected:
+        value["findings"] = []
+        value["finding_counts"] = {
+            "by_severity": {"critical": 0, "high": 0, "low": 0, "medium": 0},
+            "total": 0,
+        }
+    return value
+
+
+def write_manifest(root: Path, *, calibration: bool = False, count: int = 4) -> Path:
+    cases = []
+    for index in range(count):
+        case_id = f"case-{index + 1}"
+        fixture = root / "fixtures" / case_id
+        fixture.mkdir(parents=True)
+        (fixture / "fixture.py").write_text("dangerous(value)\n")
+        cases.append({
+            "expectedFindings": [finding()],
+            "fixtureDigest": held.directory_digest(fixture),
+            "id": case_id,
+            "knownPositive": True,
+            "oracleRef": f"sha256:{index + 1:064x}",
+            "path": f"fixtures/{case_id}",
+        })
+    manifest = root / "manifest.json"
+    manifest.write_bytes(held.canonical_bytes({
+        "calibration": calibration,
+        "cases": cases,
+        "id": "private-held-out-v1",
+        "requireSignificance": True,
+        "schemaVersion": 1,
+    }))
+    return manifest
+
+
+def artifact(manifest: Path) -> dict:
+    source = held.load_manifest(manifest, require_trusted=False)
+    champion_cases = []
+    challenger_cases = []
+    for item in source["cases"]:
+        fixture = manifest.parent / item["path"]
+        champion_cases.append(held.make_case(
+            item,
+            held.canonical_bytes(native_report(fixture, detected=False)),
+            identity()["binaryDigest"],
+            0,
+            fixture,
+        ))
+        challenger_cases.append(held.make_case(
+            item,
+            held.canonical_bytes(native_report(fixture)),
+            challenger_identity()["binaryDigest"],
+            1,
+            fixture,
+        ))
+    arms = {
+        "champion": {
+            "cases": champion_cases,
+            "id": "champion",
+            "producer": identity(),
+            "score": held.score(champion_cases),
+        },
+        "challenger": {
+            "cases": challenger_cases,
+            "id": "challenger",
+            "producer": challenger_identity(),
+            "score": held.score(challenger_cases),
+        },
+    }
+    return {
+        "arms": arms,
+        "authority": {"draftPr": False, "merge": False, "publish": False},
+        "candidateId": "candidate-1",
+        "contract": held.CONTRACT,
+        "corpus": held.corpus_binding(manifest, require_trusted=False),
+        "decision": {
+            "capabilityGatePassed": not source["calibration"],
+            "reason": "calibration_only" if source["calibration"] else "significant_improvement",
+            "significant": True,
+        },
+        "evaluatorDigest": held.evaluator_digest(),
+        "schemaVersion": 1,
+    }
+
+
+class HeldOutTests(unittest.TestCase):
+    def test_four_perfect_disjoint_cases_are_significant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            held.validate_artifact(value, manifest, require_trusted=False)
+            self.assertTrue(value["decision"]["capabilityGatePassed"])
+            self.assertGreater(
+                value["arms"]["challenger"]["score"]["wilson95"][0],
+                value["arms"]["champion"]["score"]["wilson95"][1],
+            )
+
+    def test_three_cases_are_rejected_before_evaluation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory), count=3)
+            with self.assertRaisesRegex(ValueError, "at least four"):
+                held.load_manifest(manifest, require_trusted=False)
+
+    def test_direct_non_calibration_execution_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root)
+            binary = root / "foxguard"
+            binary.write_bytes(b"not executed")
+            producer = identity()
+            producer["binaryDigest"] = held.sha256_file(binary)
+            with self.assertRaisesRegex(ValueError, "controller sandbox broker"):
+                held.evaluate_arm(
+                    arm_id="champion",
+                    binary=binary,
+                    producer=producer,
+                    manifest_path=manifest,
+                    results_dir=root / "results",
+                    timeout_seconds=1,
+                    require_trusted=False,
+                )
+
+    def test_calibration_corpus_can_never_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory), calibration=True)
+            value = artifact(manifest)
+            held.validate_artifact(value, manifest, require_trusted=False)
+            self.assertEqual(value["decision"]["reason"], "calibration_only")
+            self.assertFalse(value["decision"]["capabilityGatePassed"])
+
+    def test_forged_aggregate_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            value["arms"]["challenger"]["score"]["detected"] = 3
+            with self.assertRaisesRegex(ValueError, "not recomputable"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_forged_decision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory), calibration=True)
+            value = artifact(manifest)
+            value["decision"]["capabilityGatePassed"] = True
+            with self.assertRaisesRegex(ValueError, "decision is not recomputable"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_capability_artifact_cannot_claim_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            value["authority"]["draftPr"] = True
+            with self.assertRaisesRegex(ValueError, "must not carry"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_identical_producers_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            value["arms"]["challenger"]["producer"] = copy.deepcopy(value["arms"]["champion"]["producer"])
+            with self.assertRaisesRegex(ValueError, "producer identities must differ"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_embedded_native_report_tamper_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            case = value["arms"]["challenger"]["cases"][0]
+            case["nativeReport"]["value"] += "AAAA"
+            with self.assertRaisesRegex(ValueError, "native report JSON"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_arm_id_cannot_escape_results_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root, calibration=True)
+            binary = root / "foxguard"
+            binary.write_bytes(b"not executed")
+            producer = identity()
+            producer["binaryDigest"] = held.sha256_file(binary)
+            with self.assertRaisesRegex(ValueError, "safe identifier"):
+                held.evaluate_arm(
+                    arm_id="../escape",
+                    binary=binary,
+                    producer=producer,
+                    manifest_path=manifest,
+                    results_dir=root / "results",
+                    timeout_seconds=1,
+                    require_trusted=False,
+                )
+
+    def test_case_substitution_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            value["arms"]["challenger"]["cases"][0]["id"] = "substituted"
+            with self.assertRaisesRegex(ValueError, "exact case ids"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_expected_finding_change_breaks_oracle_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            source = json.loads(manifest.read_text())
+            source["cases"][0]["expectedFindings"][0]["line"] = 2
+            manifest.write_bytes(held.canonical_bytes(source))
+            with self.assertRaisesRegex(ValueError, "local corpus"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
+    def test_default_manifest_policy_rejects_developer_owned_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            with self.assertRaisesRegex(ValueError, "root-owned"):
+                held.load_manifest(manifest.resolve())
+
+    def test_trusted_manifest_rejects_symlinked_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            real = root / "real"
+            real.mkdir()
+            manifest = write_manifest(real)
+            alias = root / "alias"
+            alias.symlink_to(real, target_is_directory=True)
+            with self.assertRaisesRegex(ValueError, "canonical.*symlink"):
+                held.require_private_manifest(alias / manifest.name)
+
+    def test_artifact_reference_binds_exact_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root)
+            output = root / "evidence.json"
+            output.write_bytes(held.canonical_bytes(artifact(manifest)))
+            before = held.artifact_ref(output)
+            output.write_bytes(output.read_bytes() + b" ")
+            self.assertNotEqual(before, held.artifact_ref(output))
+
+    def test_fixture_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "outside").write_text("secret")
+            fixture = root / "fixture"
+            fixture.mkdir()
+            (fixture / "link").symlink_to(root / "outside")
+            with self.assertRaisesRegex(ValueError, "must not contain symlinks"):
+                held.directory_digest(fixture)
+
+    def test_duplicate_findings_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unique"):
+            held.canonical_findings([finding(), copy.deepcopy(finding())], "findings")
+
+    def test_native_report_binds_exact_target_and_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture"
+            fixture.mkdir()
+            (fixture / "fixture.py").write_text("dangerous(value)\n")
+            self.assertEqual(held.normalize_native_findings(native_report(fixture), fixture), [finding()])
+            wrong_target = native_report(fixture)
+            wrong_target["target"]["path"] = str(fixture.parent)
+            with self.assertRaisesRegex(ValueError, "target"):
+                held.normalize_native_findings(wrong_target, fixture)
+            wrong_count = native_report(fixture)
+            wrong_count["finding_counts"]["total"] = 2
+            with self.assertRaisesRegex(ValueError, "counts"):
+                held.normalize_native_findings(wrong_count, fixture)
+
+    def test_duplicate_native_findings_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture"
+            fixture.mkdir()
+            (fixture / "fixture.py").write_text("dangerous(value)\n")
+            report = native_report(fixture)
+            report["findings"].append(copy.deepcopy(report["findings"][0]))
+            report["finding_counts"]["total"] = 2
+            report["finding_counts"]["by_severity"]["high"] = 2
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                held.normalize_native_findings(report, fixture)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/held-out-capability-v1/test_held_out.py
+++ b/benchmarks/held-out-capability-v1/test_held_out.py
@@ -246,7 +246,7 @@ class HeldOutTests(unittest.TestCase):
             value = artifact(manifest)
             case = value["arms"]["challenger"]["cases"][0]
             case["nativeReport"]["value"] += "AAAA"
-            with self.assertRaisesRegex(ValueError, "native report JSON"):
+            with self.assertRaisesRegex(ValueError, r"native report (encoding|JSON)"):
                 held.validate_artifact(value, manifest, require_trusted=False)
 
     def test_arm_id_cannot_escape_results_directory(self) -> None:

--- a/benchmarks/held-out-capability-v1/test_source_change.py
+++ b/benchmarks/held-out-capability-v1/test_source_change.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("source_change.py")
+SPEC = importlib.util.spec_from_file_location("source_change", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+change = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(change)
+
+
+def command(root: Path, *args: str) -> str:
+    process = subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True)
+    if process.returncode:
+        raise RuntimeError(process.stderr)
+    return process.stdout.strip()
+
+
+def commit(root: Path, message: str) -> str:
+    env = dict(os.environ)
+    env.update({
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.invalid",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.invalid",
+    })
+    process = subprocess.run(
+        ["git", "-C", str(root), "commit", "-m", message],
+        capture_output=True, text=True, env=env,
+    )
+    if process.returncode:
+        raise RuntimeError(process.stderr)
+    return command(root, "rev-parse", "HEAD")
+
+
+class RepositoryFixture:
+    def __init__(self, root: Path) -> None:
+        self.head = root / "head"
+        self.base = root / "base"
+        self.head.mkdir()
+        command(self.head, "init")
+        command(self.head, "remote", "add", "origin", "https://github.com/0sec-labs/foxguard.git")
+        (self.head / "src" / "rules").mkdir(parents=True)
+        (self.head / "Cargo.toml").write_text('[package]\nname = "fixture"\nversion = "0.1.0"\n')
+        (self.head / "Cargo.lock").write_text("# lock\n")
+        (self.head / "src" / "rules" / "example.rs").write_text("const RULE: u8 = 1;\n")
+        command(self.head, "add", ".")
+        self.base_sha = commit(self.head, "base")
+        (self.head / "src" / "rules" / "example.rs").write_text("const RULE: u8 = 2;\n")
+        (self.head / "tests").mkdir()
+        (self.head / "tests" / "example.rs").write_text("// regression\n")
+        command(self.head, "add", ".")
+        self.head_sha = commit(self.head, "head")
+        command(self.head, "worktree", "add", "--detach", str(self.base), self.base_sha)
+        self.champion = root / "champion"
+        self.challenger = root / "challenger"
+        self.champion.write_bytes(b"champion")
+        self.challenger.write_bytes(b"challenger")
+        head_identity = change.commit_identity(self.head)
+        self.receipt = root / "receipt.json"
+        self.receipt.write_bytes(change.canonical_bytes({
+            "conclusion": "success",
+            "headCommitSha": head_identity["commitSha"],
+            "headTreeOid": head_identity["gitTreeOid"],
+            "repository": change.REPOSITORY,
+            "runId": "12345",
+            "workflowRef": f"0sec-labs/foxguard/.github/workflows/ci.yml@{self.head_sha}",
+        }))
+
+    def args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            base_source_root=self.base,
+            candidate_id="candidate-1",
+            challenger_binary=self.challenger,
+            champion_binary=self.champion,
+            ci_receipt=self.receipt,
+            head_source_root=self.head,
+        )
+
+
+class SourceChangeTests(unittest.TestCase):
+    def test_exact_patch_reproduces_head_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            change.validate_descriptor(value, repository_root=fixture.base)
+            self.assertEqual(value["patch"]["changedPaths"], [
+                "src/rules/example.rs", "tests/example.rs",
+            ])
+            self.assertEqual(value["head"]["commitSha"], fixture.head_sha)
+
+    def test_patch_byte_change_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            value["patch"]["value"] += "AAAA"
+            with self.assertRaisesRegex(ValueError, "encoding|digest"):
+                change.validate_descriptor(value)
+
+    def test_ci_receipt_must_bind_exact_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            value["ciReceipt"]["headCommitSha"] = fixture.base_sha
+            with self.assertRaisesRegex(ValueError, "exact head"):
+                change.validate_descriptor(value)
+
+    def test_ci_receipt_must_name_exact_main_workflow_at_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            value["ciReceipt"]["workflowRef"] = (
+                f"0sec-labs/foxguard/.github/workflows/lookalike.yml@{fixture.head_sha}"
+            )
+            with self.assertRaisesRegex(ValueError, "exact head"):
+                change.validate_descriptor(value)
+
+    def test_candidate_change_digest_is_recomputed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            value["candidateChangeDigest"] = f"sha256:{'0' * 64}"
+            with self.assertRaisesRegex(ValueError, "not recomputable"):
+                change.validate_descriptor(value)
+
+    def test_descriptor_cannot_claim_verified_build_or_ci(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = RepositoryFixture(Path(directory))
+            value = change.build_descriptor(fixture.args())
+            value["provenance"]["ciVerified"] = True
+            with self.assertRaisesRegex(ValueError, "must not claim"):
+                change.validate_descriptor(value)
+
+    def test_non_rule_candidate_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = RepositoryFixture(root)
+            command(fixture.head, "reset", "--hard", fixture.base_sha)
+            (fixture.head / "README.md").write_text("outside profile\n")
+            command(fixture.head, "add", ".")
+            fixture.head_sha = commit(fixture.head, "outside")
+            head_identity = change.commit_identity(fixture.head)
+            fixture.receipt.write_bytes(change.canonical_bytes({
+                "conclusion": "success",
+                "headCommitSha": head_identity["commitSha"],
+                "headTreeOid": head_identity["gitTreeOid"],
+                "repository": change.REPOSITORY,
+                "runId": "12346",
+                "workflowRef": f"0sec-labs/foxguard/.github/workflows/ci.yml@{fixture.head_sha}",
+            }))
+            with self.assertRaisesRegex(ValueError, "outside the first Foxguard profile"):
+                change.build_descriptor(fixture.args())
+
+    def test_symlink_rule_change_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = RepositoryFixture(root)
+            command(fixture.head, "reset", "--hard", fixture.base_sha)
+            (fixture.head / "src" / "rules" / "link.rs").symlink_to("../../../outside")
+            command(fixture.head, "add", ".")
+            fixture.head_sha = commit(fixture.head, "symlink")
+            head_identity = change.commit_identity(fixture.head)
+            fixture.receipt.write_bytes(change.canonical_bytes({
+                "conclusion": "success",
+                "headCommitSha": head_identity["commitSha"],
+                "headTreeOid": head_identity["gitTreeOid"],
+                "repository": change.REPOSITORY,
+                "runId": "12347",
+                "workflowRef": f"0sec-labs/foxguard/.github/workflows/ci.yml@{fixture.head_sha}",
+            }))
+            with self.assertRaisesRegex(ValueError, "regular Git blobs"):
+                change.build_descriptor(fixture.args())
+
+    def test_descriptor_reference_binds_exact_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = RepositoryFixture(root)
+            output = root / "descriptor.json"
+            output.write_bytes(change.canonical_bytes(change.build_descriptor(fixture.args())))
+            before = change.artifact_ref(output)
+            output.write_bytes(output.read_bytes() + b" ")
+            self.assertNotEqual(before, change.artifact_ref(output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

0research needs a positive Foxguard capability lane without weakening the sealed negative-control contracts or letting scanner evidence authorize promotion by itself.

## What

- adds `foxguard-held-out-capability-v1` with a four-case minimum and non-overlapping Wilson-95 gate
- embeds and revalidates exact native reports, execution digests, corpus/oracle bindings, and distinct producer identities
- makes direct execution calibration-only; real private execution is reserved for the controller sandbox broker
- hard-codes draft-PR, merge, and publication authority to false
- adds `foxguard-executed-source-change-v1` with exact full-index patch replay, path/status/mode restrictions, ancestry, tree/Cargo/binary identities, and exact-head CI claims
- explicitly marks CI/build provenance unverified until 0brain composes trusted receipts

## Verification

- precision metadata validation
- 16 precision tests
- 13 sealed negative-control tests
- 28 new adversarial held-out/source-change tests
- Python bytecode compilation
- Foxguard pre-commit scan
- `git diff --check`

## Deliberately not in this PR

- private non-calibration execution
- trusted build/CI receipt verification
- 0brain composite draft-PR authority
- four-case private burn-in

Those remain fail-closed and are the next gated slice.