### PR TITLE
ci(togi): add Rust toolchain, cargo cache, --locked, and SARIF category

### DIFF
--- a/.github/workflows/togi-advisory.yml
+++ b/.github/workflows/togi-advisory.yml
@@ -13,7 +13,7 @@ jobs:
   mutation-test:
     name: Mutation testing (advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -21,6 +21,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-togi-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-togi-
 
       - name: Install Togi
         env:
@@ -51,7 +61,7 @@ jobs:
           args=(
             check
             --base "origin/${BASE_REF}"
-            --test-cmd "cargo test --all-features"
+            --test-cmd "cargo test --locked --all-features"
             --timeout 60
             --format sarif
             --pr-comment togi-pr-comment.md
@@ -67,6 +77,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: togi-report.sarif
+          category: mutation-testing
 
       - name: Publish PR summary
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('togi-pr-comment.md') != '' }}


### PR DESCRIPTION
The togi-advisory workflow was missing a Rust toolchain and cargo cache, forcing a cold compile of the full workspace on every run — impossible within the 3-minute timeout.

## Changes
- Add `dtolnay/rust-toolchain@stable` step
- Add `actions/cache@v5` for `~/.cargo` and `target/` (arch-aware key)
- Use `--locked` on `cargo test` (matches ci.yml convention)
- Add `category: mutation-testing` to SARIF upload for dashboard separation
- Bump job timeout 3→10 min (cached builds are fast; provides headroom)