### PR TITLE
feat(diff): compare paired CodeQL databases

### DIFF
--- a/docs/agent-editor-integration.md
+++ b/docs/agent-editor-integration.md
@@ -52,7 +52,7 @@ Common request fields:
 | `request_id` | string | Optional host correlation id echoed in the response. |
 | `command` | string | `scan-file`, `scan-workspace`, `diff`, `secrets`, `pqc`, `explain`, or `suppress`. |
 | `path` | string | File or workspace path. Required for `scan-file`; optional for workspace commands. |
-| `workspace_root` | string | Optional root for resolving relative `path`, `config`, `rules`, and `baseline`. |
+| `workspace_root` | string | Optional root for resolving relative `path`, `config`, `rules`, `baseline`, and CodeQL database paths. |
 | `severity` | string | Optional minimum severity: `low`, `medium`, `high`, or `critical`. |
 | `config` | string | Optional `.foxguard.yml` path. |
 | `rules` | string | Optional external Semgrep/OpenGrep-compatible rule file or directory. |
@@ -60,6 +60,8 @@ Common request fields:
 | `exclude` | string[] | Optional scan path prefixes/globs to skip. |
 | `baseline` | string | Optional baseline file. |
 | `base` | string | Diff base for `diff`; defaults to `main`. |
+| `codeql_base_db` | string | Pre-built base CodeQL database for `diff`; requires `codeql_head_db`. |
+| `codeql_head_db` | string | Pre-built head CodeQL database for `diff`; requires `codeql_base_db`. |
 | `explain` | bool | Include dataflow metadata where available. |
 | `max_file_size` | number | Optional byte limit, defaulting to the CLI default. |
 | `min_confidence` | number | Optional confidence threshold. |
@@ -133,6 +135,7 @@ Adapter command mapping:
 | Scan current file | `{ "command": "scan-file", "path": "src/app.py", "severity": "medium" }` |
 | Scan workspace | `{ "command": "scan-workspace", "workspace_root": ".", "severity": "medium" }` |
 | Diff scan | `{ "command": "diff", "base": "main", "workspace_root": "." }` |
+| Diff scan with paired CodeQL databases | `{ "command": "diff", "base": "main", "workspace_root": ".", "rules": "rules.yml", "codeql_base_db": "artifacts/base-db", "codeql_head_db": "artifacts/head-db" }` |
 | Secrets scan | `{ "command": "secrets", "workspace_root": "." }` |
 | PQ audit | `{ "command": "pqc", "workspace_root": ".", "severity": "medium" }` |
 | Explain finding | `{ "command": "explain", "path": ".", "finding": { "rule_id": "py/taint-sql-injection" } }` |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -273,7 +273,8 @@ Execution model:
 - SARIF results are normalized into the same `Finding` shape used by built-in, Semgrep-compatible, and Coccinelle rules.
 - If `codeql` is missing from PATH, foxguard emits a single warning and skips CodeQL rules while continuing the rest of the scan.
 - If `codeql database create` fails (e.g. no compilable source under the scan target, or the qlpack language family isn't installed), foxguard emits a per-rule warning and continues. Set `FOXGUARD_CODEQL_CREATE_TIMEOUT_SECS` to override the default 15-minute build timeout.
-- `foxguard diff` does not run the CodeQL bridge yet. Accurate diffing needs a base/current database strategy rather than a single current database.
+- `foxguard diff` compares CodeQL only when both pre-built databases are supplied. Use `--codeql-base-db /path/to/base-db --codeql-head-db /path/to/head-db` (or `diff.codeql_base_db` and `diff.codeql_head_db` in config) with `--rules`; an incomplete pair is an error. It never builds databases in diff mode. Each configured rule runs against both databases, normalized equivalent findings are suppressed, and head-only findings flow through normal diff output once. If CodeQL is unavailable or either analysis fails, the diff exits with an explicit error rather than emitting a clean CodeQL delta.
+- In paired diff mode, unloadable CodeQL rules and malformed SARIF are errors; foxguard never treats them as an empty result set. Paired SARIF must be version 2.1.0 with a run/tool/driver/results structure. Singleton artifact roots share one comparison identity across `uriBaseId` and source-root encodings; multiple independent `uriBaseId` roots are namespaced and must map identically between base and head. Anonymous or incompatible multi-root inputs fail explicitly rather than collapsing same-tail paths.
 
 ## Important limitations
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -67,6 +67,10 @@ pub struct AdapterRequest {
     pub config: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rules: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codeql_base_db: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codeql_head_db: Option<String>,
     #[serde(default)]
     pub no_builtins: bool,
     #[serde(default)]
@@ -99,6 +103,8 @@ impl AdapterRequest {
             severity: None,
             config: None,
             rules: None,
+            codeql_base_db: None,
+            codeql_head_db: None,
             no_builtins: false,
             change_mode: AdapterChangeMode::None,
             exclude: Vec::new(),
@@ -343,24 +349,7 @@ fn diff_response(request: &AdapterRequest) -> AdapterResponse {
         .or(request.workspace_root.as_deref())
         .unwrap_or(".");
     let base = request.base.clone().unwrap_or_else(|| "main".to_string());
-    let args = DiffArgs {
-        target: base.clone(),
-        path: resolve_workspace_path(path, request.workspace_root.as_deref()),
-        config: resolve_optional_workspace_path(
-            request.config.as_deref(),
-            request.workspace_root.as_deref(),
-        ),
-        format: OutputFormat::Json,
-        severity: request.severity.map(severity_filter),
-        rules: resolve_optional_workspace_path(
-            request.rules.as_deref(),
-            request.workspace_root.as_deref(),
-        ),
-        no_builtins: request.no_builtins,
-        output: None,
-        github_pr: None,
-        max_file_size: max_file_size(request),
-    };
+    let args = adapter_diff_args(request, path, &base);
     match execute_diff(&args) {
         Ok(result) => {
             let summary = summarize(&result.findings, result.files_scanned, result.duration);
@@ -381,6 +370,35 @@ fn diff_response(request: &AdapterRequest) -> AdapterResponse {
             )
         }
         Err(error) => request_error(request, error),
+    }
+}
+
+fn adapter_diff_args(request: &AdapterRequest, path: &str, base: &str) -> DiffArgs {
+    DiffArgs {
+        target: base.to_string(),
+        path: resolve_workspace_path(path, request.workspace_root.as_deref()),
+        config: resolve_optional_workspace_path(
+            request.config.as_deref(),
+            request.workspace_root.as_deref(),
+        ),
+        format: OutputFormat::Json,
+        severity: request.severity.map(severity_filter),
+        rules: resolve_optional_workspace_path(
+            request.rules.as_deref(),
+            request.workspace_root.as_deref(),
+        ),
+        codeql_base_db: resolve_optional_workspace_path(
+            request.codeql_base_db.as_deref(),
+            request.workspace_root.as_deref(),
+        ),
+        codeql_head_db: resolve_optional_workspace_path(
+            request.codeql_head_db.as_deref(),
+            request.workspace_root.as_deref(),
+        ),
+        no_builtins: request.no_builtins,
+        output: None,
+        github_pr: None,
+        max_file_size: max_file_size(request),
     }
 }
 
@@ -681,6 +699,33 @@ mod tests {
         assert_eq!(
             encoded["schema_version"].as_str(),
             Some(ADAPTER_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
+    fn adapter_diff_maps_paired_codeql_databases() {
+        let workspace = tempfile::tempdir().expect("failed to create workspace");
+        let workspace_root = workspace.path().to_string_lossy().into_owned();
+        let request: AdapterRequest = must(serde_json::from_value(json!({
+            "command": "diff",
+            "workspace_root": workspace_root,
+            "codeql_base_db": "codeql/base",
+            "codeql_head_db": "codeql/head"
+        })));
+
+        let args = adapter_diff_args(
+            &request,
+            request.workspace_root.as_deref().expect("workspace root"),
+            "main",
+        );
+
+        assert_eq!(
+            args.codeql_base_db.as_deref(),
+            Some(format!("{}/codeql/base", workspace.path().display()).as_str())
+        );
+        assert_eq!(
+            args.codeql_head_db.as_deref(),
+            Some(format!("{}/codeql/head", workspace.path().display()).as_str())
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,11 @@ pub struct DiffExecution {
     pub notices: Vec<String>,
 }
 
+struct CodeQlDiffDatabases {
+    base: PathBuf,
+    head: PathBuf,
+}
+
 pub struct DiffSummary {
     pub target: String,
     pub total_current: usize,
@@ -468,6 +473,7 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
 pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), args.config.as_deref())?;
+    let codeql_databases = resolve_codeql_diff_databases(args, config.as_ref())?;
     let identity_root = finding_identity_root(Path::new(&args.path), config.as_ref());
     let config_scan = config.as_ref().map(|config| &config.scan);
     let rules_path = args
@@ -488,22 +494,37 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
         Some(rules_path) => coccinelle::load_coccinelle_rules(Path::new(rules_path)),
         None => (Vec::new(), Vec::new()),
     };
+    let mut codeql_rules = if codeql_databases.is_some() {
+        let rules_path = rules_path.ok_or_else(|| {
+            "CodeQL diff requires --rules or scan.rules with engine: codeql rules".to_string()
+        })?;
+        codeql::load_codeql_rules_for_diff(Path::new(rules_path))?
+    } else {
+        Vec::new()
+    };
     let coccinelle_rule_ids = coccinelle::rule_ids(&coccinelle_rules);
+    let codeql_rule_ids = codeql::rule_ids(&codeql_rules);
+    let external_rule_ids = external_rule_ids(&coccinelle_rule_ids, &codeql_rule_ids);
     let rule_filter_unknown = if let Some(config) = config.as_ref() {
         coccinelle::apply_rule_filter(
             &mut coccinelle_rules,
             &config.scan.enable_rules,
             &config.scan.disable_rules,
         );
+        codeql::apply_rule_filter(
+            &mut codeql_rules,
+            &config.scan.enable_rules,
+            &config.scan.disable_rules,
+        );
         registry.apply_rule_filter_with_known(
             &config.scan.enable_rules,
             &config.scan.disable_rules,
-            &coccinelle_rule_ids,
+            &external_rule_ids,
         )
     } else {
-        registry.apply_rule_filter_with_known(&[], &[], &coccinelle_rule_ids)
+        registry.apply_rule_filter_with_known(&[], &[], &external_rule_ids)
     };
-    let ((scan_result, mut diff_result), mut notices) = run_diff_with_coccinelle_warnings(
+    let ((mut scan_result, mut diff_result), mut notices) = run_diff_with_coccinelle_warnings(
         &args.path,
         &args.target,
         &registry,
@@ -512,6 +533,28 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     )?;
     notices.append(&mut coccinelle_notices);
     append_scan_stats_notice(&mut notices, &scan_result.stats);
+
+    if let Some(databases) = codeql_databases {
+        let base_result = codeql::scan_prebuilt_database(&codeql_rules, &databases.base)
+            .map_err(|error| format!("CodeQL base database comparison could not run: {error}"))?;
+        let head_result = codeql::scan_prebuilt_database(&codeql_rules, &databases.head)
+            .map_err(|error| format!("CodeQL head database comparison could not run: {error}"))?;
+        let head_files_scanned = head_result.files_scanned;
+        let codeql_diff = codeql::diff_prebuilt_database_findings(head_result, base_result)
+            .map_err(|error| format!("CodeQL database comparison could not run: {error}"))?;
+
+        scan_result.files_scanned += head_files_scanned;
+        diff_result.total_current += codeql_diff.total_current;
+        diff_result.existing_count += codeql_diff.existing_count;
+        diff_result.new_findings.extend(codeql_diff.new_findings);
+        diff_result.new_findings.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.column.cmp(&b.column))
+                .then(a.rule_id.cmp(&b.rule_id))
+        });
+    }
 
     if !rule_filter_unknown.is_empty() {
         notices.insert(
@@ -531,7 +574,7 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     // Annotate CNSA 2.0 deadlines on the new findings surfaced by this diff.
     crate::compliance::annotate_cnsa2_deadlines(&mut diff_result.new_findings, &registry);
 
-    let known_rule_ids = collect_rule_ids(&registry, &coccinelle_rules, &[]);
+    let known_rule_ids = collect_rule_ids(&registry, &coccinelle_rules, &codeql_rules);
     let override_warnings = apply_severity_overrides(
         &mut diff_result.new_findings,
         config.as_ref(),
@@ -576,6 +619,41 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
         existing_count: diff_result.existing_count,
         notices,
     })
+}
+
+fn resolve_codeql_diff_databases(
+    args: &DiffArgs,
+    config: Option<&FoxguardConfig>,
+) -> Result<Option<CodeQlDiffDatabases>, String> {
+    if args.codeql_base_db.is_some() || args.codeql_head_db.is_some() {
+        return codeql_diff_database_pair(
+            args.codeql_base_db.as_deref(),
+            args.codeql_head_db.as_deref(),
+            "--codeql-base-db and --codeql-head-db",
+        );
+    }
+
+    let config = config.map(|config| &config.diff);
+    codeql_diff_database_pair(
+        config.and_then(|config| config.codeql_base_db.as_deref()),
+        config.and_then(|config| config.codeql_head_db.as_deref()),
+        "diff.codeql_base_db and diff.codeql_head_db",
+    )
+}
+
+fn codeql_diff_database_pair(
+    base: Option<&str>,
+    head: Option<&str>,
+    source: &str,
+) -> Result<Option<CodeQlDiffDatabases>, String> {
+    match (base, head) {
+        (Some(base), Some(head)) => Ok(Some(CodeQlDiffDatabases {
+            base: PathBuf::from(base),
+            head: PathBuf::from(head),
+        })),
+        (None, None) => Ok(None),
+        _ => Err(format!("CodeQL diff requires both {source}")),
+    }
 }
 
 fn append_scan_stats_notice(notices: &mut Vec<String>, stats: &ScanStats) {
@@ -676,6 +754,8 @@ fn tui_diff_args(args: &TuiArgs, target: &str) -> DiffArgs {
         severity: args.severity,
         config: args.config.clone(),
         rules: args.rules.clone(),
+        codeql_base_db: None,
+        codeql_head_db: None,
         no_builtins: args.no_builtins,
         output: None,
         github_pr: None,

--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -309,6 +309,20 @@ fn diff_input_schema() -> Value {
                 "description": "Target branch or revision to compare against"
             }),
         );
+        properties.insert(
+            "codeql_base_db".to_string(),
+            json!({
+                "type": "string",
+                "description": "Pre-built CodeQL database for the base side; requires codeql_head_db"
+            }),
+        );
+        properties.insert(
+            "codeql_head_db".to_string(),
+            json!({
+                "type": "string",
+                "description": "Pre-built CodeQL database for the head side; requires codeql_base_db"
+            }),
+        );
     }
     schema
 }
@@ -489,6 +503,8 @@ fn diff_args(arguments: &Value) -> Result<DiffArgs, String> {
         format: OutputFormat::Json,
         severity: optional_severity(arguments, "severity")?,
         rules: optional_string(arguments, "rules")?,
+        codeql_base_db: optional_string(arguments, "codeql_base_db")?,
+        codeql_head_db: optional_string(arguments, "codeql_head_db")?,
         no_builtins: optional_bool(arguments, "no_builtins")?,
         output: None,
         github_pr: None,
@@ -778,5 +794,27 @@ fn optional_severity(value: &Value, key: &str) -> Result<Option<SeverityFilter>,
         "high" => Ok(Some(SeverityFilter::High)),
         "critical" => Ok(Some(SeverityFilter::Critical)),
         _ => Err(format!("{key} must be one of: low, medium, high, critical")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_interface_accepts_paired_codeql_databases() {
+        let schema = diff_input_schema();
+        assert!(schema["properties"]["codeql_base_db"].is_object());
+        assert!(schema["properties"]["codeql_head_db"].is_object());
+
+        let args = diff_args(&json!({
+            "path": "/workspace",
+            "target": "main",
+            "codeql_base_db": "/artifacts/base-db",
+            "codeql_head_db": "/artifacts/head-db"
+        }))
+        .expect("paired CodeQL database inputs should parse");
+        assert_eq!(args.codeql_base_db.as_deref(), Some("/artifacts/base-db"));
+        assert_eq!(args.codeql_head_db.as_deref(), Some("/artifacts/head-db"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -393,6 +393,13 @@ pub struct DiffArgs {
     /// Path to external YAML rule file or directory
     #[arg(short, long)]
     pub rules: Option<String>,
+    /// Pre-built CodeQL database for the base side of this diff. Must be paired with --codeql-head-db.
+    #[arg(long = "codeql-base-db", requires = "codeql_head_db")]
+    pub codeql_base_db: Option<String>,
+
+    /// Pre-built CodeQL database for the head side of this diff. Must be paired with --codeql-base-db.
+    #[arg(long = "codeql-head-db", requires = "codeql_base_db")]
+    pub codeql_head_db: Option<String>,
 
     /// Disable built-in rules and run only external rules loaded via --rules
     #[arg(long, default_value_t = false)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct FoxguardConfig {
     pub project_root: PathBuf,
     pub scan: ScanConfig,
     pub secrets: SecretsConfig,
+    pub diff: DiffConfig,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -70,6 +71,12 @@ pub struct ScanConfig {
     /// is suppressed. Useful for silencing known false positives in test
     /// or fixture directories without a per-file ignore entry.
     pub suppressions: Vec<SuppressionPattern>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DiffConfig {
+    pub codeql_base_db: Option<String>,
+    pub codeql_head_db: Option<String>,
 }
 
 /// Tunable thresholds for pattern/heuristic rules.
@@ -136,6 +143,8 @@ struct RawFoxguardConfig {
     scan: RawScanConfig,
     #[serde(default)]
     secrets: RawSecretsConfig,
+    #[serde(default)]
+    diff: RawDiffConfig,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -175,6 +184,12 @@ struct RawScanConfig {
     sca_cache: Option<String>,
     #[serde(default)]
     suppressions: Vec<RawSuppressionPattern>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawDiffConfig {
+    codeql_base_db: Option<String>,
+    codeql_head_db: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -324,6 +339,17 @@ impl FoxguardConfig {
             .sca_cache
             .map(|path| resolve_value_path(config_dir, allowed_root, "scan.sca_cache", &path))
             .transpose()?;
+        let diff_codeql_base_db = raw
+            .diff
+            .codeql_base_db
+            .map(|path| resolve_value_path(config_dir, allowed_root, "diff.codeql_base_db", &path))
+            .transpose()?;
+        let diff_codeql_head_db = raw
+            .diff
+            .codeql_head_db
+            .map(|path| resolve_value_path(config_dir, allowed_root, "diff.codeql_head_db", &path))
+            .transpose()?;
+
         let scan_ignore_rules = raw
             .scan
             .ignore_rules
@@ -443,6 +469,10 @@ impl FoxguardConfig {
                 exclude_paths: secrets_exclude_paths,
                 exclude_path_file: secrets_exclude_path_file,
                 ignored_rules: raw.secrets.ignore_rules,
+            },
+            diff: DiffConfig {
+                codeql_base_db: diff_codeql_base_db,
+                codeql_head_db: diff_codeql_head_db,
             },
         })
     }
@@ -2061,5 +2091,39 @@ mod tests {
         assert_eq!(filtered[0].file, "src/app.py");
         assert_eq!(filtered[1].rule_id, "js/no-eval");
         assert_eq!(filtered[1].file, "src/main.js");
+    }
+    #[test]
+    fn loads_diff_codeql_database_pair() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        fs::create_dir_all(repo.path().join("codeql/base"))
+            .expect("failed to create base database");
+        fs::create_dir_all(repo.path().join("codeql/head"))
+            .expect("failed to create head database");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "diff:\n  codeql_base_db: codeql/base\n  codeql_head_db: codeql/head\n",
+        );
+
+        let config = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+
+        assert!(Path::new(
+            config
+                .diff
+                .codeql_base_db
+                .as_deref()
+                .expect("base database path")
+        )
+        .ends_with("codeql/base"));
+        assert!(Path::new(
+            config
+                .diff
+                .codeql_head_db
+                .as_deref()
+                .expect("head database path")
+        )
+        .ends_with("codeql/head"));
     }
 }

--- a/src/engine/codeql.rs
+++ b/src/engine/codeql.rs
@@ -1,10 +1,11 @@
+use crate::diff::{diff_findings, DiffResult};
 use crate::{Finding, Severity};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use serde_yaml_ng::Value as YamlValue;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 use tempfile::TempDir;
@@ -24,6 +25,30 @@ pub struct CodeQlScanResult {
     pub files_scanned: usize,
     pub candidate_rules: usize,
     pub notices: Vec<String>,
+}
+
+pub struct CodeQlDiffScanResult {
+    findings: Vec<CodeQlDiffFinding>,
+    namespaces_by_rule: HashMap<String, HashSet<String>>,
+    pub files_scanned: usize,
+}
+
+#[derive(Clone)]
+struct CodeQlDiffFinding {
+    finding: Finding,
+    comparison_path: String,
+    identity: String,
+    has_fingerprint: bool,
+}
+
+struct CodeQlArtifactPath {
+    display_path: String,
+    comparison_path: String,
+}
+
+struct ParsedCodeQlDiffFindings {
+    findings: Vec<CodeQlDiffFinding>,
+    namespaces: HashSet<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,6 +166,84 @@ pub fn load_codeql_rules(path: &Path) -> (Vec<CodeQlRule>, Vec<String>) {
     (rules, notices)
 }
 
+/// Load CodeQL rules for a paired database diff.
+///
+/// A diff cannot safely treat an unloadable rule set as zero findings, so this
+/// strict variant turns parser notices, missing queries, and an empty CodeQL
+/// rule selection into errors. The regular one-tree scan keeps its existing
+/// warn-and-skip behavior through [`load_codeql_rules`].
+pub fn load_codeql_rules_for_diff(path: &Path) -> Result<Vec<CodeQlRule>, String> {
+    let mut rules = Vec::new();
+    for rule_file in strict_codeql_rule_files(path)? {
+        let (parsed, notices) = parse_codeql_file(&rule_file).map_err(|error| {
+            format!(
+                "CodeQL diff failed to load rules from {}: {}",
+                rule_file.display(),
+                error
+            )
+        })?;
+        if !notices.is_empty() {
+            return Err(format!(
+                "CodeQL diff failed to load rules from {}: {}",
+                rule_file.display(),
+                notices.join("; ")
+            ));
+        }
+        rules.extend(parsed);
+    }
+
+    if rules.is_empty() {
+        return Err(format!(
+            "CodeQL diff requires at least one engine: codeql rule in {}",
+            path.display()
+        ));
+    }
+    for rule in &rules {
+        if !rule.query.is_file() {
+            return Err(format!(
+                "CodeQL diff failed to load rule '{}': query {} does not exist",
+                rule.id,
+                rule.query.display()
+            ));
+        }
+    }
+
+    Ok(rules)
+}
+
+fn strict_codeql_rule_files(path: &Path) -> Result<Vec<PathBuf>, String> {
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+    if !path.is_dir() {
+        return Err(format!(
+            "CodeQL diff failed to load rules: {} does not exist",
+            path.display()
+        ));
+    }
+
+    let mut files = Vec::new();
+    for entry in walkdir::WalkDir::new(path) {
+        let entry = entry.map_err(|error| {
+            format!(
+                "CodeQL diff failed to traverse rules under {}: {}",
+                path.display(),
+                error
+            )
+        })?;
+        if entry.file_type().is_file()
+            && matches!(
+                entry.path().extension().and_then(|ext| ext.to_str()),
+                Some("yaml" | "yml")
+            )
+        {
+            files.push(entry.into_path());
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
 pub fn parse_codeql_file(path: &Path) -> Result<(Vec<CodeQlRule>, Vec<String>), String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
@@ -209,6 +312,165 @@ pub fn parse_codeql_file(path: &Path) -> Result<(Vec<CodeQlRule>, Vec<String>), 
 
 pub fn scan_with_notices(rules: &[CodeQlRule], cli_database: Option<&Path>) -> CodeQlScanResult {
     scan_with_notices_for_target(rules, cli_database, None)
+}
+
+/// Run CodeQL rules against one explicitly supplied, prebuilt database.
+///
+/// Unlike the regular scan path, this never consults a rule-level database,
+/// environment variable, or auto-build fallback. A configured diff must use
+/// exactly the paired base/head databases supplied by the caller. Failure to
+/// run every rule returns an error so callers cannot compare a partial result
+/// set as though it were a clean delta.
+pub fn scan_prebuilt_database(
+    rules: &[CodeQlRule],
+    database: &Path,
+) -> Result<CodeQlDiffScanResult, String> {
+    if rules.is_empty() {
+        return Ok(CodeQlDiffScanResult {
+            findings: Vec::new(),
+            namespaces_by_rule: HashMap::new(),
+            files_scanned: 0,
+        });
+    }
+
+    probe_codeql().map_err(|error| {
+        format!(
+            "CodeQL diff skipped: {}; install CodeQL (`codeql`) to compare configured databases",
+            error
+        )
+    })?;
+    let source_roots = codeql_database_source_roots(database)?;
+
+    let mut findings = Vec::new();
+    let mut namespaces_by_rule = HashMap::new();
+    for rule in rules {
+        let sarif = run_codeql_database_analyze(database, &rule.query).map_err(|error| {
+            format!(
+                "CodeQL diff failed: rule '{}' against {}: {}",
+                rule.id,
+                database.display(),
+                error
+            )
+        })?;
+        let parsed = parse_sarif_diff_findings(rule, &sarif, &source_roots).map_err(|error| {
+            format!(
+                "CodeQL diff failed: rule '{}' against {} produced invalid SARIF: {}",
+                rule.id,
+                database.display(),
+                error
+            )
+        })?;
+        if !parsed.namespaces.is_empty() {
+            namespaces_by_rule
+                .entry(rule.id.clone())
+                .or_insert_with(HashSet::new)
+                .extend(parsed.namespaces);
+        }
+        findings.extend(parsed.findings);
+    }
+
+    findings.sort_by(|a, b| {
+        a.finding
+            .file
+            .cmp(&b.finding.file)
+            .then(a.finding.line.cmp(&b.finding.line))
+            .then(a.finding.column.cmp(&b.finding.column))
+            .then(a.finding.rule_id.cmp(&b.finding.rule_id))
+    });
+
+    Ok(CodeQlDiffScanResult {
+        findings,
+        namespaces_by_rule,
+        files_scanned: 1,
+    })
+}
+
+/// Compare paired CodeQL result sets using the normal diff comparator while
+/// retaining SARIF-derived finding identities and display snippets.
+pub fn diff_prebuilt_database_findings(
+    current: CodeQlDiffScanResult,
+    base: CodeQlDiffScanResult,
+) -> Result<DiffResult, String> {
+    validate_codeql_namespace_compatibility(&current.namespaces_by_rule, &base.namespaces_by_rule)?;
+    let current = deduplicate_codeql_diff_findings(current.findings);
+    let base = deduplicate_codeql_diff_findings(base.findings);
+    let mut originals = HashMap::new();
+    let current_for_comparison = current
+        .into_iter()
+        .map(|finding| {
+            let key = codeql_diff_key(
+                &finding.finding.rule_id,
+                &finding.comparison_path,
+                &finding.identity,
+            );
+            let mut comparison = finding.finding.clone();
+            comparison.file = finding.comparison_path;
+            comparison.snippet = finding.identity;
+            originals.insert(key, finding.finding);
+            comparison
+        })
+        .collect();
+    let base_for_comparison = base
+        .into_iter()
+        .map(|finding| {
+            let mut comparison = finding.finding;
+            comparison.file = finding.comparison_path;
+            comparison.snippet = finding.identity;
+            comparison
+        })
+        .collect();
+    let mut result = diff_findings(current_for_comparison, base_for_comparison);
+
+    for finding in &mut result.new_findings {
+        if let Some(original) = originals.remove(&codeql_diff_key(
+            &finding.rule_id,
+            &finding.file,
+            &finding.snippet,
+        )) {
+            *finding = original;
+        }
+    }
+
+    Ok(result)
+}
+
+fn validate_codeql_namespace_compatibility(
+    current: &HashMap<String, HashSet<String>>,
+    base: &HashMap<String, HashSet<String>>,
+) -> Result<(), String> {
+    if current == base {
+        return Ok(());
+    }
+    Err(
+        "paired CodeQL databases have incompatible multi-base uriBaseId namespaces; unable to map them safely"
+            .to_string(),
+    )
+}
+
+fn deduplicate_codeql_diff_findings(findings: Vec<CodeQlDiffFinding>) -> Vec<CodeQlDiffFinding> {
+    let mut seen = HashSet::new();
+    findings
+        .into_iter()
+        .filter(|finding| {
+            seen.insert(codeql_diff_key(
+                &finding.finding.rule_id,
+                &finding.comparison_path,
+                &finding.identity,
+            ))
+        })
+        .collect()
+}
+
+fn codeql_diff_key(
+    rule_id: &str,
+    comparison_path: &str,
+    identity: &str,
+) -> (String, String, String) {
+    (
+        rule_id.to_string(),
+        comparison_path.replace('\\', "/"),
+        identity.to_string(),
+    )
 }
 
 /// Run loaded CodeQL rules against the provided target.
@@ -427,22 +689,145 @@ fn parse_sarif_findings(rule: &CodeQlRule, sarif: &str) -> Vec<Finding> {
                 .into_iter()
                 .flatten()
         })
-        .filter_map(|result| finding_from_sarif_result(rule, result))
+        .filter_map(|result| {
+            normalized_finding_from_sarif_result(
+                rule,
+                result,
+                CodeQlSnippetSource::LiveCheckout,
+                None,
+            )
+            .ok()
+            .flatten()
+        })
+        .map(|finding| finding.finding)
         .collect()
 }
 
-fn finding_from_sarif_result(rule: &CodeQlRule, result: &JsonValue) -> Option<Finding> {
-    let physical = result
-        .get("locations")?
-        .as_array()?
-        .first()?
-        .get("physicalLocation")?;
-    let uri = physical
-        .get("artifactLocation")?
-        .get("uri")?
-        .as_str()
-        .unwrap_or("<unknown>");
-    let file = normalize_sarif_uri(uri);
+fn parse_sarif_diff_findings(
+    rule: &CodeQlRule,
+    sarif: &str,
+    source_roots: &[PathBuf],
+) -> Result<ParsedCodeQlDiffFindings, String> {
+    const SUPPORTED_SARIF_VERSION: &str = "2.1.0";
+
+    let root: JsonValue =
+        serde_json::from_str(sarif).map_err(|error| format!("invalid JSON: {error}"))?;
+    let version = root
+        .get("version")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "missing SARIF version".to_string())?;
+    if version != SUPPORTED_SARIF_VERSION {
+        return Err(format!(
+            "unsupported SARIF version '{version}'; expected {SUPPORTED_SARIF_VERSION}"
+        ));
+    }
+    let runs = root
+        .get("runs")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| "missing SARIF runs array".to_string())?;
+    if runs.is_empty() {
+        return Err("SARIF runs array is empty".to_string());
+    }
+
+    let mut findings = Vec::new();
+    let mut namespaces = HashSet::new();
+    for (run_index, run) in runs.iter().enumerate() {
+        let results = sarif_run_results(run, run_index + 1)?;
+        let resolver = CodeQlSarifPathResolver::from_run(run, source_roots)
+            .map_err(|error| format!("SARIF run {}: {error}", run_index + 1))?;
+        namespaces.extend(resolver.comparison_namespaces().iter().cloned());
+        for (result_index, result) in results.iter().enumerate() {
+            let finding = normalized_finding_from_sarif_result(
+                rule,
+                result,
+                CodeQlSnippetSource::Sarif,
+                Some(&resolver),
+            )
+            .map_err(|error| {
+                format!(
+                    "SARIF result {} in run {} has an unsafe artifact path: {error}",
+                    result_index + 1,
+                    run_index + 1
+                )
+            })?
+            .ok_or_else(|| {
+                format!(
+                    "SARIF result {} in run {} lacks a physical location",
+                    result_index + 1,
+                    run_index + 1
+                )
+            })?;
+            findings.push(finding);
+        }
+    }
+
+    Ok(ParsedCodeQlDiffFindings {
+        findings: assign_fallback_occurrences(findings),
+        namespaces,
+    })
+}
+
+fn sarif_run_results(run: &JsonValue, run_index: usize) -> Result<&Vec<JsonValue>, String> {
+    let tool = run
+        .get("tool")
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| format!("SARIF run {run_index} lacks a tool object"))?;
+    let driver = tool
+        .get("driver")
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| format!("SARIF run {run_index} lacks a tool driver object"))?;
+    if driver
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .is_none_or(|name| name.trim().is_empty())
+    {
+        return Err(format!("SARIF run {run_index} has a driver without a name"));
+    }
+
+    run.get("results")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| format!("SARIF run {run_index} has a missing or non-array results field"))
+}
+
+#[derive(Clone, Copy)]
+enum CodeQlSnippetSource {
+    LiveCheckout,
+    Sarif,
+}
+
+fn normalized_finding_from_sarif_result(
+    rule: &CodeQlRule,
+    result: &JsonValue,
+    snippet_source: CodeQlSnippetSource,
+    path_resolver: Option<&CodeQlSarifPathResolver>,
+) -> Result<Option<CodeQlDiffFinding>, String> {
+    let Some(physical) = result
+        .get("locations")
+        .and_then(JsonValue::as_array)
+        .and_then(|locations| locations.first())
+        .and_then(|location| location.get("physicalLocation"))
+    else {
+        return Ok(None);
+    };
+    let Some(artifact_location) = physical.get("artifactLocation") else {
+        return Ok(None);
+    };
+    let Some(uri) = artifact_location.get("uri").and_then(JsonValue::as_str) else {
+        return Ok(None);
+    };
+    let CodeQlArtifactPath {
+        display_path: file,
+        comparison_path,
+    } = match path_resolver {
+        Some(resolver) => resolver.normalize_artifact_location(artifact_location)?,
+        None => {
+            let file = normalize_sarif_uri(uri);
+            CodeQlArtifactPath {
+                comparison_path: single_root_comparison_path(&file),
+                display_path: file,
+            }
+        }
+    };
     let region = physical.get("region");
     let line = region
         .and_then(|region| region.get("startLine"))
@@ -462,47 +847,493 @@ fn finding_from_sarif_result(rule: &CodeQlRule, result: &JsonValue) -> Option<Fi
         .and_then(JsonValue::as_str)
         .filter(|message| !message.trim().is_empty())
         .unwrap_or(&rule.message);
-    let snippet = snippet_for_path(&file, line);
+    let sarif_snippet = region
+        .and_then(|region| region.get("snippet"))
+        .and_then(|snippet| snippet.get("text"))
+        .and_then(JsonValue::as_str)
+        .filter(|snippet| !snippet.trim().is_empty())
+        .map(str::to_string);
+    let snippet = match snippet_source {
+        CodeQlSnippetSource::LiveCheckout => snippet_for_path(&file, line),
+        CodeQlSnippetSource::Sarif => sarif_snippet.clone().unwrap_or_default(),
+    };
     let end_column = region
         .and_then(|region| region.get("endColumn"))
         .and_then(JsonValue::as_u64)
         .map(|column| column as usize)
         .unwrap_or_else(|| column + snippet.chars().count().max(1));
-
-    Some(Finding {
-        rule_id: rule.id.clone(),
-        severity: rule.severity,
-        cwe: rule.cwe.clone(),
-        description: message.to_string(),
-        file,
+    let (identity, has_fingerprint) = sarif_finding_identity(
+        result,
+        sarif_snippet.as_deref(),
+        message,
         line,
         column,
         end_line,
         end_column,
-        snippet,
-        source_line: None,
-        source_description: None,
-        sink_line: None,
-        sink_description: None,
-        fix_suggestion: None,
-        sink_start_byte: None,
-        sink_end_byte: None,
-        confidence: 0.8,
-        taint_hops: None,
-        tags: vec!["codeql".to_string()],
-        crypto_algorithm: None,
-        cnsa2_deadline: None,
-        dep_name: None,
-        dep_version: None,
-        dep_ecosystem: None,
-        dep_purl: None,
-        dep_vulnerability_id: None,
-        dep_fixed_version: None,
-        dep_source: None,
-        dep_vulnerability_severity: None,
-        dep_path: vec![],
-        crypto_material: None,
-    })
+    );
+
+    Ok(Some(CodeQlDiffFinding {
+        finding: Finding {
+            rule_id: rule.id.clone(),
+            severity: rule.severity,
+            cwe: rule.cwe.clone(),
+            description: message.to_string(),
+            file,
+            line,
+            column,
+            end_line,
+            end_column,
+            snippet,
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 0.8,
+            taint_hops: None,
+            tags: vec!["codeql".to_string()],
+            crypto_algorithm: None,
+            cnsa2_deadline: None,
+            dep_name: None,
+            dep_version: None,
+            dep_ecosystem: None,
+            dep_purl: None,
+            dep_vulnerability_id: None,
+            dep_fixed_version: None,
+            dep_source: None,
+            dep_vulnerability_severity: None,
+            dep_path: vec![],
+            crypto_material: None,
+        },
+        comparison_path,
+        identity,
+        has_fingerprint,
+    }))
+}
+
+struct CodeQlSarifPathResolver {
+    uri_bases: HashMap<String, PathBuf>,
+    source_roots: Vec<PathBuf>,
+    comparison_namespaces: HashSet<String>,
+}
+
+impl CodeQlSarifPathResolver {
+    fn from_run(run: &JsonValue, source_roots: &[PathBuf]) -> Result<Self, String> {
+        let mut uri_bases = HashMap::new();
+        if let Some(original_uri_base_ids) = run.get("originalUriBaseIds") {
+            let original_uri_base_ids = original_uri_base_ids
+                .as_object()
+                .ok_or_else(|| "originalUriBaseIds must be an object".to_string())?;
+            for (id, location) in original_uri_base_ids {
+                let uri = location
+                    .get("uri")
+                    .and_then(JsonValue::as_str)
+                    .ok_or_else(|| format!("originalUriBaseIds.{id} lacks a URI"))?;
+                let (path, is_absolute) = sarif_uri_path(uri)?;
+                if !is_absolute {
+                    return Err(format!(
+                        "originalUriBaseIds.{id} is not an absolute file URI"
+                    ));
+                }
+                uri_bases.insert(id.clone(), normalize_absolute_path(&path)?);
+            }
+        }
+
+        let mut source_roots = source_roots
+            .iter()
+            .map(|root| normalize_absolute_path(root))
+            .collect::<Result<Vec<_>, _>>()?;
+        source_roots.sort();
+        source_roots.dedup();
+        let comparison_namespaces = if uri_bases.values().cloned().collect::<HashSet<_>>().len() > 1
+        {
+            uri_bases.keys().cloned().collect()
+        } else {
+            HashSet::new()
+        };
+        Ok(Self {
+            uri_bases,
+            source_roots,
+            comparison_namespaces,
+        })
+    }
+
+    fn comparison_namespaces(&self) -> &HashSet<String> {
+        &self.comparison_namespaces
+    }
+
+    fn normalize_artifact_location(
+        &self,
+        artifact_location: &JsonValue,
+    ) -> Result<CodeQlArtifactPath, String> {
+        let uri = artifact_location
+            .get("uri")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| "artifact location lacks a URI".to_string())?;
+        let (path, is_absolute) = sarif_uri_path(uri)?;
+
+        match artifact_location.get("uriBaseId") {
+            Some(JsonValue::String(uri_base_id)) => {
+                let root = self.uri_bases.get(uri_base_id).ok_or_else(|| {
+                    format!("artifact references unknown uriBaseId '{uri_base_id}'")
+                })?;
+                let display_path = if is_absolute {
+                    stable_path_under_root(&path, root)?
+                } else {
+                    stable_relative_path(&path)?
+                };
+                let comparison_path = if self.comparison_namespaces.contains(uri_base_id) {
+                    uri_base_comparison_path(uri_base_id, &display_path)
+                } else {
+                    single_root_comparison_path(&display_path)
+                };
+                Ok(CodeQlArtifactPath {
+                    comparison_path,
+                    display_path,
+                })
+            }
+            Some(_) => Err("artifact uriBaseId must be a string".to_string()),
+            None => {
+                if self.source_roots.len() > 1 {
+                    return Err(
+                        "artifact path has multiple CodeQL source roots without a uriBaseId"
+                            .to_string(),
+                    );
+                }
+                let display_path = if is_absolute {
+                    stable_path_under_source_root(&path, &self.source_roots)?
+                } else {
+                    stable_relative_path(&path)?
+                };
+                Ok(CodeQlArtifactPath {
+                    comparison_path: single_root_comparison_path(&display_path),
+                    display_path,
+                })
+            }
+        }
+    }
+}
+
+fn uri_base_comparison_path(uri_base_id: &str, display_path: &str) -> String {
+    let mut namespace = String::with_capacity(uri_base_id.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in uri_base_id.bytes() {
+        namespace.push(HEX[(byte >> 4) as usize] as char);
+        namespace.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    format!("codeql-uri-base/{namespace}/{display_path}")
+}
+
+fn single_root_comparison_path(display_path: &str) -> String {
+    format!("codeql-single-root/{display_path}")
+}
+
+fn codeql_database_source_roots(database: &Path) -> Result<Vec<PathBuf>, String> {
+    let metadata_path = database.join("codeql-database.yml");
+    if !metadata_path.exists() {
+        return Ok(Vec::new());
+    }
+    if !metadata_path.is_file() {
+        return Err(format!(
+            "CodeQL database metadata {} is not a file",
+            metadata_path.display()
+        ));
+    }
+
+    let content = std::fs::read_to_string(&metadata_path).map_err(|error| {
+        format!(
+            "failed to read CodeQL database metadata {}: {error}",
+            metadata_path.display()
+        )
+    })?;
+    let metadata: YamlValue = serde_yaml_ng::from_str(&content).map_err(|error| {
+        format!(
+            "failed to parse CodeQL database metadata {}: {error}",
+            metadata_path.display()
+        )
+    })?;
+
+    let mut source_roots = Vec::new();
+    for key in [
+        "sourceLocationPrefix",
+        "sourceLocationPrefixes",
+        "sourceRoot",
+    ] {
+        let Some(value) = metadata.get(key) else {
+            continue;
+        };
+        if let Some(value) = value.as_str() {
+            add_codeql_source_root(&mut source_roots, key, value)?;
+        } else if let Some(values) = value.as_sequence() {
+            for value in values {
+                let value = value.as_str().ok_or_else(|| {
+                    format!(
+                        "CodeQL database metadata {} has a non-string {key} entry",
+                        metadata_path.display()
+                    )
+                })?;
+                add_codeql_source_root(&mut source_roots, key, value)?;
+            }
+        } else if !matches!(value, YamlValue::Null) {
+            return Err(format!(
+                "CodeQL database metadata {} has an invalid {key} value",
+                metadata_path.display()
+            ));
+        }
+    }
+    source_roots.sort();
+    source_roots.dedup();
+    Ok(source_roots)
+}
+
+fn add_codeql_source_root(
+    source_roots: &mut Vec<PathBuf>,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    let (path, is_absolute) =
+        sarif_uri_path(value).map_err(|error| format!("invalid {key} value '{value}': {error}"))?;
+    if !is_absolute {
+        return Err(format!("{key} value '{value}' is not an absolute path"));
+    }
+    source_roots.push(normalize_absolute_path(&path)?);
+    Ok(())
+}
+
+fn sarif_uri_path(uri: &str) -> Result<(PathBuf, bool), String> {
+    let decoded = decode_sarif_uri(uri)?;
+    let path = if let Some(uri) = decoded.strip_prefix("file://") {
+        if uri.starts_with('/') {
+            uri.to_string()
+        } else if let Some(uri) = uri.strip_prefix("localhost/") {
+            format!("/{uri}")
+        } else {
+            return Err(format!("unsupported non-local file URI '{uri}'"));
+        }
+    } else {
+        if decoded.contains("://") {
+            return Err(format!("unsupported artifact URI '{uri}'"));
+        }
+        decoded
+    };
+
+    if looks_like_windows_absolute_path(&path) {
+        return Err(format!(
+            "cannot safely normalize Windows artifact path '{path}' on this platform"
+        ));
+    }
+    let path = PathBuf::from(path);
+    Ok((path.clone(), path.is_absolute()))
+}
+
+fn decode_sarif_uri(uri: &str) -> Result<String, String> {
+    let bytes = uri.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        if index + 2 >= bytes.len() {
+            return Err(format!("invalid percent escape in URI '{uri}'"));
+        }
+        let high = decode_hex(bytes[index + 1])
+            .ok_or_else(|| format!("invalid percent escape in URI '{uri}'"))?;
+        let low = decode_hex(bytes[index + 2])
+            .ok_or_else(|| format!("invalid percent escape in URI '{uri}'"))?;
+        decoded.push(high << 4 | low);
+        index += 3;
+    }
+    String::from_utf8(decoded).map_err(|_| format!("URI '{uri}' is not valid UTF-8"))
+}
+
+fn decode_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn looks_like_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+fn normalize_absolute_path(path: &Path) -> Result<PathBuf, String> {
+    if !path.is_absolute() {
+        return Err(format!("path {} is not absolute", path.display()));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(Path::new("/")),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(format!("path {} escapes its root", path.display()));
+                }
+            }
+            Component::Normal(component) => normalized.push(component),
+        }
+    }
+    Ok(normalized)
+}
+
+fn stable_path_under_source_root(path: &Path, source_roots: &[PathBuf]) -> Result<String, String> {
+    let path = normalize_absolute_path(path)?;
+    let mut matching_roots = Vec::new();
+    for root in source_roots {
+        let root = normalize_absolute_path(root)?;
+        if path.strip_prefix(&root).is_ok() {
+            matching_roots.push(root);
+        }
+    }
+    matching_roots.sort();
+    matching_roots.dedup();
+    let Some(longest_root) = matching_roots
+        .iter()
+        .max_by_key(|root| root.components().count())
+    else {
+        return Err(format!(
+            "absolute artifact path {} has no matching CodeQL source root",
+            path.display()
+        ));
+    };
+    let longest_count = longest_root.components().count();
+    if matching_roots
+        .iter()
+        .filter(|root| root.components().count() == longest_count)
+        .count()
+        != 1
+    {
+        return Err(format!(
+            "absolute artifact path {} has ambiguous CodeQL source roots",
+            path.display()
+        ));
+    }
+    stable_path_under_root(&path, longest_root)
+}
+
+fn stable_path_under_root(path: &Path, root: &Path) -> Result<String, String> {
+    let path = normalize_absolute_path(path)?;
+    let root = normalize_absolute_path(root)?;
+    let relative = path.strip_prefix(&root).map_err(|_| {
+        format!(
+            "artifact path {} is outside {}",
+            path.display(),
+            root.display()
+        )
+    })?;
+    stable_relative_path(relative)
+}
+
+fn stable_relative_path(path: &Path) -> Result<String, String> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(component) => {
+                components.push(component.to_string_lossy().into_owned())
+            }
+            Component::ParentDir => {
+                if components.pop().is_none() {
+                    return Err(format!(
+                        "relative artifact path {} escapes its root",
+                        path.display()
+                    ));
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(format!(
+                    "artifact path {} is not repository-relative",
+                    path.display()
+                ))
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err("artifact path does not identify a source file".to_string());
+    }
+    Ok(components.join("/"))
+}
+
+fn sarif_finding_identity(
+    result: &JsonValue,
+    snippet: Option<&str>,
+    message: &str,
+    line: usize,
+    column: usize,
+    end_line: usize,
+    end_column: usize,
+) -> (String, bool) {
+    if let Some(fingerprint) = sarif_fingerprint(result) {
+        return (format!("fingerprint:{fingerprint}"), true);
+    }
+    if let Some(snippet) = snippet {
+        return (format!("snippet:{}", snippet.trim()), false);
+    }
+    (
+        format!(
+            "location:{line}:{column}:{end_line}:{end_column}:{}",
+            message.trim()
+        ),
+        false,
+    )
+}
+
+fn sarif_fingerprint(result: &JsonValue) -> Option<String> {
+    for field in ["partialFingerprints", "fingerprints"] {
+        let Some(fingerprints) = result.get(field).and_then(JsonValue::as_object) else {
+            continue;
+        };
+        for name in [
+            "primaryLocationLineHash",
+            "primaryLocationStartColumnFingerprint",
+            "primaryLocationEndColumnFingerprint",
+        ] {
+            if let Some(value) = fingerprints.get(name).and_then(JsonValue::as_str) {
+                return Some(format!("{field}:{name}:{value}"));
+            }
+        }
+        let mut values: Vec<_> = fingerprints
+            .iter()
+            .filter_map(|(name, value)| value.as_str().map(|value| (name, value)))
+            .collect();
+        values.sort_unstable_by_key(|(name, _)| *name);
+        if let Some((name, value)) = values.into_iter().next() {
+            return Some(format!("{field}:{name}:{value}"));
+        }
+    }
+    None
+}
+
+fn assign_fallback_occurrences(mut findings: Vec<CodeQlDiffFinding>) -> Vec<CodeQlDiffFinding> {
+    let mut occurrences = HashMap::new();
+    for finding in &mut findings {
+        if finding.has_fingerprint {
+            continue;
+        }
+        let key = codeql_diff_key(
+            &finding.finding.rule_id,
+            &finding.comparison_path,
+            &finding.identity,
+        );
+        let occurrence = occurrences.entry(key).or_insert(0usize);
+        *occurrence += 1;
+        finding.identity = format!("{}#{occurrence}", finding.identity);
+    }
+    findings
 }
 
 /// Resolve a pre-existing database for the rule — rule-level field, then
@@ -826,6 +1657,16 @@ rules:
     }
 
     #[test]
+    fn strict_diff_loader_rejects_missing_rule_path() {
+        let directory = TempDir::new().expect("tempdir");
+        let missing = directory.path().join("missing-rules");
+
+        let error = load_codeql_rules_for_diff(&missing).expect_err("missing path must fail");
+
+        assert!(error.contains("does not exist"), "{error}");
+    }
+
+    #[test]
     fn missing_database_emits_notice_without_findings() {
         let result = scan_with_notices(&[sample_rule()], None);
 
@@ -1004,5 +1845,85 @@ select f, "found main"
         assert_eq!(findings[0].end_column, 11);
         assert_eq!(findings[0].description, "CodeQL found this");
         assert_eq!(findings[0].tags, vec!["codeql".to_string()]);
+    }
+
+    #[test]
+    fn paired_sarif_resolves_uri_base_id_to_repo_relative_path() {
+        let sarif = r#"
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "CodeQL" } },
+      "originalUriBaseIds": {
+        "SRCROOT": { "uri": "file:///tmp/base/" }
+      },
+      "results": [
+        {
+          "message": { "text": "CodeQL found this" },
+          "partialFingerprints": { "primaryLocationLineHash": "stable" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "src/file.c", "uriBaseId": "SRCROOT" },
+                "region": { "startLine": 7, "startColumn": 3 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"#;
+
+        let parsed =
+            parse_sarif_diff_findings(&sample_rule(), sarif, &[]).expect("valid paired SARIF");
+
+        assert_eq!(parsed.findings.len(), 1);
+        assert_eq!(parsed.findings[0].finding.file, "src/file.c");
+        assert_eq!(
+            parsed.findings[0].comparison_path,
+            "codeql-single-root/src/file.c"
+        );
+        assert!(parsed.namespaces.is_empty());
+    }
+
+    #[test]
+    fn paired_sarif_rejects_multiple_source_roots_without_a_uri_base_id() {
+        let sarif = r#"
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "CodeQL" } },
+      "results": [
+        {
+          "message": { "text": "CodeQL found this" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "src/file.c" },
+                "region": { "startLine": 7, "startColumn": 3 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"#;
+        let source_roots = vec![
+            PathBuf::from("/tmp/base/pkg-a"),
+            PathBuf::from("/tmp/base/pkg-b"),
+        ];
+
+        let error = match parse_sarif_diff_findings(&sample_rule(), sarif, &source_roots) {
+            Ok(_) => panic!("multiple anonymous source roots must fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("multiple CodeQL source roots without a uriBaseId"));
     }
 }

--- a/src/engine/codeql.rs
+++ b/src/engine/codeql.rs
@@ -595,10 +595,12 @@ pub fn scan_with_notices_for_target(
 
     let mut scanned_databases = HashSet::new();
     for (rule, database) in runnable_rules {
-        match run_codeql_database_analyze(database.as_path(), &rule.query) {
-            Ok(sarif) => {
+        match run_codeql_database_analyze(database.as_path(), &rule.query)
+            .and_then(|sarif| parse_sarif_findings(rule, &sarif))
+        {
+            Ok(parsed_findings) => {
                 scanned_databases.insert(database);
-                findings.extend(parse_sarif_findings(rule, &sarif));
+                findings.extend(parsed_findings);
             }
             Err(error) => notices.push(format!(
                 "Warning: CodeQL rule '{}' failed: {}",
@@ -674,33 +676,33 @@ fn run_codeql_database_analyze(database: &Path, query: &Path) -> Result<String, 
     }
 }
 
-fn parse_sarif_findings(rule: &CodeQlRule, sarif: &str) -> Vec<Finding> {
-    let Ok(root) = serde_json::from_str::<JsonValue>(sarif) else {
-        return Vec::new();
-    };
+fn parse_sarif_findings(rule: &CodeQlRule, sarif: &str) -> Result<Vec<Finding>, String> {
+    let root: JsonValue =
+        serde_json::from_str(sarif).map_err(|error| format!("invalid CodeQL SARIF: {error}"))?;
+    let mut findings = Vec::new();
 
-    root.get("runs")
+    for run in root
+        .get("runs")
         .and_then(JsonValue::as_array)
         .into_iter()
         .flatten()
-        .flat_map(|run| {
-            run.get("results")
-                .and_then(JsonValue::as_array)
-                .into_iter()
-                .flatten()
-        })
-        .filter_map(|result| {
-            normalized_finding_from_sarif_result(
+    {
+        let Some(results) = run.get("results").and_then(JsonValue::as_array) else {
+            continue;
+        };
+        for result in results {
+            if let Some(finding) = normalized_finding_from_sarif_result(
                 rule,
                 result,
                 CodeQlSnippetSource::LiveCheckout,
                 None,
-            )
-            .ok()
-            .flatten()
-        })
-        .map(|finding| finding.finding)
-        .collect()
+            )? {
+                findings.push(finding.finding);
+            }
+        }
+    }
+
+    Ok(findings)
 }
 
 fn parse_sarif_diff_findings(
@@ -1835,7 +1837,7 @@ select f, "found main"
 }
 "#;
 
-        let findings = parse_sarif_findings(&sample_rule(), sarif);
+        let findings = parse_sarif_findings(&sample_rule(), sarif).expect("valid SARIF");
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].rule_id, "kernel/codeql-test");
@@ -1845,6 +1847,13 @@ select f, "found main"
         assert_eq!(findings[0].end_column, 11);
         assert_eq!(findings[0].description, "CodeQL found this");
         assert_eq!(findings[0].tags, vec!["codeql".to_string()]);
+    }
+
+    #[test]
+    fn rejects_malformed_sarif_instead_of_silently_dropping_it() {
+        let error = parse_sarif_findings(&sample_rule(), "{").expect_err("invalid SARIF");
+
+        assert!(error.starts_with("invalid CodeQL SARIF:"));
     }
 
     #[test]

--- a/tests/codeql_diff.rs
+++ b/tests/codeql_diff.rs
@@ -1,0 +1,784 @@
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_repo() -> TempDir {
+    let repo = TempDir::new().expect("failed to create repository");
+    git(repo.path(), &["init", "-b", "main"]);
+    fs::create_dir_all(repo.path().join("src")).expect("failed to create source directory");
+    fs::write(
+        repo.path().join("src/app.c"),
+        "int main(void) { return 0; }\n",
+    )
+    .expect("failed to write base source");
+    fs::write(
+        repo.path().join("src/shared.c"),
+        "base line 1\nbase line 2\nbase line 3\n",
+    )
+    .expect("failed to write base shared source");
+    git(repo.path(), &["add", "."]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.name=Foxguard Test",
+            "-c",
+            "user.email=foxguard@example.test",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+    fs::write(
+        repo.path().join("src/app.c"),
+        "int main(void) { return 1; }\n",
+    )
+    .expect("failed to write head source");
+    let head_shared = (1..=24)
+        .map(|line| format!("head line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(repo.path().join("src/shared.c"), format!("{head_shared}\n"))
+        .expect("failed to write head shared source");
+    repo
+}
+
+fn write_rule(repo: &Path) -> PathBuf {
+    let query = repo.join("query.ql");
+    fs::write(&query, "import cpp\n").expect("failed to write query");
+    let rules = repo.join("rules.yml");
+    fs::write(
+        &rules,
+        "rules:\n  - id: test/codeql-diff\n    engine: codeql\n    severity: high\n    message: fake CodeQL result\n    query: query.ql\n",
+    )
+    .expect("failed to write CodeQL rule");
+    rules
+}
+
+fn write_database_source_root(database: &Path, source_root: &str) {
+    fs::write(
+        database.join("codeql-database.yml"),
+        format!("sourceLocationPrefix: {source_root}\n"),
+    )
+    .expect("failed to write CodeQL database metadata");
+}
+
+fn write_fake_codeql(dir: &Path) -> PathBuf {
+    let codeql = dir.join("codeql");
+    fs::write(
+        &codeql,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  if [ "$FOXGUARD_TEST_CODEQL_MODE" = "unavailable" ]; then
+    echo "fake CodeQL unavailable" >&2
+    exit 1
+  fi
+  echo "fake CodeQL"
+  exit 0
+fi
+
+output=""
+for arg in "$@"; do
+  case "$arg" in
+    --output=*) output="${arg#--output=}" ;;
+  esac
+done
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "malformed" ]; then
+  printf 'not SARIF' > "$output"
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "malformed-json" ]; then
+  printf '%s' '{"version":"2.1.0","runs":[{"results":[]}]}' > "$output"
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "unsupported-version" ]; then
+  printf '%s' '{"version":"2.0.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[]}]}' > "$output"
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "empty" ]; then
+  printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[]}]}' > "$output"
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "absolute-paths" ]; then
+  case "$3" in
+    *base*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"stable-shared"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"file:///tmp/base/src/shared.c"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"base"}}}}]}]}]}' > "$output"
+      ;;
+    *head*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"stable-shared"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"file:///tmp/head/src/shared.c"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"head"}}}}]}]}]}' > "$output"
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "unrooted-absolute" ]; then
+  printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"stable-shared"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"file:///tmp/no-source-root/src/shared.c"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"shared"}}}}]}]}]}' > "$output"
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "uri-base-namespaces" ]; then
+  case "$3" in
+    *base*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"PKG_A":{"uri":"file:///tmp/base/pkg-a/"},"PKG_B":{"uri":"file:///tmp/base/pkg-b/"}},"results":[{"message":{"text":"pkg-a"},"partialFingerprints":{"primaryLocationLineHash":"same-tail"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/x.c","uriBaseId":"PKG_A"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"pkg-a"}}}}]}]}]}' > "$output"
+      ;;
+    *head*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"PKG_A":{"uri":"file:///tmp/head/pkg-a/"},"PKG_B":{"uri":"file:///tmp/head/pkg-b/"}},"results":[{"message":{"text":"pkg-a"},"partialFingerprints":{"primaryLocationLineHash":"same-tail"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/x.c","uriBaseId":"PKG_A"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"pkg-a"}}}}]},{"message":{"text":"pkg-b"},"partialFingerprints":{"primaryLocationLineHash":"same-tail"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/x.c","uriBaseId":"PKG_B"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"pkg-b"}}}}]}]}]}' > "$output"
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "singleton-mixed" ]; then
+  case "$3" in
+    *base*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"BASE_LABEL":{"uri":"file:///tmp/base/"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"singleton"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/shared.c","uriBaseId":"BASE_LABEL"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"base"}}}}]}]}]}' > "$output"
+      ;;
+    *head*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"singleton"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"file:///tmp/head/src/shared.c"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"head"}}}}]}]}]}' > "$output"
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "singleton-labels" ]; then
+  case "$3" in
+    *base*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"BASE_LABEL":{"uri":"file:///tmp/base/"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"singleton"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/shared.c","uriBaseId":"BASE_LABEL"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"base"}}}}]}]}]}' > "$output"
+      ;;
+    *head*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"HEAD_LABEL":{"uri":"file:///tmp/head/"}},"results":[{"message":{"text":"shared"},"partialFingerprints":{"primaryLocationLineHash":"singleton"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/shared.c","uriBaseId":"HEAD_LABEL"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"head"}}}}]}]}]}' > "$output"
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$FOXGUARD_TEST_CODEQL_MODE" = "multi-base-label-mismatch" ]; then
+  case "$3" in
+    *base*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"PKG_A":{"uri":"file:///tmp/base/pkg-a/"},"PKG_B":{"uri":"file:///tmp/base/pkg-b/"}},"results":[{"message":{"text":"pkg-a"},"partialFingerprints":{"primaryLocationLineHash":"multi"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/x.c","uriBaseId":"PKG_A"},"region":{"startLine":3,"startColumn":1,"snippet":{"text":"pkg-a"}}}}]}]}]}' > "$output"
+      ;;
+    *head*)
+      printf '%s' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL"}},"originalUriBaseIds":{"HEAD_A":{"uri":"file:///tmp/head/pkg-a/"},"HEAD_B":{"uri":"file:///tmp/head/pkg-b/"}},"results":[{"message":{"text":"pkg-a"},"partialFingerprints":{"primaryLocationLineHash":"multi"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/x.c","uriBaseId":"HEAD_A"},"region":{"startLine":17,"startColumn":1,"snippet":{"text":"pkg-a"}}}}]}]}]}' > "$output"
+      ;;
+  esac
+  exit 0
+fi
+
+case "$3" in
+  *failure*)
+    echo "forced CodeQL analysis failure" >&2
+    exit 1
+    ;;
+  *base*)
+    cat > "$output" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {"driver": {"name": "CodeQL"}},
+      "results": [
+        {
+          "message": {"text": "shared base content"},
+          "partialFingerprints": {"primaryLocationLineHash": "stable-shared"},
+          "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "src/shared.c"},
+            "region": {"startLine": 3, "startColumn": 1, "snippet": {"text": "base database source"}}
+          }}]
+        },
+        {
+          "message": {"text": "removed"},
+          "partialFingerprints": {"primaryLocationLineHash": "removed"},
+          "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "src/removed.c"},
+            "region": {"startLine": 1, "startColumn": 1, "snippet": {"text": "removed database source"}}
+          }}]
+        }
+      ]
+    }
+  ]
+}
+SARIF
+    ;;
+  *head*)
+    cat > "$output" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {"driver": {"name": "CodeQL"}},
+      "results": [
+        {
+          "message": {"text": "shared head content"},
+          "partialFingerprints": {"primaryLocationLineHash": "stable-shared"},
+          "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "src/shared.c"},
+            "region": {"startLine": 17, "startColumn": 1, "snippet": {"text": "head database source"}}
+          }}]
+        },
+        {
+          "message": {"text": "shared head content"},
+          "partialFingerprints": {"primaryLocationLineHash": "stable-shared"},
+          "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "src/shared.c"},
+            "region": {"startLine": 17, "startColumn": 1, "snippet": {"text": "head database source"}}
+          }}]
+        },
+        {
+          "message": {"text": "introduced"},
+          "partialFingerprints": {"primaryLocationLineHash": "introduced"},
+          "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "src/shared.c"},
+            "region": {"startLine": 19, "startColumn": 1, "snippet": {"text": "introduced database source"}}
+          }}]
+        }
+      ]
+    }
+  ]
+}
+SARIF
+    ;;
+  *)
+    echo "unexpected database: $3" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )
+    .expect("failed to write fake CodeQL");
+    fs::set_permissions(&codeql, fs::Permissions::from_mode(0o755))
+        .expect("failed to make fake CodeQL executable");
+    codeql
+}
+
+fn foxguard_diff(repo: &Path, fake_codeql_dir: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_foxguard"));
+    let mut path = fake_codeql_dir.as_os_str().to_os_string();
+    path.push(":");
+    path.push(env::var_os("PATH").expect("PATH should be set for git"));
+    command.current_dir(repo).env("PATH", path).args([
+        "diff",
+        "main",
+        ".",
+        "--no-builtins",
+        "-f",
+        "json",
+    ]);
+    command
+}
+
+#[test]
+fn paired_databases_use_sarif_identity_for_moved_findings() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("expected JSON diff report");
+    let findings = report["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "head-only result should appear once");
+    assert_eq!(findings[0]["file"].as_str(), Some("src/shared.c"));
+    assert_eq!(findings[0]["line"].as_u64(), Some(19));
+    assert_eq!(findings[0]["description"].as_str(), Some("introduced"));
+    assert_eq!(
+        findings[0]["snippet"].as_str(),
+        Some("introduced database source")
+    );
+    assert_eq!(findings[0]["rule_id"].as_str(), Some("test/codeql-diff"));
+}
+
+#[test]
+fn paired_databases_normalize_absolute_sarif_paths_from_database_metadata() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+    write_database_source_root(&base, "/tmp/base");
+    write_database_source_root(&head, "/tmp/head");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "absolute-paths")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("expected JSON diff report");
+    assert!(
+        report["findings"]
+            .as_array()
+            .expect("findings array")
+            .is_empty(),
+        "equivalent absolute-source-root findings must be suppressed"
+    );
+}
+
+#[test]
+fn paired_databases_keep_uri_base_ids_with_identical_tails_distinct() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "uri-base-namespaces")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("expected JSON diff report");
+    let findings = report["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["file"].as_str(), Some("src/x.c"));
+    assert_eq!(findings[0]["description"].as_str(), Some("pkg-b"));
+}
+
+#[test]
+fn paired_databases_match_equivalent_singletons_across_encodings_and_labels() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+    write_database_source_root(&head, "/tmp/head");
+
+    for mode in ["singleton-mixed", "singleton-labels"] {
+        let output = foxguard_diff(repo.path(), fake_bin.path())
+            .env("FOXGUARD_TEST_CODEQL_MODE", mode)
+            .args([
+                "--rules",
+                rules.to_str().expect("non-UTF-8 rules path"),
+                "--codeql-base-db",
+                base.to_str().expect("non-UTF-8 base database path"),
+                "--codeql-head-db",
+                head.to_str().expect("non-UTF-8 head database path"),
+            ])
+            .output()
+            .expect("failed to execute foxguard diff");
+
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{mode}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("expected JSON diff report");
+        assert!(
+            report["findings"]
+                .as_array()
+                .expect("findings array")
+                .is_empty(),
+            "{mode}: equivalent singleton findings must be suppressed"
+        );
+    }
+}
+
+#[test]
+fn incompatible_multi_base_namespaces_fail_without_a_clean_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "multi-base-label-mismatch")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("incompatible multi-base uriBaseId namespaces"));
+    assert!(
+        output.stdout.is_empty(),
+        "incompatible multi-base namespaces must not report a clean JSON delta"
+    );
+}
+
+#[test]
+fn paired_databases_accept_valid_empty_sarif_results() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "empty")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(0));
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("expected JSON diff report");
+    assert!(report["findings"]
+        .as_array()
+        .expect("findings array")
+        .is_empty());
+}
+
+#[test]
+fn malformed_json_sarif_and_unsupported_versions_fail_without_a_clean_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    for (mode, expected_error) in [
+        ("malformed-json", "lacks a tool object"),
+        ("unsupported-version", "unsupported SARIF version"),
+    ] {
+        let output = foxguard_diff(repo.path(), fake_bin.path())
+            .env("FOXGUARD_TEST_CODEQL_MODE", mode)
+            .args([
+                "--rules",
+                rules.to_str().expect("non-UTF-8 rules path"),
+                "--codeql-base-db",
+                base.to_str().expect("non-UTF-8 base database path"),
+                "--codeql-head-db",
+                head.to_str().expect("non-UTF-8 head database path"),
+            ])
+            .output()
+            .expect("failed to execute foxguard diff");
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(expected_error),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "invalid SARIF must not report a clean JSON delta"
+        );
+    }
+}
+
+#[test]
+fn unrooted_absolute_sarif_path_fails_without_a_clean_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "unrooted-absolute")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("no matching CodeQL source root"));
+    assert!(
+        output.stdout.is_empty(),
+        "an unrooted absolute artifact must not report a clean JSON delta"
+    );
+}
+
+#[test]
+fn incomplete_codeql_database_pairs_are_rejected() {
+    let repo = setup_repo();
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    let base = repo.path().join("base-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+
+    let cli = foxguard_diff(repo.path(), fake_bin.path())
+        .args([
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+    assert_eq!(cli.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&cli.stderr).contains("--codeql-head-db"));
+
+    let config = repo.path().join("foxguard.yml");
+    fs::write(&config, "diff:\n  codeql_base_db: base-db\n")
+        .expect("failed to write incomplete config");
+    let configured = foxguard_diff(repo.path(), fake_bin.path())
+        .args(["--config", config.to_str().expect("non-UTF-8 config path")])
+        .output()
+        .expect("failed to execute configured foxguard diff");
+    assert_eq!(configured.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&configured.stderr)
+        .contains("diff.codeql_base_db and diff.codeql_head_db"));
+}
+
+#[test]
+fn unavailable_codeql_fails_without_a_clean_diff_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "unavailable")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("CodeQL diff skipped"));
+    assert!(
+        output.stdout.is_empty(),
+        "a failed CodeQL comparison must not report clean JSON"
+    );
+}
+
+#[test]
+fn failed_head_analysis_fails_without_a_clean_diff_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("failure-head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("forced CodeQL analysis failure"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a failed CodeQL comparison must not report clean JSON"
+    );
+}
+
+#[test]
+fn malformed_sarif_fails_without_a_clean_diff_report() {
+    let repo = setup_repo();
+    let rules = write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    write_fake_codeql(fake_bin.path());
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("FOXGUARD_TEST_CODEQL_MODE", "malformed")
+        .args([
+            "--rules",
+            rules.to_str().expect("non-UTF-8 rules path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute foxguard diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("produced invalid SARIF"), "{stderr}");
+    assert!(stderr.contains("invalid JSON"), "{stderr}");
+    assert!(
+        output.stdout.is_empty(),
+        "malformed CodeQL output must not report clean JSON"
+    );
+}
+
+#[test]
+fn invalid_or_unloadable_codeql_rules_fail_the_paired_comparison() {
+    let repo = setup_repo();
+    write_rule(repo.path());
+    let fake_bin = TempDir::new().expect("failed to create fake CodeQL directory");
+    let base = repo.path().join("base-db");
+    let head = repo.path().join("head-db");
+    fs::create_dir_all(&base).expect("failed to create base database directory");
+    fs::create_dir_all(&head).expect("failed to create head database directory");
+
+    let invalid = repo.path().join("invalid-codeql.yml");
+    fs::write(
+        &invalid,
+        "rules:\n  - id: test/invalid\n    engine: codeql\n    severity: nope\n    message: invalid\n    query: query.ql\n",
+    )
+    .expect("failed to write invalid rule");
+    let invalid_output = foxguard_diff(repo.path(), fake_bin.path())
+        .args([
+            "--rules",
+            invalid.to_str().expect("non-UTF-8 invalid rule path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute invalid CodeQL diff");
+    assert_eq!(invalid_output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&invalid_output.stderr)
+        .contains("CodeQL diff failed to load rules"));
+    assert!(invalid_output.stdout.is_empty());
+
+    let missing_query = repo.path().join("missing-query-codeql.yml");
+    fs::write(
+        &missing_query,
+        "rules:\n  - id: test/missing-query\n    engine: codeql\n    severity: high\n    message: missing query\n    query: queries/missing.ql\n",
+    )
+    .expect("failed to write missing-query rule");
+    let missing_query_output = foxguard_diff(repo.path(), fake_bin.path())
+        .args([
+            "--rules",
+            missing_query
+                .to_str()
+                .expect("non-UTF-8 missing-query rule path"),
+            "--codeql-base-db",
+            base.to_str().expect("non-UTF-8 base database path"),
+            "--codeql-head-db",
+            head.to_str().expect("non-UTF-8 head database path"),
+        ])
+        .output()
+        .expect("failed to execute unloadable CodeQL diff");
+    assert_eq!(missing_query_output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&missing_query_output.stderr).contains("query"));
+    assert!(missing_query_output.stdout.is_empty());
+}

--- a/tests/mcp_server.rs
+++ b/tests/mcp_server.rs
@@ -169,6 +169,14 @@ fn test_mcp_server_lifecycle() {
         );
     }
 
+    let diff_schema = tools
+        .iter()
+        .find(|tool| tool["name"].as_str() == Some("scan_diff"))
+        .map(|tool| &tool["inputSchema"])
+        .expect("scan_diff schema");
+    assert!(diff_schema["properties"]["codeql_base_db"].is_object());
+    assert!(diff_schema["properties"]["codeql_head_db"].is_object());
+
     // 4. Send tools/call with scan_file on a known vulnerable fixture
     let fixture_dir = tempfile::tempdir()
         .unwrap_or_else(|error| panic!("failed to create temporary fixture directory: {error}"));


### PR DESCRIPTION
## Summary
- add paired base/head CodeQL database inputs to `foxguard diff`
- compare normalized CodeQL results through the existing diff path
- reject incomplete or failed comparisons without a clean delta

## Verification
- `cargo test --locked --test codeql_diff`
- `cargo test --locked`
- `cargo test --locked --all-features -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Fixes #582