### PR TITLE
fix(0research): bind held-out replay inputs

### DIFF
--- a/benchmarks/held-out-capability-v1/README.md
+++ b/benchmarks/held-out-capability-v1/README.md
@@ -31,6 +31,16 @@ reach the network, or access sibling/controller state. Retain its manifest,
 fixtures, raw reports, evidence, executed-change descriptor, and signatures in
 the private evidence root. Nothing here publishes, discloses, or uploads them.
 
+The native verifier captures artifact bytes once and derives both validation
+and the printed reference from that same bounded snapshot. Fixture traversal is
+descriptor-relative and capped by total files, bytes, entries, and depth before
+content is retained. Calibration executes owner-private, read-only copies made
+from that captured fixture and binary byte view, and checks their complete
+byte/identity seals before and after every scan. These controls are
+prerequisites for the private
+`foxguard-held-out-provenance-v2` custody package; the v1 evidence JSON is not
+itself self-contained, signed, or eligible for a global training corpus.
+
 `source_change.py` separately binds the candidate to clean base/head commits,
 Git tree OIDs, content-tree digests, canonical full-index binary patch bytes,
 the allowed changed paths (`src/rules/**` plus tests), both executed binaries,

--- a/benchmarks/held-out-capability-v1/held_out.py
+++ b/benchmarks/held-out-capability-v1/held_out.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 
 ROOT = Path(__file__).resolve().parent
@@ -29,6 +29,14 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 MAX_REPORT_BYTES = 8 * 1024 * 1024
 MAX_FINDINGS = 10_000
 MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
+MAX_BINARY_BYTES = 256 * 1024 * 1024
+MAX_FIXTURE_FILES = 2_000
+MAX_FIXTURE_BYTES = 384 * 1024 * 1024
+MAX_FIXTURE_ENTRIES = 4_000
+MAX_FIXTURE_DEPTH = 64
+MAX_CASES = 256
+_SCAN_DIRECTORY = os.scandir
 APPROVED_REMOTES = {
     "https://github.com/0sec-labs/foxguard",
     "https://github.com/0sec-labs/foxguard.git",
@@ -42,6 +50,24 @@ FINDING_FIELDS = {
 }
 
 
+class CapturedCorpus(NamedTuple):
+    manifest_path: Path
+    manifest_bytes: bytes
+    manifest: dict[str, Any]
+    fixtures: dict[str, tuple[tuple[Path, bytes], ...]]
+
+
+class ExecutionSnapshot(NamedTuple):
+    root: Path
+    root_identity: tuple[int, ...]
+    binary: Path
+    binary_bytes: bytes
+    binary_identity: tuple[int, ...]
+    fixtures: dict[str, Path]
+    fixture_files: dict[str, tuple[tuple[Path, bytes], ...]]
+    fixture_identities: dict[str, dict[Path, tuple[Any, ...]]]
+
+
 def canonical_bytes(value: Any) -> bytes:
     return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
 
@@ -50,8 +76,59 @@ def sha256_bytes(value: bytes) -> str:
     return f"sha256:{hashlib.sha256(value).hexdigest()}"
 
 
-def sha256_file(path: Path) -> str:
-    return sha256_bytes(path.read_bytes())
+def path_identity(path: Path) -> tuple[int, ...]:
+    info = path.lstat()
+    return (
+        info.st_dev,
+        info.st_ino,
+        info.st_mode,
+        info.st_nlink,
+        info.st_size,
+        info.st_mtime_ns,
+        info.st_ctime_ns,
+    )
+
+
+def read_stable_file(path: Path, label: str, maximum: int) -> bytes:
+    descriptor = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+    )
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size < 1
+            or before.st_size > maximum
+        ):
+            raise ValueError(f"{label} must be a bounded single-link regular file")
+        chunks: list[bytes] = []
+        total = 0
+        while chunk := os.read(descriptor, min(1024 * 1024, maximum + 1)):
+            total += len(chunk)
+            if total > maximum:
+                raise ValueError(f"{label} exceeds its byte limit")
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+        identity = lambda info: (
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_nlink,
+            info.st_size,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+        if identity(before) != identity(after) or total != before.st_size:
+            raise ValueError(f"{label} changed while it was read")
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def sha256_file(path: Path, maximum: int = MAX_BINARY_BYTES) -> str:
+    return sha256_bytes(read_stable_file(path, "hashed file", maximum))
 
 
 def write_new_private(path: Path, data: bytes) -> None:
@@ -84,25 +161,172 @@ def read_stable_report(path: Path) -> bytes:
         os.close(descriptor)
 
 
+def capture_directory(
+    root: Path,
+    *,
+    require_trusted: bool = False,
+    corpus_budget: dict[str, int] | None = None,
+    identity_view: dict[Path, tuple[Any, ...]] | None = None,
+) -> list[tuple[Path, bytes]]:
+    requested = root.resolve(strict=True)
+    if root.is_symlink():
+        raise ValueError("held-out fixture path must not be a symlink")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    files: list[tuple[Path, bytes]] = []
+    entries = 0
+    total_bytes = 0
+
+    def trusted(info: os.stat_result, label: str) -> None:
+        if require_trusted and (info.st_uid != 0 or info.st_mode & 0o022):
+            raise ValueError(
+                f"held-out fixture must be root-owned and immutable to the evaluator: {label}"
+            )
+
+    def directory_identity(info: os.stat_result) -> tuple[int, ...]:
+        return (
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_nlink,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+
+    def file_identity(info: os.stat_result) -> tuple[int, ...]:
+        return (*directory_identity(info), info.st_size)
+
+    def walk(directory: int, prefix: Path, depth: int) -> None:
+        nonlocal entries, total_bytes
+        if depth > MAX_FIXTURE_DEPTH:
+            raise ValueError("held-out fixture exceeds its depth limit")
+        opened = os.fstat(directory)
+        trusted(opened, str(requested / prefix))
+        names: list[str] = []
+        # The input is a pinned directory descriptor, never a filesystem path.
+        with _SCAN_DIRECTORY(directory) as iterator:
+            for entry in iterator:
+                entries += 1
+                if entries > MAX_FIXTURE_ENTRIES:
+                    raise ValueError("held-out fixture exceeds its entry limit")
+                if corpus_budget is not None:
+                    corpus_budget["entries"] += 1
+                    if corpus_budget["entries"] > MAX_FIXTURE_ENTRIES:
+                        raise ValueError("held-out corpus exceeds its entry limit")
+                name = entry.name
+                if name in {"", ".", ".."} or "/" in name or "\0" in name:
+                    raise ValueError("held-out fixture contains an unsafe entry name")
+                names.append(name)
+        for name in sorted(names):
+            relative = prefix / name
+            info = os.stat(name, dir_fd=directory, follow_symlinks=False)
+            if stat.S_ISLNK(info.st_mode):
+                raise ValueError(f"held-out fixture must not contain symlinks: {relative}")
+            trusted(info, str(requested / relative))
+            if stat.S_ISDIR(info.st_mode):
+                child = os.open(name, flags, dir_fd=directory)
+                try:
+                    child_info = os.fstat(child)
+                    if directory_identity(info) != directory_identity(child_info):
+                        raise ValueError("held-out fixture directory changed while opened")
+                    walk(child, relative, depth + 1)
+                    after = os.fstat(child)
+                    if directory_identity(child_info) != directory_identity(after):
+                        raise ValueError("held-out fixture directory changed while read")
+                finally:
+                    os.close(child)
+                continue
+            if not stat.S_ISREG(info.st_mode):
+                raise ValueError("held-out fixture contains an unsupported entry")
+            if len(files) >= MAX_FIXTURE_FILES:
+                raise ValueError("held-out fixture exceeds its file limit")
+            if (
+                corpus_budget is not None
+                and corpus_budget["files"] >= MAX_FIXTURE_FILES
+            ):
+                raise ValueError("held-out corpus exceeds its file limit")
+            if info.st_size > MAX_FIXTURE_BYTES - total_bytes:
+                raise ValueError("held-out fixture exceeds its aggregate byte limit")
+            if (
+                corpus_budget is not None
+                and info.st_size > MAX_FIXTURE_BYTES - corpus_budget["bytes"]
+            ):
+                raise ValueError("held-out corpus exceeds its aggregate byte limit")
+            descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=directory,
+            )
+            try:
+                actual = os.fstat(descriptor)
+                if file_identity(info) != file_identity(actual):
+                    raise ValueError("held-out fixture file changed while opened")
+                chunks: list[bytes] = []
+                remaining = MAX_FIXTURE_BYTES - total_bytes
+                if corpus_budget is not None:
+                    remaining = min(
+                        remaining, MAX_FIXTURE_BYTES - corpus_budget["bytes"]
+                    )
+                while chunk := os.read(descriptor, min(1024 * 1024, remaining + 1)):
+                    remaining -= len(chunk)
+                    if remaining < 0:
+                        raise ValueError("held-out fixture exceeds its aggregate byte limit")
+                    chunks.append(chunk)
+                after = os.fstat(descriptor)
+                data = b"".join(chunks)
+                if file_identity(actual) != file_identity(after) or len(data) != actual.st_size:
+                    raise ValueError("held-out fixture file changed while read")
+            finally:
+                os.close(descriptor)
+            total_bytes += len(data)
+            if corpus_budget is not None:
+                corpus_budget["files"] += 1
+                corpus_budget["bytes"] += len(data)
+            files.append((relative, data))
+            if identity_view is not None:
+                identity_view[relative] = ("file", *file_identity(after))
+        finished = os.fstat(directory)
+        if directory_identity(opened) != directory_identity(finished):
+            raise ValueError("held-out fixture directory changed while read")
+        if identity_view is not None:
+            identity_view[prefix] = ("directory", *directory_identity(finished))
+
+    root_descriptor = os.open(requested, flags)
+    try:
+        before = os.fstat(root_descriptor)
+        walk(root_descriptor, Path(), 0)
+        after = os.fstat(root_descriptor)
+        if directory_identity(before) != directory_identity(after):
+            raise ValueError("held-out fixture root changed while read")
+    finally:
+        os.close(root_descriptor)
+    return files
+
+
 def relative_files(root: Path) -> list[Path]:
-    files = []
-    for path in root.rglob("*"):
-        if path.is_symlink():
-            raise ValueError(f"held-out fixture must not contain symlinks: {path}")
-        if path.is_file():
-            files.append(path)
-    return sorted(files, key=lambda path: path.relative_to(root).as_posix())
+    return [root / relative for relative, _ in capture_directory(root)]
 
 
-def directory_digest(root: Path) -> str:
+def captured_directory_digest(files: list[tuple[Path, bytes]]) -> str:
     digest = hashlib.sha256()
     digest.update(b"foxguard-held-out-capability-directory-v1\0")
-    for path in relative_files(root):
-        name = path.relative_to(root).as_posix().encode()
-        data = path.read_bytes()
+    for relative, data in files:
+        name = relative.as_posix().encode()
         digest.update(len(name).to_bytes(8, "big") + name)
         digest.update(len(data).to_bytes(8, "big") + data)
     return f"sha256:{digest.hexdigest()}"
+
+
+def directory_digest(root: Path, *, require_trusted: bool = False) -> str:
+    return captured_directory_digest(
+        capture_directory(root, require_trusted=require_trusted)
+    )
 
 
 def require_private_manifest(path: Path) -> None:
@@ -131,27 +355,11 @@ def require_private_manifest(path: Path) -> None:
 def read_manifest_bytes(path: Path, *, require_trusted: bool) -> bytes:
     if require_trusted:
         require_private_manifest(path)
-    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-    try:
-        before = os.fstat(descriptor)
-        if not stat.S_ISREG(before.st_mode) or before.st_size > MAX_MANIFEST_BYTES:
-            raise ValueError("held-out manifest must be a bounded regular file")
-        with os.fdopen(descriptor, "rb", closefd=False) as handle:
-            data = handle.read(MAX_MANIFEST_BYTES + 1)
-        after = os.fstat(descriptor)
-        if len(data) > MAX_MANIFEST_BYTES or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
-            raise ValueError("held-out manifest changed while it was being read")
-        return data
-    finally:
-        os.close(descriptor)
+    return read_stable_file(path, "held-out manifest", MAX_MANIFEST_BYTES)
 
 
 def require_immutable_fixture(root: Path) -> None:
-    paths = [root, *sorted(root.rglob("*"))]
-    for path in paths:
-        metadata = path.stat()
-        if metadata.st_uid != 0 or metadata.st_mode & 0o022:
-            raise ValueError(f"held-out fixture must be root-owned and immutable to the evaluator: {path}")
+    capture_directory(root, require_trusted=True)
 
 
 def validate_finding(value: Any, label: str) -> dict[str, Any]:
@@ -181,8 +389,10 @@ def canonical_findings(values: Any, label: str) -> list[dict[str, Any]]:
     return findings
 
 
-def load_manifest(path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
-    value = json.loads(read_manifest_bytes(path, require_trusted=require_trusted))
+def capture_corpus(path: Path, *, require_trusted: bool = True) -> CapturedCorpus:
+    manifest_path = path.resolve(strict=True)
+    manifest_bytes = read_manifest_bytes(path, require_trusted=require_trusted)
+    value = json.loads(manifest_bytes)
     expected = {"calibration", "cases", "id", "requireSignificance", "schemaVersion"}
     if not isinstance(value, dict) or set(value) != expected or value["schemaVersion"] != 1:
         raise ValueError("manifest schema has unsupported or missing fields")
@@ -193,7 +403,11 @@ def load_manifest(path: Path, *, require_trusted: bool = True) -> dict[str, Any]
     cases = value["cases"]
     if not isinstance(cases, list) or len(cases) < 4:
         raise ValueError("held-out capability corpus requires at least four cases")
+    if len(cases) > MAX_CASES:
+        raise ValueError(f"held-out capability corpus exceeds its {MAX_CASES}-case limit")
     ids = []
+    corpus_budget = {"entries": 0, "files": 0, "bytes": 0}
+    fixtures: dict[str, tuple[tuple[Path, bytes], ...]] = {}
     for index, case in enumerate(cases):
         fields = {"expectedFindings", "fixtureDigest", "id", "knownPositive", "oracleRef", "path"}
         if not isinstance(case, dict) or set(case) != fields:
@@ -206,30 +420,47 @@ def load_manifest(path: Path, *, require_trusted: bool = True) -> dict[str, Any]
         candidate = Path(relative)
         if candidate.is_absolute() or ".." in candidate.parts:
             raise ValueError(f"manifest case {index} path is unsafe")
-        fixture = (path.parent / candidate).resolve()
+        fixture = (manifest_path.parent / candidate).resolve()
         try:
-            fixture.relative_to(path.parent.resolve())
+            fixture.relative_to(manifest_path.parent)
         except ValueError as exc:
             raise ValueError(f"manifest case {index} escapes the corpus") from exc
-        if not fixture.is_dir() or not relative_files(fixture):
+        if not fixture.is_dir():
             raise ValueError(f"manifest case {index} fixture is missing or empty")
-        if require_trusted:
-            require_immutable_fixture(fixture)
-        if case["fixtureDigest"] != directory_digest(fixture):
+        captured = capture_directory(
+            fixture,
+            require_trusted=require_trusted,
+            corpus_budget=corpus_budget,
+        )
+        if not captured:
+            raise ValueError(f"manifest case {index} fixture is missing or empty")
+        if case["fixtureDigest"] != captured_directory_digest(captured):
             raise ValueError(f"manifest case {index} fixture digest does not match bytes")
         canonical_findings(case["expectedFindings"], f"manifest case {index} expectedFindings")
         ids.append(case_id)
+        fixtures[case_id] = tuple(captured)
     if ids != sorted(ids) or len(ids) != len(set(ids)):
         raise ValueError("manifest case ids must be unique and sorted")
-    return value
+    return CapturedCorpus(manifest_path, manifest_bytes, value, fixtures)
 
 
-def corpus_binding(path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
-    manifest = load_manifest(path, require_trusted=require_trusted)
+def load_manifest(path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
+    return capture_corpus(path, require_trusted=require_trusted).manifest
+
+
+def corpus_binding(
+    source: Path | CapturedCorpus, *, require_trusted: bool = True
+) -> dict[str, Any]:
+    captured = (
+        source
+        if isinstance(source, CapturedCorpus)
+        else capture_corpus(source, require_trusted=require_trusted)
+    )
+    manifest = captured.manifest
     bound = {
         "calibration": manifest["calibration"],
         "id": manifest["id"],
-        "manifestDigest": sha256_bytes(read_manifest_bytes(path, require_trusted=require_trusted)),
+        "manifestDigest": sha256_bytes(captured.manifest_bytes),
         "cases": [
             {"fixtureDigest": case["fixtureDigest"], "id": case["id"], "oracleRef": case["oracleRef"]}
             for case in manifest["cases"]
@@ -442,24 +673,188 @@ def score(cases: list[dict[str, Any]]) -> dict[str, Any]:
     return {"cases": len(cases), "detected": detected, "detectionRate": detected / len(cases), "wilson95": wilson_interval(detected, len(cases))}
 
 
-def evaluate_arm(*, arm_id: str, binary: Path, producer: dict[str, str], manifest_path: Path, results_dir: Path, timeout_seconds: int, require_trusted: bool = True) -> dict[str, Any]:
+def prepare_execution_snapshot(
+    captured: CapturedCorpus,
+    binary: Path,
+    binary_digest: str,
+    root: Path,
+) -> ExecutionSnapshot:
+    if root.exists() or root.is_symlink():
+        raise ValueError("execution snapshot path must not already exist")
+    root.parent.mkdir(parents=True, exist_ok=True)
+    root.mkdir(mode=0o700)
+    binary_bytes = read_stable_file(binary, "executed Foxguard binary", MAX_BINARY_BYTES)
+    if sha256_bytes(binary_bytes) != binary_digest:
+        raise ValueError("executed Foxguard binary does not match producer identity")
+    snapshot_binary = root / "foxguard"
+    write_new_private(snapshot_binary, binary_bytes)
+    snapshot_binary.chmod(0o500)
+    fixtures_root = root / "fixtures"
+    fixtures_root.mkdir(mode=0o700)
+    fixture_paths: dict[str, Path] = {}
+    fixture_files: dict[str, tuple[tuple[Path, bytes], ...]] = {}
+    fixture_identities: dict[str, dict[Path, tuple[Any, ...]]] = {}
+    for case in captured.manifest["cases"]:
+        case_id = case["id"]
+        destination = fixtures_root / case_id
+        destination.mkdir(mode=0o700)
+        for relative, data in captured.fixtures[case_id]:
+            write_new_private(destination / relative, data)
+        directories = [
+            path for path in destination.rglob("*") if path.is_dir()
+        ]
+        for path in sorted(directories, key=lambda item: len(item.parts), reverse=True):
+            path.chmod(0o500)
+        for path in destination.rglob("*"):
+            if path.is_file():
+                path.chmod(0o400)
+        destination.chmod(0o500)
+        identities: dict[Path, tuple[Any, ...]] = {}
+        files = tuple(capture_directory(destination, identity_view=identities))
+        expected = captured.fixtures[case_id]
+        if files != expected:
+            raise ValueError("execution fixture snapshot does not match captured bytes")
+        fixture_paths[case_id] = destination
+        fixture_files[case_id] = files
+        fixture_identities[case_id] = identities
+    fixtures_root.chmod(0o500)
+    root.chmod(0o500)
+    return ExecutionSnapshot(
+        root=root,
+        root_identity=path_identity(root),
+        binary=snapshot_binary,
+        binary_bytes=binary_bytes,
+        binary_identity=path_identity(snapshot_binary),
+        fixtures=fixture_paths,
+        fixture_files=fixture_files,
+        fixture_identities=fixture_identities,
+    )
+
+
+def assert_execution_snapshot(snapshot: ExecutionSnapshot) -> None:
+    if path_identity(snapshot.root) != snapshot.root_identity:
+        raise ValueError("execution snapshot root changed during evaluation")
+    if (
+        path_identity(snapshot.binary) != snapshot.binary_identity
+        or read_stable_file(
+            snapshot.binary, "executed Foxguard binary", MAX_BINARY_BYTES
+        )
+        != snapshot.binary_bytes
+    ):
+        raise ValueError("executed Foxguard binary changed during evaluation")
+    for case_id, fixture in snapshot.fixtures.items():
+        identities: dict[Path, tuple[Any, ...]] = {}
+        files = tuple(capture_directory(fixture, identity_view=identities))
+        if (
+            files != snapshot.fixture_files[case_id]
+            or identities != snapshot.fixture_identities[case_id]
+        ):
+            raise ValueError("execution fixture snapshot changed during evaluation")
+
+
+def expected_entry_identity(
+    path: Path, expected: tuple[Any, ...]
+) -> tuple[Any, ...]:
+    info = path.lstat()
+    if expected[0] == "directory":
+        return (
+            "directory",
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_nlink,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+    return (
+        "file",
+        info.st_dev,
+        info.st_ino,
+        info.st_mode,
+        info.st_nlink,
+        info.st_mtime_ns,
+        info.st_ctime_ns,
+        info.st_size,
+    )
+
+
+def assert_execution_metadata(snapshot: ExecutionSnapshot) -> None:
+    if (
+        path_identity(snapshot.root) != snapshot.root_identity
+        or path_identity(snapshot.binary) != snapshot.binary_identity
+    ):
+        raise ValueError("execution snapshot metadata changed during evaluation")
+    for case_id, fixture in snapshot.fixtures.items():
+        for relative, expected in snapshot.fixture_identities[case_id].items():
+            path = fixture if relative == Path() else fixture / relative
+            if expected_entry_identity(path, expected) != expected:
+                raise ValueError("execution snapshot metadata changed during evaluation")
+
+
+def assert_execution_case(snapshot: ExecutionSnapshot, case_id: str) -> None:
+    assert_execution_metadata(snapshot)
+    identities: dict[Path, tuple[Any, ...]] = {}
+    files = tuple(
+        capture_directory(snapshot.fixtures[case_id], identity_view=identities)
+    )
+    if (
+        files != snapshot.fixture_files[case_id]
+        or identities != snapshot.fixture_identities[case_id]
+    ):
+        raise ValueError("execution fixture snapshot changed during evaluation")
+
+
+def evaluate_arm(
+    *,
+    arm_id: str,
+    binary: Path,
+    producer: dict[str, str],
+    manifest_path: Path,
+    results_dir: Path,
+    timeout_seconds: int,
+    require_trusted: bool = True,
+    captured_corpus: CapturedCorpus | None = None,
+    evidence_budget: dict[str, int] | None = None,
+) -> dict[str, Any]:
     if not SAFE_ID_RE.fullmatch(arm_id):
         raise ValueError("arm id must be a safe identifier")
     producer = validate_producer(producer, arm_id)
     if sha256_file(binary) != producer["binaryDigest"]:
         raise ValueError(f"{arm_id} binary bytes do not match producer identity")
-    manifest = load_manifest(manifest_path, require_trusted=require_trusted)
+    captured = captured_corpus or capture_corpus(
+        manifest_path, require_trusted=require_trusted
+    )
+    manifest = captured.manifest
     if manifest["calibration"] is not True:
         raise ValueError("direct execution is calibration-only; production execution requires the controller sandbox broker")
+    snapshot = prepare_execution_snapshot(
+        captured,
+        binary,
+        producer["binaryDigest"],
+        results_dir / f".{arm_id}-execution-inputs",
+    )
     cases = []
+    retained_budget = evidence_budget if evidence_budget is not None else {"bytes": 0}
+    assert_execution_snapshot(snapshot)
     for item in manifest["cases"]:
-        fixture = manifest_path.parent / item["path"]
+        fixture = snapshot.fixtures[item["id"]]
+        assert_execution_case(snapshot, item["id"])
         report_bytes, exit_code = scan_case(
-            binary, fixture, results_dir / f"{arm_id}-{item['id']}.json", timeout_seconds,
+            snapshot.binary,
+            fixture,
+            results_dir / f"{arm_id}-{item['id']}.json",
+            timeout_seconds,
         )
-        cases.append(make_case(
+        assert_execution_case(snapshot, item["id"])
+        case = make_case(
             item, report_bytes, producer["binaryDigest"], exit_code, fixture,
-        ))
+        )
+        retained = retained_budget["bytes"] + len(canonical_bytes(case))
+        if retained > MAX_ARTIFACT_BYTES * 3 // 4:
+            raise ValueError("generated evidence exceeds its retained byte budget")
+        retained_budget["bytes"] = retained
+        cases.append(case)
+    assert_execution_snapshot(snapshot)
     return {"cases": cases, "id": arm_id, "producer": producer, "score": score(cases)}
 
 
@@ -467,16 +862,25 @@ def evaluator_digest() -> str:
     return sha256_bytes(b"foxguard-held-out-capability-evaluator-v1\0" + Path(__file__).read_bytes())
 
 
-def validate_artifact(value: Any, manifest_path: Path, *, require_trusted: bool = True) -> dict[str, Any]:
+def validate_artifact(
+    value: Any,
+    manifest_path: Path,
+    *,
+    require_trusted: bool = True,
+    captured_corpus: CapturedCorpus | None = None,
+) -> dict[str, Any]:
     fields = {"arms", "authority", "candidateId", "contract", "corpus", "decision", "evaluatorDigest", "schemaVersion"}
     if not isinstance(value, dict) or set(value) != fields or value["schemaVersion"] != 1 or value["contract"] != CONTRACT:
         raise ValueError("artifact schema or contract is invalid")
     if not isinstance(value["candidateId"], str) or not SAFE_ID_RE.fullmatch(value["candidateId"]):
         raise ValueError("candidateId is invalid")
-    corpus = corpus_binding(manifest_path, require_trusted=require_trusted)
+    captured = captured_corpus or capture_corpus(
+        manifest_path, require_trusted=require_trusted
+    )
+    corpus = corpus_binding(captured)
     if value["corpus"] != corpus or value["evaluatorDigest"] != evaluator_digest():
         raise ValueError("artifact does not bind the local corpus and evaluator")
-    manifest = load_manifest(manifest_path, require_trusted=require_trusted)
+    manifest = captured.manifest
     ids = [case["id"] for case in manifest["cases"]]
     arms = value["arms"]
     if not isinstance(arms, dict) or set(arms) != {"champion", "challenger"}:
@@ -510,12 +914,39 @@ def validate_artifact(value: Any, manifest_path: Path, *, require_trusted: bool 
                 report_bytes = base64.b64decode(native["value"], validate=True)
             except (ValueError, TypeError) as exc:
                 raise ValueError(f"{label} case {index} native report encoding is invalid") from exc
+            try:
+                native_value = json.loads(report_bytes)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{label} case {index} native report JSON is invalid"
+                ) from exc
+            try:
+                execution_target = Path(native_value["target"]["path"])
+            except (KeyError, TypeError) as exc:
+                raise ValueError(
+                    f"{label} case {index} native report target is invalid"
+                ) from exc
+            if not execution_target.is_absolute():
+                raise ValueError(f"{label} case {index} native report target is invalid")
+            source_target = captured.manifest_path.parent / item["path"]
+            snapshot_suffix = (
+                f".{arm['id']}-execution-inputs",
+                "fixtures",
+                item["id"],
+            )
+            if (
+                execution_target.resolve() != source_target.resolve()
+                and tuple(execution_target.parts[-3:]) != snapshot_suffix
+            ):
+                raise ValueError(
+                    f"{label} case {index} native report target does not bind the expected arm and case"
+                )
             execution = case["execution"]
             if not isinstance(execution, dict) or set(execution) != {"binaryDigest", "exitCode", "fixtureDigest", "invocationDigest", "reportDigest"}:
                 raise ValueError(f"{label} case {index} execution receipt is invalid")
             rebuilt.append(make_case(
                 item, report_bytes, arm["producer"]["binaryDigest"],
-                execution["exitCode"], manifest_path.parent / item["path"],
+                execution["exitCode"], execution_target,
             ))
         if arm["cases"] != rebuilt or arm["score"] != score(rebuilt):
             raise ValueError(f"{label} verdict or score is not recomputable")
@@ -535,7 +966,15 @@ def validate_artifact(value: Any, manifest_path: Path, *, require_trusted: bool 
 
 
 def artifact_ref(path: Path) -> str:
-    return f"foxguard-held-out-capability-v1:{sha256_file(path)}"
+    return artifact_ref_bytes(
+        read_stable_file(path, "held-out capability artifact", MAX_ARTIFACT_BYTES)
+    )
+
+
+def artifact_ref_bytes(data: bytes) -> str:
+    if not 0 < len(data) <= MAX_ARTIFACT_BYTES:
+        raise ValueError("held-out capability artifact exceeds its byte limit")
+    return f"foxguard-held-out-capability-v1:{sha256_bytes(data)}"
 
 
 def run_command(args: argparse.Namespace) -> int:
@@ -544,39 +983,55 @@ def run_command(args: argparse.Namespace) -> int:
     if args.results_dir.exists() and any(args.results_dir.iterdir()):
         raise ValueError("results directory must be absent or empty")
     args.results_dir.mkdir(parents=True, exist_ok=True)
-    manifest = load_manifest(args.manifest, require_trusted=False)
+    captured = capture_corpus(args.manifest, require_trusted=False)
+    manifest = captured.manifest
     if manifest["calibration"] is not True:
         raise ValueError("direct execution is calibration-only; production execution requires the controller sandbox broker")
     champion = producer_from_paths(args.champion_source_root, args.champion_binary)
     challenger = producer_from_paths(args.challenger_source_root, args.challenger_binary)
+    evidence_budget = {"bytes": 0}
     arms = {
-        "champion": evaluate_arm(arm_id=args.champion_id, binary=args.champion_binary, producer=champion, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False),
-        "challenger": evaluate_arm(arm_id=args.challenger_id, binary=args.challenger_binary, producer=challenger, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False),
+        "champion": evaluate_arm(arm_id=args.champion_id, binary=args.champion_binary, producer=champion, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False, captured_corpus=captured, evidence_budget=evidence_budget),
+        "challenger": evaluate_arm(arm_id=args.challenger_id, binary=args.challenger_binary, producer=challenger, manifest_path=args.manifest, results_dir=args.results_dir, timeout_seconds=args.timeout_seconds, require_trusted=False, captured_corpus=captured, evidence_budget=evidence_budget),
     }
     significant = arms["challenger"]["score"]["wilson95"][0] > arms["champion"]["score"]["wilson95"][1]
     calibration = manifest["calibration"]
     value = {
         "schemaVersion": 1, "contract": CONTRACT, "candidateId": args.candidate_id,
-        "corpus": corpus_binding(args.manifest, require_trusted=False), "evaluatorDigest": evaluator_digest(), "arms": arms,
+        "corpus": corpus_binding(captured), "evaluatorDigest": evaluator_digest(), "arms": arms,
         "authority": {"draftPr": False, "merge": False, "publish": False},
         "decision": {"capabilityGatePassed": significant and not calibration, "reason": "significant_improvement" if significant and not calibration else ("calibration_only" if calibration else "not_significant"), "significant": significant},
     }
     if producer_from_paths(args.champion_source_root, args.champion_binary) != champion or producer_from_paths(args.challenger_source_root, args.challenger_binary) != challenger:
         raise ValueError("producer bytes changed during evaluation")
-    validate_artifact(value, args.manifest, require_trusted=False)
-    write_new_private(args.output, canonical_bytes(value))
-    print(artifact_ref(args.output))
+    validate_artifact(
+        value, args.manifest, require_trusted=False, captured_corpus=captured
+    )
+    artifact_bytes = canonical_bytes(value)
+    retained_ref = artifact_ref_bytes(artifact_bytes)
+    write_new_private(args.output, artifact_bytes)
+    print(retained_ref)
     return 0
 
 
 def verify_command(args: argparse.Namespace) -> int:
-    manifest = load_manifest(args.manifest, require_trusted=False)
+    captured = capture_corpus(args.manifest, require_trusted=False)
+    manifest = captured.manifest
     if manifest["calibration"] is not True:
         raise ValueError("this verifier is calibration-only; production verification belongs to the controller composite")
-    validate_artifact(json.loads(args.artifact.read_text()), args.manifest, require_trusted=False)
-    if args.ref and args.ref != artifact_ref(args.artifact):
+    artifact_bytes = read_stable_file(
+        args.artifact, "held-out capability artifact", MAX_ARTIFACT_BYTES
+    )
+    validate_artifact(
+        json.loads(artifact_bytes),
+        args.manifest,
+        require_trusted=False,
+        captured_corpus=captured,
+    )
+    retained_ref = artifact_ref_bytes(artifact_bytes)
+    if args.ref and args.ref != retained_ref:
         raise ValueError("artifact reference does not match retained bytes")
-    print(artifact_ref(args.artifact))
+    print(retained_ref)
     return 0
 
 

--- a/benchmarks/held-out-capability-v1/test_held_out.py
+++ b/benchmarks/held-out-capability-v1/test_held_out.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import base64
 import copy
 import importlib.util
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("held_out.py")
@@ -276,6 +279,17 @@ class HeldOutTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "exact case ids"):
                 held.validate_artifact(value, manifest, require_trusted=False)
 
+    def test_cross_case_native_report_substitution_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            value = artifact(manifest)
+            cases = value["arms"]["challenger"]["cases"]
+            cases[0]["nativeReport"] = copy.deepcopy(cases[1]["nativeReport"])
+            report_bytes = base64.b64decode(cases[0]["nativeReport"]["value"])
+            cases[0]["execution"]["reportDigest"] = held.sha256_bytes(report_bytes)
+            with self.assertRaisesRegex(ValueError, "expected arm and case"):
+                held.validate_artifact(value, manifest, require_trusted=False)
+
     def test_expected_finding_change_breaks_oracle_binding(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             manifest = write_manifest(Path(directory))
@@ -312,6 +326,223 @@ class HeldOutTests(unittest.TestCase):
             before = held.artifact_ref(output)
             output.write_bytes(output.read_bytes() + b" ")
             self.assertNotEqual(before, held.artifact_ref(output))
+
+    def test_artifact_reference_rejects_oversized_bytes(self) -> None:
+        with mock.patch.object(held, "MAX_ARTIFACT_BYTES", 3):
+            with self.assertRaisesRegex(ValueError, "artifact exceeds its byte limit"):
+                held.artifact_ref_bytes(b"1234")
+
+    def test_verifier_uses_captured_artifact_bytes_for_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root, calibration=True)
+            output = root / "evidence.json"
+            artifact_bytes = held.canonical_bytes(artifact(manifest))
+            output.write_bytes(artifact_bytes)
+            retained_ref = held.artifact_ref_bytes(artifact_bytes)
+
+            def mutate_after_validation(*_args, **_kwargs):
+                output.write_bytes(b"replaced after validation\n")
+
+            with mock.patch.object(held, "validate_artifact", side_effect=mutate_after_validation):
+                self.assertEqual(
+                    held.verify_command(
+                        SimpleNamespace(
+                            artifact=output, manifest=manifest, ref=retained_ref
+                        )
+                    ),
+                    0,
+                )
+
+    def test_verifier_rejects_manifest_swap_after_calibration_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root)
+            promoted_artifact = held.canonical_bytes(artifact(manifest))
+            non_calibration_bytes = manifest.read_bytes()
+            calibration_manifest = json.loads(non_calibration_bytes)
+            calibration_manifest["calibration"] = True
+            manifest.write_bytes(held.canonical_bytes(calibration_manifest))
+            output = root / "evidence.json"
+            output.write_bytes(promoted_artifact)
+            validate = held.validate_artifact
+
+            def swap_then_validate(*args, **kwargs):
+                manifest.write_bytes(non_calibration_bytes)
+                return validate(*args, **kwargs)
+
+            with mock.patch.object(
+                held, "validate_artifact", side_effect=swap_then_validate
+            ):
+                with self.assertRaisesRegex(ValueError, "local corpus"):
+                    held.verify_command(
+                        SimpleNamespace(artifact=output, manifest=manifest, ref=None)
+                    )
+
+    def test_producer_stops_before_output_on_unbounded_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root, calibration=True)
+            champion_binary = root / "champion"
+            challenger_binary = root / "challenger"
+            champion_binary.write_bytes(b"champion")
+            challenger_binary.write_bytes(b"challenger")
+            champion = identity()
+            challenger = challenger_identity()
+            champion["binaryDigest"] = held.sha256_file(champion_binary)
+            challenger["binaryDigest"] = held.sha256_file(challenger_binary)
+            output = root / "evidence.json"
+
+            def report_for_fixture(_binary, fixture, _report, _timeout):
+                return held.canonical_bytes(native_report(fixture)), 1
+
+            with (
+                mock.patch.object(held, "MAX_ARTIFACT_BYTES", 1_000),
+                mock.patch.object(
+                    held, "scan_case", side_effect=report_for_fixture
+                ) as scan,
+                mock.patch.object(
+                    held,
+                    "producer_from_paths",
+                    side_effect=[champion, challenger],
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, "retained byte budget"):
+                    held.run_command(
+                        SimpleNamespace(
+                            candidate_id="candidate-1",
+                            champion_id="champion",
+                            challenger_id="challenger",
+                            champion_binary=champion_binary,
+                            challenger_binary=challenger_binary,
+                            champion_source_root=root / "champion-source",
+                            challenger_source_root=root / "challenger-source",
+                            manifest=manifest,
+                            output=output,
+                            results_dir=root / "results",
+                            timeout_seconds=1,
+                        )
+                    )
+            self.assertEqual(scan.call_count, 1)
+            self.assertFalse(output.exists())
+
+    def test_evaluator_executes_captured_fixture_not_mutated_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root, calibration=True)
+            captured = held.capture_corpus(manifest, require_trusted=False)
+            (root / "fixtures" / "case-1" / "fixture.py").write_text("mutated()\n")
+            binary = root / "foxguard"
+            binary.write_bytes(b"captured binary")
+            producer = identity()
+            producer["binaryDigest"] = held.sha256_file(binary)
+
+            def inspect_snapshot(_binary, fixture, _report, _timeout):
+                self.assertEqual(
+                    (fixture / "fixture.py").read_text(), "dangerous(value)\n"
+                )
+                return held.canonical_bytes(native_report(fixture)), 1
+
+            with (
+                mock.patch.object(
+                    held, "scan_case", side_effect=inspect_snapshot
+                ) as scan,
+                mock.patch.object(
+                    held,
+                    "assert_execution_snapshot",
+                    wraps=held.assert_execution_snapshot,
+                ) as full_seal,
+                mock.patch.object(
+                    held,
+                    "assert_execution_case",
+                    wraps=held.assert_execution_case,
+                ) as case_seal,
+            ):
+                arm = held.evaluate_arm(
+                    arm_id="champion",
+                    binary=binary,
+                    producer=producer,
+                    manifest_path=manifest,
+                    results_dir=root / "results",
+                    timeout_seconds=1,
+                    require_trusted=False,
+                    captured_corpus=captured,
+                )
+            self.assertEqual(scan.call_count, 4)
+            self.assertEqual(full_seal.call_count, 2)
+            self.assertEqual(case_seal.call_count, 8)
+            self.assertEqual(arm["score"]["detected"], 4)
+
+    def test_evaluator_rejects_execution_binary_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_manifest(root, calibration=True)
+            captured = held.capture_corpus(manifest, require_trusted=False)
+            binary = root / "foxguard"
+            binary.write_bytes(b"captured binary")
+            producer = identity()
+            producer["binaryDigest"] = held.sha256_file(binary)
+
+            def mutate_snapshot(snapshot_binary, fixture, _report, _timeout):
+                snapshot_binary.chmod(0o700)
+                snapshot_binary.write_bytes(b"swapped binary")
+                return held.canonical_bytes(native_report(fixture)), 1
+
+            with mock.patch.object(
+                held, "scan_case", side_effect=mutate_snapshot
+            ):
+                with self.assertRaisesRegex(
+                    ValueError, "snapshot (root|metadata)|binary.*changed"
+                ):
+                    held.evaluate_arm(
+                        arm_id="champion",
+                        binary=binary,
+                        producer=producer,
+                        manifest_path=manifest,
+                        results_dir=root / "results",
+                        timeout_seconds=1,
+                        require_trusted=False,
+                        captured_corpus=captured,
+                    )
+
+    def test_fixture_capture_enforces_entry_file_byte_and_depth_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "a").write_bytes(b"1234")
+            (root / "b").write_bytes(b"5")
+            with mock.patch.object(held, "MAX_FIXTURE_ENTRIES", 1):
+                with self.assertRaisesRegex(ValueError, "entry limit"):
+                    held.capture_directory(root)
+            with mock.patch.object(held, "MAX_FIXTURE_FILES", 1):
+                with self.assertRaisesRegex(ValueError, "file limit"):
+                    held.capture_directory(root)
+            with mock.patch.object(held, "MAX_FIXTURE_BYTES", 3):
+                with self.assertRaisesRegex(ValueError, "byte limit"):
+                    held.capture_directory(root)
+            nested = root / "nested"
+            nested.mkdir()
+            (nested / "leaf").write_bytes(b"leaf")
+            with mock.patch.object(held, "MAX_FIXTURE_DEPTH", 0):
+                with self.assertRaisesRegex(ValueError, "depth limit"):
+                    held.capture_directory(root)
+
+    def test_manifest_enforces_case_and_aggregate_corpus_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = write_manifest(Path(directory))
+            with mock.patch.object(held, "MAX_CASES", 3):
+                with self.assertRaisesRegex(ValueError, "3-case limit"):
+                    held.load_manifest(manifest, require_trusted=False)
+            with mock.patch.object(held, "MAX_FIXTURE_FILES", 3):
+                with self.assertRaisesRegex(ValueError, "corpus exceeds its file limit"):
+                    held.load_manifest(manifest, require_trusted=False)
+            with mock.patch.object(held, "MAX_FIXTURE_ENTRIES", 3):
+                with self.assertRaisesRegex(ValueError, "corpus exceeds its entry limit"):
+                    held.load_manifest(manifest, require_trusted=False)
+            with mock.patch.object(held, "MAX_FIXTURE_BYTES", 20):
+                with self.assertRaisesRegex(
+                    ValueError, "corpus exceeds its aggregate byte limit"
+                ):
+                    held.load_manifest(manifest, require_trusted=False)
 
     def test_fixture_symlink_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- capture one bounded held-out manifest + fixture byte view and reuse it through calibration, replay, and corpus binding
- execute owner-private read-only binary/fixture snapshots with pre/post byte and identity seals
- bind embedded report targets to exact arm/case identities and close artifact-reference TOCTOU
- enforce aggregate case, entry, file, fixture-byte, binary, artifact, and retained-evidence limits

## Safety
- calibration remains inert: no draft PR, merge, publish, promotion, provider, spend, training, or model authority
- held-out private fixtures remain excluded from the global training corpus
- this is a prerequisite for the later signed private `foxguard-held-out-provenance-v2` custody package

## Proof
- 37/37 held-out tests
- `cargo test --locked --workspace`
- `python3 -m compileall -q benchmarks/held-out-capability-v1`
- `cargo fmt --all -- --check`
- real compiled Foxguard snapshot execution smoke
- `git diff --check`
- independent review: no P0/P1/P2
