### PR TITLE
chore: exclude VCS and binary artifacts from secrets scans

### DIFF
--- a/.foxguard.yml
+++ b/.foxguard.yml
@@ -3,3 +3,6 @@ scan:
 
 secrets:
   baseline: .foxguard/secrets-baseline.json
+  exclude_paths:
+    - .git
+    - assets/demo.gif


### PR DESCRIPTION
## Summary
Exclude `.git` object storage and `assets/demo.gif` from repository secrets scans. These paths only produced size-skip warnings and are not actionable source-level scan targets.

## Verification
`target/debug/foxguard secrets . --format json` returns 0 findings with no warnings.