### PR TITLE
feat: add PR security policy

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,5 +1,11 @@
 use crate::app::{execute_diff, execute_scan, execute_secrets};
-use crate::cli::{ChangeModeArgs, DiffArgs, OutputFormat, ScanArgs, SecretsArgs, SeverityFilter};
+use crate::cli::{
+    ChangeModeArgs, DiffArgs, OutputFormat, PrSecurityPolicyArgs, ScanArgs, SecretsArgs,
+    SeverityFilter,
+};
+use crate::pr_policy::{
+    evaluate, PrPolicyNotEvaluated, PrPolicyReport, PrSecurityPolicy, PrSecurityPolicyInput,
+};
 use crate::{Finding, Severity};
 use serde::{Deserialize, Serialize};
 
@@ -66,6 +72,8 @@ pub struct AdapterRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_security_policy: Option<PrSecurityPolicyInput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rules: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codeql_base_db: Option<String>,
@@ -102,6 +110,7 @@ impl AdapterRequest {
             base: None,
             severity: None,
             config: None,
+            pr_security_policy: None,
             rules: None,
             codeql_base_db: None,
             codeql_head_db: None,
@@ -173,6 +182,10 @@ pub struct AdapterResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff: Option<AdapterDiffSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_security_policy: Option<PrPolicyReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_security_policy_not_evaluated: Option<PrPolicyNotEvaluated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub suppression: Option<AdapterSuppressionSuggestion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -205,6 +218,8 @@ pub fn adapter_error_response(
         findings: Vec::new(),
         notices: Vec::new(),
         diff: None,
+        pr_security_policy: None,
+        pr_security_policy_not_evaluated: None,
         suppression: None,
         error: Some(error.into()),
     }
@@ -263,17 +278,23 @@ fn explain_response(request: &AdapterRequest) -> AdapterResponse {
     scan.explain = true;
     match execute_scan(&scan) {
         Ok(result) => {
-            let findings = select_findings(result.findings, request.finding.as_ref());
+            let pr_security_policy_not_evaluated = result.pr_security_policy_not_evaluated;
+            let (findings, pr_security_policy, policy_exit_code) =
+                apply_pr_security_policy(result.pr_security_policy, result.findings);
+            let findings = select_findings(findings, request.finding.as_ref());
             let summary = summarize(&findings, result.files_scanned, result.duration);
-            success_response(
+            let mut response = success_response(
                 request,
-                findings_exit_code(&findings),
+                policy_exit_code.unwrap_or_else(|| findings_exit_code(&findings)),
                 Some(summary),
                 findings,
                 result.notices,
                 None,
                 None,
-            )
+            );
+            response.pr_security_policy = pr_security_policy;
+            response.pr_security_policy_not_evaluated = pr_security_policy_not_evaluated;
+            response
         }
         Err(error) => request_error(request, error),
     }
@@ -283,17 +304,22 @@ fn run_scan_response(request: &AdapterRequest, path: String, pq_mode: bool) -> A
     let scan = scan_args(request, path, pq_mode);
     match execute_scan(&scan) {
         Ok(result) => {
-            let summary = summarize(&result.findings, result.files_scanned, result.duration);
-            let exit_code = findings_exit_code(&result.findings);
-            success_response(
+            let pr_security_policy_not_evaluated = result.pr_security_policy_not_evaluated;
+            let (findings, pr_security_policy, policy_exit_code) =
+                apply_pr_security_policy(result.pr_security_policy, result.findings);
+            let summary = summarize(&findings, result.files_scanned, result.duration);
+            let mut response = success_response(
                 request,
-                exit_code,
+                policy_exit_code.unwrap_or_else(|| findings_exit_code(&findings)),
                 Some(summary),
-                result.findings,
+                findings,
                 result.notices,
                 None,
                 None,
-            )
+            );
+            response.pr_security_policy = pr_security_policy;
+            response.pr_security_policy_not_evaluated = pr_security_policy_not_evaluated;
+            response
         }
         Err(error) => request_error(request, error),
     }
@@ -352,22 +378,27 @@ fn diff_response(request: &AdapterRequest) -> AdapterResponse {
     let args = adapter_diff_args(request, path, &base);
     match execute_diff(&args) {
         Ok(result) => {
-            let summary = summarize(&result.findings, result.files_scanned, result.duration);
-            let exit_code = findings_exit_code(&result.findings);
+            let pr_security_policy_not_evaluated = result.pr_security_policy_not_evaluated;
+            let (findings, pr_security_policy, policy_exit_code) =
+                apply_pr_security_policy(result.pr_security_policy, result.findings);
+            let summary = summarize(&findings, result.files_scanned, result.duration);
             let diff = AdapterDiffSummary {
                 base,
                 total_current: result.total_current,
                 existing_count: result.existing_count,
             };
-            success_response(
+            let mut response = success_response(
                 request,
-                exit_code,
+                policy_exit_code.unwrap_or_else(|| findings_exit_code(&findings)),
                 Some(summary),
-                result.findings,
+                findings,
                 result.notices,
                 Some(diff),
                 None,
-            )
+            );
+            response.pr_security_policy = pr_security_policy;
+            response.pr_security_policy_not_evaluated = pr_security_policy_not_evaluated;
+            response
         }
         Err(error) => request_error(request, error),
     }
@@ -398,6 +429,7 @@ fn adapter_diff_args(request: &AdapterRequest, path: &str, base: &str) -> DiffAr
         no_builtins: request.no_builtins,
         output: None,
         github_pr: None,
+        pr_security_policy: pr_security_policy_args(request),
         max_file_size: max_file_size(request),
     }
 }
@@ -456,6 +488,7 @@ fn scan_args(request: &AdapterRequest, path: String, pq_mode: bool) -> ScanArgs 
         explain: request.explain || pq_mode,
         fix: false,
         github_pr: None,
+        pr_security_policy: pr_security_policy_args(request),
         quiet: true,
         output: None,
         max_file_size: max_file_size(request),
@@ -468,6 +501,35 @@ fn scan_args(request: &AdapterRequest, path: String, pq_mode: bool) -> ScanArgs 
         sca_db: None,
         sca_cache: None,
     }
+}
+
+fn pr_security_policy_args(request: &AdapterRequest) -> PrSecurityPolicyArgs {
+    let Some(policy) = request.pr_security_policy.as_ref() else {
+        return PrSecurityPolicyArgs::default();
+    };
+
+    PrSecurityPolicyArgs {
+        pr_policy: true,
+        policy_version: policy.version,
+        scope: policy.scope,
+        reporting_threshold: policy.reporting_threshold.map(severity_filter),
+        blocking_threshold: policy.blocking_threshold,
+        policy_output: None,
+    }
+}
+
+fn apply_pr_security_policy(
+    policy: Option<PrSecurityPolicy>,
+    findings: Vec<Finding>,
+) -> (Vec<Finding>, Option<PrPolicyReport>, Option<u8>) {
+    let Some(policy) = policy else {
+        return (findings, None, None);
+    };
+
+    let evaluation = evaluate(policy, findings);
+    let exit_code = evaluation.report().decision.exit_code() as u8;
+    let report = evaluation.report().clone();
+    (evaluation.findings, Some(report), Some(exit_code))
 }
 
 fn success_response(
@@ -490,6 +552,8 @@ fn success_response(
         notices,
         diff,
         suppression,
+        pr_security_policy: None,
+        pr_security_policy_not_evaluated: None,
         error: None,
     }
 }
@@ -756,6 +820,108 @@ mod tests {
         };
         assert_eq!(summary.findings_total, response.findings.len());
         assert_eq!(summary.files_scanned, 1);
+    }
+
+    #[test]
+    fn adapter_scan_file_policy_is_explicitly_not_evaluated() {
+        let temp = must(tempfile::tempdir());
+        let file = temp.path().join("app.py");
+        if let Err(error) = std::fs::write(&file, "password = \"supersecret123\"\nDEBUG = True\n") {
+            panic!("{error}");
+        }
+
+        let mut request = AdapterRequest::new(AdapterCommand::ScanFile);
+        request.path = Some(file.to_string_lossy().into_owned());
+        request.pr_security_policy = Some(PrSecurityPolicyInput::default());
+
+        let response = execute_adapter_request(request);
+        assert!(
+            response.ok,
+            "unexpected adapter error: {:?}",
+            response.error
+        );
+        assert!(response.pr_security_policy.is_none());
+        assert_eq!(
+            response
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(crate::pr_policy::PrPolicyNotEvaluatedReason::PartialScan)
+        );
+    }
+
+    #[test]
+    fn adapter_nested_project_directory_is_not_a_repository_policy_scan() {
+        let temp = must(tempfile::tempdir());
+        let repo = temp.path();
+        let source = repo.join("src").join("app.py");
+        if let Err(error) = std::fs::create_dir_all(source.parent().expect("source parent")) {
+            panic!("{error}");
+        }
+        if let Err(error) = std::fs::write(repo.join(".foxguard.yml"), "scan: {}\n") {
+            panic!("{error}");
+        }
+        if let Err(error) = std::fs::write(&source, "print('safe')\n") {
+            panic!("{error}");
+        }
+
+        let mut request = AdapterRequest::new(AdapterCommand::ScanWorkspace);
+        request.path = Some(
+            source
+                .parent()
+                .expect("source parent")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        request.pr_security_policy = Some(PrSecurityPolicyInput::default());
+
+        let response = execute_adapter_request(request);
+
+        assert!(
+            response.ok,
+            "unexpected adapter error: {:?}",
+            response.error
+        );
+        assert!(response.pr_security_policy.is_none());
+        assert_eq!(
+            response
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(crate::pr_policy::PrPolicyNotEvaluatedReason::PartialScan)
+        );
+    }
+
+    #[test]
+    fn adapter_response_matches_shared_mixed_policy_contract() {
+        let (policy, findings, expected) = crate::pr_policy::contract_fixture::mixed_v1();
+        let (findings, pr_security_policy, policy_exit_code) =
+            apply_pr_security_policy(Some(policy), findings);
+        let request = AdapterRequest::new(AdapterCommand::ScanWorkspace);
+        let mut response = success_response(
+            &request,
+            policy_exit_code.expect("policy exit code"),
+            Some(summarize(
+                &findings,
+                findings.len(),
+                std::time::Duration::default(),
+            )),
+            findings,
+            Vec::new(),
+            None,
+            None,
+        );
+        response.pr_security_policy = pr_security_policy;
+
+        let encoded = must(serde_json::to_value(&response));
+        assert_eq!(response.pr_security_policy.as_ref(), Some(&expected));
+        assert_eq!(response.findings.len(), expected.included_findings);
+        assert_eq!(response.exit_code, expected.decision.exit_code() as u8);
+        assert_eq!(
+            encoded["pr_security_policy"]["decision"].as_str(),
+            Some("fail")
+        );
+        assert!(encoded.get("pr_security_policy_not_evaluated").is_none());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,19 @@
 use crate::baseline::{load_baseline, suppress_with_baseline_at_root, write_baseline_at_root};
-use crate::cli::{DiffArgs, OutputFormat, ScanArgs, SecretsArgs, TuiArgs};
+use crate::cli::{DiffArgs, OutputFormat, PrSecurityPolicyArgs, ScanArgs, SecretsArgs, TuiArgs};
 use crate::config::{
-    apply_scan_defaults, apply_secrets_defaults, apply_severity_overrides, load_for_scan,
-    secret_scan_thresholds, suppress_with_patterns, suppress_with_scan_ignores, FoxguardConfig,
+    apply_scan_defaults, apply_secrets_defaults, apply_severity_overrides, config_root_for_scan,
+    load_for_scan, secret_scan_thresholds, suppress_with_patterns, suppress_with_scan_ignores,
+    FoxguardConfig,
 };
 use crate::deps::{scan_dependency_vulnerabilities, DependencyScanOptions};
 use crate::diff::run_diff_with_coccinelle_warnings;
 use crate::engine::{
     coccinelle, codeql, scan_directory_with_notices, scan_paths_with_root_with_notices, ScanResult,
     ScanStats,
+};
+use crate::pr_policy::{
+    resolve as resolve_pr_security_policy, PrPolicyNotEvaluated, PrPolicyNotEvaluatedReason,
+    PrSecurityPolicy,
 };
 use crate::rules::semgrep_compat::load_semgrep_rules;
 use crate::rules::RuleRegistry;
@@ -27,6 +32,8 @@ pub struct ScanExecution {
     pub stats: ScanStats,
     pub duration: std::time::Duration,
     pub notices: Vec<String>,
+    pub pr_security_policy: Option<PrSecurityPolicy>,
+    pub pr_security_policy_not_evaluated: Option<PrPolicyNotEvaluated>,
 }
 
 pub struct SecretsExecution {
@@ -45,6 +52,8 @@ pub struct DiffExecution {
     pub total_current: usize,
     pub existing_count: usize,
     pub notices: Vec<String>,
+    pub pr_security_policy: Option<PrSecurityPolicy>,
+    pub pr_security_policy_not_evaluated: Option<PrPolicyNotEvaluated>,
 }
 
 struct CodeQlDiffDatabases {
@@ -89,6 +98,37 @@ pub fn resolve_secrets_args(args: &SecretsArgs) -> Result<SecretsArgs, String> {
     Ok(args)
 }
 
+fn resolve_pr_security_policy_for_surface(
+    config: Option<&FoxguardConfig>,
+    args: &PrSecurityPolicyArgs,
+    github_pr: bool,
+) -> Result<Option<PrSecurityPolicy>, String> {
+    if !github_pr && !args.is_enabled() {
+        return Ok(None);
+    }
+
+    resolve_pr_security_policy(
+        config.and_then(|config| config.pr_security_policy.as_ref()),
+        &args.input(),
+    )
+    .map(Some)
+}
+
+fn scan_targets_pr_policy_root(scan_path: &Path, config_path: Option<&str>) -> bool {
+    if !scan_path.is_dir() {
+        return false;
+    }
+
+    let configured_root = config_root_for_scan(scan_path, config_path);
+    let Some(project_root) =
+        crate::path_identity::pr_policy_root(scan_path, configured_root.as_deref())
+    else {
+        return false;
+    };
+
+    crate::path_identity::resolve_path_for_boundary(scan_path) == project_root
+}
+
 pub fn scan_findings(scan: &ScanArgs) -> Result<ScanResult, String> {
     let execution = execute_scan(scan)?;
     Ok(ScanResult {
@@ -117,6 +157,28 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     let config = load_for_scan(Path::new(&scan.path), scan.config.as_deref())?;
     validate_root_path(&scan.path)?;
     validate_rules_path(scan.rules.as_deref())?;
+    let change_limited = scan.changed_files_from.is_some() || scan.changes.selection().is_some();
+    let requested_pr_security_policy = resolve_pr_security_policy_for_surface(
+        config.as_ref(),
+        &scan.pr_security_policy,
+        scan.github_pr.is_some(),
+    )?;
+    let full_repository_scan = requested_pr_security_policy.is_some()
+        && !change_limited
+        && scan_targets_pr_policy_root(Path::new(&scan.path), scan.config.as_deref());
+    let (pr_security_policy, pr_security_policy_not_evaluated) = match requested_pr_security_policy
+    {
+        Some(policy) if full_repository_scan => (Some(policy), None),
+        Some(policy) => {
+            let reason = if change_limited {
+                PrPolicyNotEvaluatedReason::ChangedOnlyScan
+            } else {
+                PrPolicyNotEvaluatedReason::PartialScan
+            };
+            (None, Some(PrPolicyNotEvaluated::new(policy, reason)))
+        }
+        None => (None, None),
+    };
     let identity_root = finding_identity_root(Path::new(&scan.path), config.as_ref());
 
     let mut registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
@@ -403,12 +465,18 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
         }
     }
 
+    if let Some(policy) = &pr_security_policy_not_evaluated {
+        notices.push(policy.to_string());
+    }
+
     Ok(ScanExecution {
         args: scan,
         findings,
         files_scanned,
         stats,
         duration,
+        pr_security_policy,
+        pr_security_policy_not_evaluated,
         notices,
     })
 }
@@ -474,6 +542,13 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), args.config.as_deref())?;
     let codeql_databases = resolve_codeql_diff_databases(args, config.as_ref())?;
+    let pr_security_policy_not_evaluated = resolve_pr_security_policy_for_surface(
+        config.as_ref(),
+        &args.pr_security_policy,
+        args.github_pr.is_some(),
+    )?
+    .map(|policy| PrPolicyNotEvaluated::new(policy, PrPolicyNotEvaluatedReason::DiffScan));
+    let pr_security_policy = None;
     let identity_root = finding_identity_root(Path::new(&args.path), config.as_ref());
     let config_scan = config.as_ref().map(|config| &config.scan);
     let rules_path = args
@@ -610,6 +685,10 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
         diff_result.existing_count
     ));
 
+    if let Some(policy) = &pr_security_policy_not_evaluated {
+        notices.push(policy.to_string());
+    }
+
     Ok(DiffExecution {
         args: args.clone(),
         findings: diff_result.new_findings,
@@ -617,6 +696,8 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
         duration: scan_result.duration,
         total_current: diff_result.total_current,
         existing_count: diff_result.existing_count,
+        pr_security_policy,
+        pr_security_policy_not_evaluated,
         notices,
     })
 }
@@ -731,6 +812,7 @@ fn tui_scan_args(args: &TuiArgs) -> ScanArgs {
         write_baseline: None,
         explain: args.explain,
         github_pr: None,
+        pr_security_policy: PrSecurityPolicyArgs::default(),
         quiet: false,
         output: None,
         max_file_size: args.max_file_size,
@@ -759,6 +841,7 @@ fn tui_diff_args(args: &TuiArgs, target: &str) -> DiffArgs {
         no_builtins: args.no_builtins,
         output: None,
         github_pr: None,
+        pr_security_policy: PrSecurityPolicyArgs::default(),
         max_file_size: args.max_file_size,
     }
 }
@@ -910,6 +993,8 @@ fn count_secret_files(scan_path: &Path) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::Cli;
+    use clap::Parser;
 
     #[test]
     fn pq_rule_ids_include_coccinelle_rules() {
@@ -923,5 +1008,167 @@ mod tests {
 
         assert!(ids.contains(&"kernel/pq-vulnerable-cocci".to_string()));
         assert!(!ids.contains(&"kernel/non-pq-cocci".to_string()));
+    }
+
+    #[test]
+    fn changed_file_scan_is_not_labeled_as_a_repository_policy_decision() {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        std::fs::write(temp.path().join("app.py"), "print('safe')\n").expect("write source file");
+        let changed_files = temp.path().join("changed-files.txt");
+        std::fs::write(&changed_files, "app.py\n").expect("write changed-files list");
+        let path = temp.path().to_string_lossy().into_owned();
+        let changed_files = changed_files.to_string_lossy().into_owned();
+        let cli = Cli::try_parse_from([
+            "foxguard",
+            "--pr-policy",
+            "--changed-files-from",
+            &changed_files,
+            &path,
+        ])
+        .expect("parse CLI scan");
+
+        let result = execute_scan(&cli.scan).expect("scan changed file");
+
+        assert!(result.pr_security_policy.is_none());
+        assert_eq!(
+            result
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(PrPolicyNotEvaluatedReason::ChangedOnlyScan)
+        );
+    }
+
+    #[test]
+    fn cli_scan_without_a_project_root_is_not_a_repository_policy_scan() {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        std::fs::write(temp.path().join("app.py"), "print('safe')\n").expect("write source file");
+        let path = temp.path().to_string_lossy().into_owned();
+        let cli = Cli::try_parse_from(["foxguard", "--pr-policy", &path]).expect("parse CLI scan");
+
+        let result = execute_scan(&cli.scan).expect("scan directory");
+
+        assert!(result.pr_security_policy.is_none());
+        assert_eq!(
+            result
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(PrPolicyNotEvaluatedReason::PartialScan)
+        );
+    }
+
+    #[test]
+    fn cli_nested_repository_directory_is_not_a_repository_policy_scan() {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let repo = temp.path();
+        git(repo, &["init", "-q"]);
+        let source = repo.join("src").join("app.py");
+        std::fs::create_dir_all(source.parent().expect("source parent"))
+            .expect("create source directory");
+        std::fs::write(
+            source
+                .parent()
+                .expect("source parent")
+                .join(".foxguard.yml"),
+            "scan: {}\n",
+        )
+        .expect("write nested config");
+        std::fs::write(&source, "print('safe')\n").expect("write source file");
+        let path = source
+            .parent()
+            .expect("source parent")
+            .to_string_lossy()
+            .into_owned();
+        let cli = Cli::try_parse_from(["foxguard", "--pr-policy", &path]).expect("parse CLI scan");
+
+        let result = execute_scan(&cli.scan).expect("scan nested directory");
+
+        assert!(result.pr_security_policy.is_none());
+        assert_eq!(
+            result
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(PrPolicyNotEvaluatedReason::PartialScan)
+        );
+    }
+
+    #[test]
+    fn cli_git_root_beats_ancestor_explicit_config_for_policy_scope() {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repository");
+        git(&repo, &["init", "-q"]);
+        std::fs::write(repo.join("app.py"), "print('safe')\n").expect("write source file");
+        let config = temp.path().join("foxguard.yml");
+        std::fs::write(&config, "scan: {}\n").expect("write ancestor config");
+        let path = repo.to_string_lossy().into_owned();
+        let config = config.to_string_lossy().into_owned();
+        let cli = Cli::try_parse_from(["foxguard", "--pr-policy", "--config", &config, &path])
+            .expect("parse CLI scan");
+
+        let result = execute_scan(&cli.scan).expect("scan Git root");
+
+        assert!(result.pr_security_policy.is_some());
+        assert!(result.pr_security_policy_not_evaluated.is_none());
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    #[test]
+    fn diff_policy_is_explicitly_not_evaluated() {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let repo = temp.path();
+        git(repo, &["init", "-q"]);
+        std::fs::write(repo.join("app.py"), "print('before')\n").expect("write source file");
+        git(repo, &["add", "app.py"]);
+        git(
+            repo,
+            &[
+                "-c",
+                "user.name=Foxguard Test",
+                "-c",
+                "user.email=test@example.invalid",
+                "commit",
+                "-qm",
+                "initial",
+            ],
+        );
+        std::fs::write(repo.join("app.py"), "print('after')\n").expect("modify source file");
+
+        let result = execute_diff(&DiffArgs {
+            target: "HEAD".to_string(),
+            path: repo.to_string_lossy().into_owned(),
+            config: None,
+            format: OutputFormat::Json,
+            severity: None,
+            rules: None,
+            no_builtins: false,
+            output: None,
+            github_pr: None,
+            pr_security_policy: PrSecurityPolicyArgs {
+                pr_policy: true,
+                ..PrSecurityPolicyArgs::default()
+            },
+            max_file_size: 1_048_576,
+        })
+        .expect("run diff");
+
+        assert!(result.pr_security_policy.is_none());
+        assert_eq!(
+            result
+                .pr_security_policy_not_evaluated
+                .as_ref()
+                .map(|policy| policy.reason),
+            Some(PrPolicyNotEvaluatedReason::DiffScan)
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1151,6 +1151,8 @@ mod tests {
             format: OutputFormat::Json,
             severity: None,
             rules: None,
+            codeql_base_db: None,
+            codeql_head_db: None,
             no_builtins: false,
             output: None,
             github_pr: None,

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -27,12 +27,17 @@ use axum::{
     Router,
 };
 use base64::Engine;
+use foxguard::config::load_for_scan;
 use foxguard::github_app::auth::{
     AppCredentials, AuthError, GitHubAppAuthClient, InstallationToken, InstallationTokenCache,
 };
 use foxguard::github_app::installation_store::{InstallationMetadataInput, InstallationStore};
-use foxguard::github_app::review::{GitHubReviewClient, SourceRevision};
+use foxguard::github_app::review::{CheckRunPolicy, GitHubReviewClient, SourceRevision};
 use foxguard::github_app::webhook::{verify_signature, EventKind, SignatureError};
+use foxguard::pr_policy::{
+    evaluate, resolve as resolve_pr_security_policy, PrPolicyEvaluation, PrPolicyNotEvaluated,
+    PrPolicyNotEvaluatedReason, PrSecurityPolicyInput,
+};
 use foxguard::report::github_pr::relative_path;
 use foxguard::Finding;
 use serde::Deserialize;
@@ -372,7 +377,7 @@ fn start_pull_request_workers(
                                 action = job.action,
                                 pr_number = result.pr_number,
                                 repo = result.repo,
-                                findings = result.findings.len(),
+                                findings = result.findings_for_transport().len(),
                                 review_messages = result.review_messages,
                                 deleted_comments = result.deleted_comments,
                                 posted_check_annotations = result.posted_check_annotations,
@@ -643,15 +648,43 @@ fn repository_names(repositories: Option<&[GitHubRepositorySummary]>) -> Vec<Str
 }
 
 #[derive(Debug)]
+enum PullRequestPolicyOutcome {
+    Evaluated(PrPolicyEvaluation),
+    NotEvaluated(PrPolicyNotEvaluated),
+}
+
+#[derive(Debug)]
 struct PullRequestScanResult {
     pr_number: u64,
     repo: String,
     head_sha: String,
     head_repo_web_url: String,
     findings: Vec<Finding>,
+    policy_outcome: PullRequestPolicyOutcome,
     review_messages: usize,
     deleted_comments: usize,
     posted_check_annotations: usize,
+}
+
+impl PullRequestScanResult {
+    fn findings_for_transport(&self) -> &[Finding] {
+        match &self.policy_outcome {
+            PullRequestPolicyOutcome::Evaluated(evaluation) => &evaluation.findings,
+            PullRequestPolicyOutcome::NotEvaluated(_) => &self.findings,
+        }
+    }
+
+    fn check_run_policy(&self) -> CheckRunPolicy<'_> {
+        match &self.policy_outcome {
+            PullRequestPolicyOutcome::Evaluated(evaluation) => {
+                CheckRunPolicy::Evaluated(evaluation)
+            }
+            PullRequestPolicyOutcome::NotEvaluated(policy) => CheckRunPolicy::NotEvaluated {
+                findings: &self.findings,
+                policy,
+            },
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -720,7 +753,7 @@ async fn process_pull_request_delivery(
         .post_pull_request_review(
             &result.repo,
             result.pr_number,
-            &result.findings,
+            result.findings_for_transport(),
             &source_revision,
             &token,
             changed_lines.as_ref(),
@@ -734,7 +767,7 @@ async fn process_pull_request_delivery(
         .post_check_run(
             &result.repo,
             &result.head_sha,
-            &result.findings,
+            result.check_run_policy(),
             &token,
             changed_lines.as_ref(),
         )
@@ -780,6 +813,17 @@ fn run_pull_request_scan(
         ));
     }
 
+    let config = load_for_scan(&checkout, None)
+        .map_err(|error| format!("failed to load PR security policy config: {error}"))?;
+    let policy_overrides = PrSecurityPolicyInput::default();
+    let policy = resolve_pr_security_policy(
+        config
+            .as_ref()
+            .and_then(|config| config.pr_security_policy.as_ref()),
+        &policy_overrides,
+    )
+    .map_err(|error| format!("invalid PR security policy: {error}"))?;
+
     // Full-tree scan FIRST — this preserves whole-repo cross-file taint context
     // (a source in an unchanged file reaching a sink in a changed file is still
     // caught), which is foxguard's headline capability. The ~80% of PRs whose
@@ -805,17 +849,20 @@ fn run_pull_request_scan(
         _ => None,
     };
 
-    let output = match run_scanner(&checkout, None) {
-        Ok(output) => output,
+    let (output, full_repository_scan) = match run_scanner(&checkout, None) {
+        Ok(output) => (output, true),
         Err(error) if is_scan_timeout(&error) && changed_files_list.is_some() => {
             warn!(
                 repo = target_repo,
                 pr_number = pull_request.number,
                 "full-tree scan timed out; falling back to a diff-scoped scan of \
                  the PR's changed files (cross-file taint from unchanged files not \
-                 analysed on this path)"
+                 analysed on this path); v1 repository policy will not be evaluated"
             );
-            run_scanner(&checkout, changed_files_list.as_deref())?
+            (
+                run_scanner(&checkout, changed_files_list.as_deref())?,
+                false,
+            )
         }
         Err(error) => return Err(error),
     };
@@ -823,12 +870,27 @@ fn run_pull_request_scan(
     for finding in &mut findings {
         finding.file = relative_path(&finding.file, Some(&checkout));
     }
+    let (findings, policy_outcome) = if full_repository_scan {
+        (
+            Vec::new(),
+            PullRequestPolicyOutcome::Evaluated(evaluate(policy, findings)),
+        )
+    } else {
+        (
+            findings,
+            PullRequestPolicyOutcome::NotEvaluated(PrPolicyNotEvaluated::new(
+                policy,
+                PrPolicyNotEvaluatedReason::ChangedFilesFallback,
+            )),
+        )
+    };
     Ok(PullRequestScanResult {
         pr_number: pull_request.number,
         repo: target_repo.to_string(),
         head_sha: pull_request.head.sha,
         head_repo_web_url: pull_request.head.repo.html_url,
         findings,
+        policy_outcome,
         review_messages: 0,
         deleted_comments: 0,
         posted_check_annotations: 0,

--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -1,6 +1,7 @@
 use foxguard::app::{execute_diff, execute_scan, execute_secrets, DiffExecution, ScanExecution};
 use foxguard::cli::{
-    ChangeModeArgs, DiffArgs, OutputFormat, ScanArgs, SecretsArgs, SeverityFilter,
+    ChangeModeArgs, DiffArgs, OutputFormat, PrSecurityPolicyArgs, ScanArgs, SecretsArgs,
+    SeverityFilter,
 };
 use foxguard::engine::ScanStats;
 use foxguard::report::{cbom::build_cbom, sarif::build_sarif};
@@ -465,6 +466,7 @@ fn scan_args(arguments: &Value, pq_mode: bool) -> Result<ScanArgs, String> {
         explain: optional_bool(arguments, "explain")?,
         fix: false,
         github_pr: None,
+        pr_security_policy: PrSecurityPolicyArgs::default(),
         quiet: true,
         output: None,
         max_file_size: optional_u64(arguments, "max_file_size")?.unwrap_or(DEFAULT_MAX_FILE_SIZE),
@@ -508,6 +510,7 @@ fn diff_args(arguments: &Value) -> Result<DiffArgs, String> {
         no_builtins: optional_bool(arguments, "no_builtins")?,
         output: None,
         github_pr: None,
+        pr_security_policy: PrSecurityPolicyArgs::default(),
         max_file_size: optional_u64(arguments, "max_file_size")?.unwrap_or(DEFAULT_MAX_FILE_SIZE),
     })
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
 use crate::git::ChangeSelection;
+use crate::pr_policy::{
+    PrBlockingThreshold, PrSecurityPolicyInput, PrSecurityPolicyScope, PrSecurityPolicyVersion,
+};
 use clap::{Args, Parser, Subcommand};
 use serde::Deserialize;
 
@@ -55,6 +58,57 @@ impl ChangeModeArgs {
             Some(ChangeSelection::All)
         } else {
             None
+        }
+    }
+}
+
+/// Policy controls for a PR security result. These map surface-specific inputs
+/// into the shared resolver rather than implementing severity decisions here.
+#[derive(Args, Debug, Clone, Default)]
+pub struct PrSecurityPolicyArgs {
+    /// Evaluate this scan with the versioned PR security policy.
+    #[arg(long, default_value_t = false)]
+    pub pr_policy: bool,
+
+    /// PR security policy version.
+    #[arg(long = "pr-policy-version", value_enum)]
+    pub policy_version: Option<PrSecurityPolicyVersion>,
+
+    /// Scope evaluated by the PR security policy.
+    #[arg(long = "pr-scope", value_enum)]
+    pub scope: Option<PrSecurityPolicyScope>,
+
+    /// Minimum finding severity included in the PR policy report.
+    #[arg(long = "pr-reporting-threshold", value_enum)]
+    pub reporting_threshold: Option<SeverityFilter>,
+
+    /// Minimum included severity that fails the PR policy; `none` never blocks.
+    #[arg(long = "pr-blocking-threshold", value_enum)]
+    pub blocking_threshold: Option<PrBlockingThreshold>,
+
+    /// Write the effective policy result as JSON.
+    #[arg(long = "pr-policy-output", value_name = "PATH")]
+    pub policy_output: Option<String>,
+}
+
+impl PrSecurityPolicyArgs {
+    pub fn is_enabled(&self) -> bool {
+        self.pr_policy
+            || self.policy_version.is_some()
+            || self.scope.is_some()
+            || self.reporting_threshold.is_some()
+            || self.blocking_threshold.is_some()
+            || self.policy_output.is_some()
+    }
+
+    pub fn input(&self) -> PrSecurityPolicyInput {
+        PrSecurityPolicyInput {
+            version: self.policy_version,
+            scope: self.scope,
+            reporting_threshold: self
+                .reporting_threshold
+                .map(|severity| severity.to_severity()),
+            blocking_threshold: self.blocking_threshold,
         }
     }
 }
@@ -125,6 +179,9 @@ pub struct ScanArgs {
     /// Post findings as inline review comments on a GitHub PR
     #[arg(long)]
     pub github_pr: Option<u64>,
+
+    #[command(flatten)]
+    pub pr_security_policy: PrSecurityPolicyArgs,
 
     /// Suppress terminal output (exit code still reflects findings)
     #[arg(short, long)]
@@ -413,6 +470,9 @@ pub struct DiffArgs {
     #[arg(long)]
     pub github_pr: Option<u64>,
 
+    #[command(flatten)]
+    pub pr_security_policy: PrSecurityPolicyArgs,
+
     /// Maximum file size in bytes to scan (default: 1 MB)
     #[arg(long, default_value_t = 1_048_576)]
     pub max_file_size: u64,
@@ -666,6 +726,7 @@ impl PqcArgs {
             explain: self.explain,
             fix: false,
             github_pr: self.github_pr,
+            pr_security_policy: PrSecurityPolicyArgs::default(),
             quiet: self.quiet,
             output: self.output.clone(),
             max_file_size: self.max_file_size,
@@ -702,6 +763,7 @@ impl ScaArgs {
             explain: false,
             fix: false,
             github_pr: self.github_pr,
+            pr_security_policy: PrSecurityPolicyArgs::default(),
             quiet: self.quiet,
             output: self.output.clone(),
             max_file_size: self.max_file_size,
@@ -735,6 +797,7 @@ impl BaselineScanArgs {
             explain: self.explain,
             fix: self.fix,
             github_pr: self.github_pr,
+            pr_security_policy: PrSecurityPolicyArgs::default(),
             quiet: self.quiet,
             output: None,
             max_file_size: self.max_file_size,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::cli::{ScanArgs, SecretsArgs, SeverityFilter};
+use crate::pr_policy::PrSecurityPolicyInput;
 use crate::rules::common::SecretScanThresholds;
 use crate::{Finding, Severity};
 use regex::Regex;
@@ -21,6 +22,7 @@ pub struct FoxguardConfig {
     pub scan: ScanConfig,
     pub secrets: SecretsConfig,
     pub diff: DiffConfig,
+    pub pr_security_policy: Option<PrSecurityPolicyInput>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -145,6 +147,7 @@ struct RawFoxguardConfig {
     secrets: RawSecretsConfig,
     #[serde(default)]
     diff: RawDiffConfig,
+    pr_security_policy: Option<PrSecurityPolicyInput>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -256,6 +259,22 @@ pub fn load_for_scan(
         config_dir,
         &allowed_root,
     )?))
+}
+
+/// Resolve the directory containing the configuration discovered for a scan.
+///
+/// This is distinct from `FoxguardConfig::project_root`, which is the
+/// scan-specific trust boundary for config paths.
+pub(crate) fn config_root_for_scan(
+    scan_path: &Path,
+    explicit_path: Option<&str>,
+) -> Option<PathBuf> {
+    let path = resolve_config_path(scan_path, explicit_path)
+        .ok()
+        .flatten()?;
+    let path = path.canonicalize().unwrap_or(path);
+    path.parent()
+        .map(crate::path_identity::resolve_path_for_boundary)
 }
 
 pub fn apply_scan_defaults(scan: &mut ScanArgs, config: Option<&FoxguardConfig>) {
@@ -474,6 +493,7 @@ impl FoxguardConfig {
                 codeql_base_db: diff_codeql_base_db,
                 codeql_head_db: diff_codeql_head_db,
             },
+            pr_security_policy: raw.pr_security_policy,
         })
     }
 }

--- a/src/github_app/review.rs
+++ b/src/github_app/review.rs
@@ -1,6 +1,7 @@
 //! Pull request review posting for the GitHub App receiver.
 
-use crate::report::github_pr::COMMENT_MARKER;
+use crate::pr_policy::{PrPolicyEvaluation, PrPolicyNotEvaluated, PrPolicyReport};
+use crate::report::github_pr::{format_comment_body, COMMENT_MARKER};
 use crate::{Finding, Severity};
 use reqwest::Url;
 use serde::Deserialize;
@@ -41,6 +42,15 @@ impl From<reqwest::Error> for ReviewError {
     fn from(error: reqwest::Error) -> Self {
         Self::Http(error)
     }
+}
+
+/// The policy result represented by a GitHub check run.
+pub enum CheckRunPolicy<'a> {
+    Evaluated(&'a PrPolicyEvaluation),
+    NotEvaluated {
+        findings: &'a [Finding],
+        policy: &'a PrPolicyNotEvaluated,
+    },
 }
 
 #[derive(Clone)]
@@ -156,35 +166,13 @@ impl GitHubReviewClient {
         &self,
         repo_full_name: &str,
         head_sha: &str,
-        findings: &[Finding],
+        policy: CheckRunPolicy<'_>,
         installation_token: &str,
         changed_lines: Option<&HashMap<String, HashSet<usize>>>,
     ) -> Result<PostCheckRunOutcome, ReviewError> {
         let repo = RepositoryPath::parse(repo_full_name)?;
-        let effective_findings = if let Some(lines) = changed_lines {
-            filter_findings_to_changed_lines(findings, lines)
-        } else {
-            findings.to_vec()
-        };
-        let annotation_findings: Vec<Finding> = effective_findings
-            .iter()
-            .filter(|finding| !is_summary_only_finding(finding))
-            .cloned()
-            .collect();
-        let annotations = check_run_annotations(&annotation_findings);
-        let annotation_count = annotations.len();
+        let (body, annotation_count) = check_run_payload(head_sha, policy, changed_lines);
         let url = self.endpoint(&format!("repos/{}/{}/check-runs", repo.owner, repo.name))?;
-        let body = serde_json::json!({
-            "name": "foxguard",
-            "head_sha": head_sha,
-            "status": "completed",
-            "conclusion": check_run_conclusion(&effective_findings),
-            "output": {
-                "title": check_run_title(&effective_findings),
-                "summary": check_run_summary(&effective_findings, annotation_count),
-                "annotations": annotations,
-            },
-        });
         // URL construction is restricted to a validated GitHub API base URL plus
         // repository path segments parsed by `RepositoryPath::parse`.
         let request = self.http.post(url); // foxguard: ignore[rs/no-ssrf]
@@ -733,8 +721,8 @@ fn hunk_new_start(line: &str) -> Option<usize> {
 }
 
 /// Filter line-bearing findings to changed lines and file-only findings to
-/// changed files. This ensures review summaries and check-run conclusions
-/// reflect only PR-introduced issues, not pre-existing ones.
+/// changed files. This GitHub review transport constraint is separate from a
+/// repository policy decision.
 fn filter_findings_to_changed_lines(
     findings: &[Finding],
     changed_lines: &HashMap<String, HashSet<usize>>,
@@ -752,30 +740,97 @@ fn filter_findings_to_changed_lines(
         .collect()
 }
 
-fn check_run_conclusion(findings: &[Finding]) -> &'static str {
-    if findings.is_empty() {
-        return "success";
-    }
-    if findings
-        .iter()
-        .any(|finding| matches!(finding.severity, Severity::High | Severity::Critical))
-    {
-        return "failure";
-    }
-    "neutral"
+fn check_run_payload(
+    head_sha: &str,
+    policy: CheckRunPolicy<'_>,
+    changed_lines: Option<&HashMap<String, HashSet<usize>>>,
+) -> (Value, usize) {
+    let findings = match &policy {
+        CheckRunPolicy::Evaluated(evaluation) => evaluation.findings.as_slice(),
+        CheckRunPolicy::NotEvaluated { findings, .. } => *findings,
+    };
+    let annotation_findings = match changed_lines {
+        Some(lines) => filter_findings_to_changed_lines(findings, lines),
+        None => findings.to_vec(),
+    };
+    let annotation_findings: Vec<Finding> = annotation_findings
+        .into_iter()
+        .filter(|finding| !is_summary_only_finding(finding))
+        .collect();
+    let annotations = check_run_annotations(&annotation_findings);
+    let annotation_count = annotations.len();
+    let (conclusion, title, summary) = match policy {
+        CheckRunPolicy::Evaluated(evaluation) => (
+            evaluation.report().decision.github_check_conclusion(),
+            check_run_title(evaluation),
+            check_run_summary(findings, annotation_count, evaluation.report()),
+        ),
+        CheckRunPolicy::NotEvaluated { policy, .. } => (
+            "neutral",
+            "foxguard policy not evaluated",
+            check_run_not_evaluated_summary(findings, annotation_count, policy),
+        ),
+    };
+    (
+        serde_json::json!({
+            "name": "foxguard",
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": conclusion,
+            "output": {
+                "title": title,
+                "summary": summary,
+                "annotations": annotations,
+            },
+        }),
+        annotation_count,
+    )
 }
 
-fn check_run_title(findings: &[Finding]) -> &'static str {
-    if findings.is_empty() {
-        "foxguard found no issues"
-    } else {
-        "foxguard found issues"
+fn check_run_not_evaluated_summary(
+    findings: &[Finding],
+    annotation_count: usize,
+    policy: &PrPolicyNotEvaluated,
+) -> String {
+    let mut summary = format!(
+        "foxguard found {} issue(s) in a partial scan. {policy}",
+        findings.len()
+    );
+    if annotation_count > 0 {
+        summary.push_str(&format!(
+            " Showing {annotation_count} partial-scan finding(s) as check annotations."
+        ));
+    }
+    summary.push_str("\n\nThis neutral check is not a v1 repository-scope policy decision.");
+    summary
+}
+
+fn check_run_title(evaluation: &PrPolicyEvaluation) -> &'static str {
+    match evaluation.report().decision {
+        crate::pr_policy::PrPolicyDecision::Pass => "foxguard policy passed",
+        crate::pr_policy::PrPolicyDecision::Neutral => "foxguard policy reported issues",
+        crate::pr_policy::PrPolicyDecision::Fail => "foxguard policy failed",
     }
 }
 
-fn check_run_summary(findings: &[Finding], annotation_count: usize) -> String {
+fn check_run_summary(
+    findings: &[Finding],
+    annotation_count: usize,
+    policy: &PrPolicyReport,
+) -> String {
+    let policy_summary = format!(
+        "PR security policy {} (scope {}, report >= {}, block >= {}): {} \
+         ({} included, {} blocking).",
+        policy.version,
+        policy.scope,
+        policy.reporting_threshold,
+        policy.blocking_threshold,
+        policy.decision,
+        policy.included_findings,
+        policy.blocking_findings
+    );
     if findings.is_empty() {
-        return "foxguard scan completed with no findings.".to_string();
+        return format!("foxguard scan completed with no reportable findings.\n\n{policy_summary}");
     }
 
     let mut low = 0;
@@ -792,7 +847,7 @@ fn check_run_summary(findings: &[Finding], annotation_count: usize) -> String {
     }
 
     let mut summary = format!(
-        "foxguard found {} issue(s): {critical} critical, {high} high, {medium} medium, {low} low.",
+        "foxguard found {} reportable issue(s): {critical} critical, {high} high, {medium} medium, {low} low.",
         findings.len()
     );
     let annotation_eligible_count = findings
@@ -824,6 +879,7 @@ fn check_run_summary(findings: &[Finding], annotation_count: usize) -> String {
             ));
         }
     }
+    summary.push_str(&format!("\n\n{policy_summary}"));
     summary
 }
 
@@ -1000,6 +1056,7 @@ fn dependency_summary_line(finding: &Finding) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pr_policy::evaluate;
 
     #[test]
     fn repository_path_accepts_owner_repo() {
@@ -1125,16 +1182,105 @@ mod tests {
     }
 
     #[test]
-    fn check_run_conclusion_matches_severity() {
-        assert_eq!(check_run_conclusion(&[]), "success");
+    fn check_run_conclusion_comes_from_shared_policy() {
+        let pass = evaluate(crate::pr_policy::PrSecurityPolicy::default(), vec![]);
         assert_eq!(
-            check_run_conclusion(&[finding(Severity::Low, 1)]),
-            "neutral"
+            pass.report().decision,
+            crate::pr_policy::PrPolicyDecision::Pass
+        );
+
+        let neutral = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            vec![finding(Severity::Medium, 1)],
         );
         assert_eq!(
-            check_run_conclusion(&[finding(Severity::High, 1)]),
-            "failure"
+            neutral.report().decision,
+            crate::pr_policy::PrPolicyDecision::Neutral
         );
+
+        let fail = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            vec![finding(Severity::High, 1)],
+        );
+        assert_eq!(
+            fail.report().decision,
+            crate::pr_policy::PrPolicyDecision::Fail
+        );
+        assert_eq!(check_run_title(&fail), "foxguard policy failed");
+    }
+
+    #[test]
+    fn check_run_payload_matches_shared_mixed_policy_contract() {
+        let (policy, findings, expected) = crate::pr_policy::contract_fixture::mixed_v1();
+        let evaluation = evaluate(policy, findings);
+        let (payload, annotation_count) =
+            check_run_payload("head-sha", CheckRunPolicy::Evaluated(&evaluation), None);
+
+        assert_eq!(evaluation.report(), &expected);
+        assert_eq!(annotation_count, expected.included_findings);
+        assert_eq!(payload["conclusion"].as_str(), Some("failure"));
+        assert_eq!(
+            payload["output"]["title"].as_str(),
+            Some("foxguard policy failed")
+        );
+        let summary = payload["output"]["summary"]
+            .as_str()
+            .expect("check-run summary");
+        assert!(summary.contains("scope repository"));
+        assert!(summary.contains("report >= medium, block >= high"));
+        assert!(summary.contains("fail (3 included, 2 blocking)"));
+    }
+
+    #[test]
+    fn partial_check_run_is_not_labeled_as_repository_policy() {
+        let (policy, findings, _) = crate::pr_policy::contract_fixture::mixed_v1();
+        let partial = PrPolicyNotEvaluated::new(
+            policy,
+            crate::pr_policy::PrPolicyNotEvaluatedReason::ChangedFilesFallback,
+        );
+        let (payload, _) = check_run_payload(
+            "head-sha",
+            CheckRunPolicy::NotEvaluated {
+                findings: &findings,
+                policy: &partial,
+            },
+            None,
+        );
+
+        assert_eq!(payload["conclusion"].as_str(), Some("neutral"));
+        assert_eq!(
+            payload["output"]["title"].as_str(),
+            Some("foxguard policy not evaluated")
+        );
+        let summary = payload["output"]["summary"]
+            .as_str()
+            .expect("check-run summary");
+        assert!(summary.contains("was not evaluated"));
+        assert!(summary.contains("not a v1 repository-scope policy decision"));
+        assert!(!summary.contains("scope repository"));
+    }
+
+    #[test]
+    fn partial_check_annotations_stay_within_changed_lines() {
+        let policy = crate::pr_policy::PrSecurityPolicy::default();
+        let partial = PrPolicyNotEvaluated::new(
+            policy,
+            crate::pr_policy::PrPolicyNotEvaluatedReason::ChangedFilesFallback,
+        );
+        let findings = vec![finding(Severity::High, 3), finding(Severity::High, 9)];
+        let changed_lines = HashMap::from([("src/app.js".to_string(), HashSet::from([3]))]);
+
+        let (payload, annotation_count) = check_run_payload(
+            "head-sha",
+            CheckRunPolicy::NotEvaluated {
+                findings: &findings,
+                policy: &partial,
+            },
+            Some(&changed_lines),
+        );
+
+        assert_eq!(annotation_count, 1);
+        assert_eq!(payload["output"]["annotations"][0]["start_line"], 3);
     }
 
     #[test]
@@ -1298,16 +1444,24 @@ mod tests {
         let findings: Vec<_> = (1..=60)
             .map(|line| finding(Severity::Medium, line))
             .collect();
-        let summary = check_run_summary(&findings, 50);
+        let policy = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            findings.clone(),
+        );
+        let summary = check_run_summary(&findings, 50, policy.report());
 
-        assert!(summary.contains("60 issue(s)"));
+        assert!(summary.contains("60 reportable issue(s)"));
         assert!(summary.contains("Showing the first 50"));
     }
 
     #[test]
     fn check_run_summary_mentions_dependency_findings_without_annotations() {
         let findings = vec![dependency_finding(12)];
-        let summary = check_run_summary(&findings, 0);
+        let policy = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            findings.clone(),
+        );
+        let summary = check_run_summary(&findings, 0, policy.report());
 
         assert!(summary.contains("1 dependency finding(s)"));
         assert!(summary.contains("GHSA-r9p9-mrjm-926w"));
@@ -1355,76 +1509,56 @@ mod tests {
     }
 
     #[test]
-    fn check_run_only_fails_for_pr_introduced_high_severity() {
-        // Simulate a repo scan that found both pre-existing and
-        // PR-introduced findings. The check-run conclusion must only
-        // consider findings on lines that the PR actually changed.
+    fn check_run_policy_is_not_limited_to_changed_lines() {
         let mut changed_lines: HashMap<String, HashSet<usize>> = HashMap::new();
         changed_lines.insert("src/app.js".to_string(), HashSet::from([10, 11, 12]));
 
-        // Pre-existing high-severity finding on an unchanged line.
-        let pre_existing_high = finding_in_file(Severity::High, "src/app.js", 50);
-        // Pre-existing critical finding in an entirely different file.
-        let pre_existing_critical = finding_in_file(Severity::Critical, "src/legacy.js", 1);
-        // PR-introduced low-severity finding.
-        let pr_low = finding_in_file(Severity::Low, "src/app.js", 10);
+        let all_findings = vec![
+            finding_in_file(Severity::High, "src/app.js", 50),
+            finding_in_file(Severity::Critical, "src/legacy.js", 1),
+            finding_in_file(Severity::Low, "src/app.js", 10),
+        ];
+        let policy = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            all_findings.clone(),
+        );
+        assert_eq!(
+            policy.report().decision,
+            crate::pr_policy::PrPolicyDecision::Fail
+        );
 
-        let all_findings = vec![pre_existing_high, pre_existing_critical, pr_low];
-
-        // Without filtering (the old behavior), the conclusion would be
-        // "failure" because of the pre-existing high/critical findings.
-        assert_eq!(check_run_conclusion(&all_findings), "failure");
-
-        // With filtering to changed lines, only the low-severity finding
-        // remains, so the conclusion should be "neutral" (not failure).
-        let pr_findings = filter_findings_to_changed_lines(&all_findings, &changed_lines);
-        assert_eq!(pr_findings.len(), 1);
-        assert_eq!(pr_findings[0].severity, Severity::Low);
-        assert_eq!(check_run_conclusion(&pr_findings), "neutral");
-
-        // Annotations should also only include the PR-introduced finding.
-        let annotations = check_run_annotations(&pr_findings);
+        let comment_findings = filter_findings_to_changed_lines(&all_findings, &changed_lines);
+        assert_eq!(comment_findings.len(), 1);
+        let annotations = check_run_annotations(&comment_findings);
         assert_eq!(annotations.len(), 1);
-        assert_eq!(annotations[0]["path"], "src/app.js");
-        assert_eq!(annotations[0]["start_line"], 10);
         assert_eq!(annotations[0]["annotation_level"], "notice");
     }
 
     #[test]
-    fn check_run_fails_only_when_pr_introduces_high_severity() {
-        // When the PR itself introduces a high-severity finding, the
-        // check run should correctly fail.
-        let mut changed_lines: HashMap<String, HashSet<usize>> = HashMap::new();
-        changed_lines.insert("src/app.js".to_string(), HashSet::from([10, 11]));
+    fn check_run_policy_fails_on_reported_high_severity() {
+        let policy = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            vec![
+                finding_in_file(Severity::Critical, "src/legacy.js", 1),
+                finding_in_file(Severity::High, "src/app.js", 10),
+                finding_in_file(Severity::Low, "src/app.js", 11),
+            ],
+        );
 
-        let findings = vec![
-            // Pre-existing critical (should be filtered out)
-            finding_in_file(Severity::Critical, "src/legacy.js", 1),
-            // PR-introduced high (should cause failure)
-            finding_in_file(Severity::High, "src/app.js", 10),
-            // PR-introduced low
-            finding_in_file(Severity::Low, "src/app.js", 11),
-        ];
-
-        let pr_findings = filter_findings_to_changed_lines(&findings, &changed_lines);
-        assert_eq!(pr_findings.len(), 2);
-        assert_eq!(check_run_conclusion(&pr_findings), "failure");
+        assert_eq!(
+            policy.report().decision,
+            crate::pr_policy::PrPolicyDecision::Fail
+        );
     }
 
     #[test]
-    fn check_run_succeeds_when_no_pr_findings() {
-        // All findings are pre-existing; the PR changed lines have none.
-        let mut changed_lines: HashMap<String, HashSet<usize>> = HashMap::new();
-        changed_lines.insert("src/app.js".to_string(), HashSet::from([10]));
+    fn check_run_policy_passes_without_reportable_findings() {
+        let policy = evaluate(crate::pr_policy::PrSecurityPolicy::default(), vec![]);
 
-        let findings = vec![
-            finding_in_file(Severity::Critical, "src/app.js", 50),
-            finding_in_file(Severity::High, "src/other.js", 1),
-        ];
-
-        let pr_findings = filter_findings_to_changed_lines(&findings, &changed_lines);
-        assert!(pr_findings.is_empty());
-        assert_eq!(check_run_conclusion(&pr_findings), "success");
+        assert_eq!(
+            policy.report().decision,
+            crate::pr_policy::PrPolicyDecision::Pass
+        );
     }
 
     #[test]

--- a/src/github_app/review.rs
+++ b/src/github_app/review.rs
@@ -1,7 +1,7 @@
 //! Pull request review posting for the GitHub App receiver.
 
 use crate::pr_policy::{PrPolicyEvaluation, PrPolicyNotEvaluated, PrPolicyReport};
-use crate::report::github_pr::{format_comment_body, COMMENT_MARKER};
+use crate::report::github_pr::COMMENT_MARKER;
 use crate::{Finding, Severity};
 use reqwest::Url;
 use serde::Deserialize;
@@ -1472,8 +1472,12 @@ mod tests {
     fn check_run_dependency_summary_encodes_untrusted_file_path() {
         let mut finding = dependency_finding(0);
         finding.file = "package`](<https://attacker.invalid>)\n[trick].json".to_string();
+        let policy = evaluate(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            vec![finding.clone()],
+        );
 
-        let summary = check_run_summary(&[finding], 0);
+        let summary = check_run_summary(&[finding], 0, policy.report());
 
         assert!(summary.contains(
             "in `package%60%5D%28%3Chttps%3A//attacker.invalid%3E%29%0A%5Btrick%5D.json`"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod git;
 pub mod github_app;
 pub mod output;
 pub mod path_identity;
+pub mod pr_policy;
 pub mod report;
 pub mod rules;
 pub mod scan_plan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ fn run_semgrep_readiness(args: &SemgrepReadinessArgs) -> i32 {
     }
 
     0
+}
 fn write_pr_policy_not_evaluated_output(
     output: Option<&str>,
     policy: Option<&PrPolicyNotEvaluated>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use foxguard::cli::{
 };
 use foxguard::config::add_scan_ignore_rule;
 use foxguard::config::load_for_scan;
+use foxguard::pr_policy::{
+    evaluate, write_pr_policy_result, PrPolicyEvaluation, PrPolicyNotEvaluated, PrSecurityPolicy,
+};
 use foxguard::tui::run_scan_tui;
 use foxguard::Finding;
 use serde::Serialize;
@@ -94,10 +97,44 @@ fn run_semgrep_readiness(args: &SemgrepReadinessArgs) -> i32 {
     }
 
     0
+fn write_pr_policy_not_evaluated_output(
+    output: Option<&str>,
+    policy: Option<&PrPolicyNotEvaluated>,
+) -> Result<(), String> {
+    match policy {
+        Some(policy) => write_pr_policy_result(output, policy),
+        None => Ok(()),
+    }
+}
+
+fn evaluate_pr_policy(
+    findings: &mut Vec<Finding>,
+    policy: Option<PrSecurityPolicy>,
+    output: Option<&str>,
+) -> Result<Option<PrPolicyEvaluation>, String> {
+    let Some(policy) = policy else {
+        return Ok(None);
+    };
+
+    let evaluation = evaluate(policy, std::mem::take(findings));
+    write_pr_policy_result(output, evaluation.report())?;
+    let report = evaluation.report();
+    eprintln!(
+        "PR security policy {} (scope {}, report >= {}, block >= {}): {} \
+         ({} included, {} blocking)",
+        report.version,
+        report.scope,
+        report.reporting_threshold,
+        report.blocking_threshold,
+        report.decision,
+        report.included_findings,
+        report.blocking_findings
+    );
+    Ok(Some(evaluation))
 }
 
 fn run_scan(scan: &ScanArgs) -> i32 {
-    let result = match execute_scan(scan) {
+    let mut result = match execute_scan(scan) {
         Ok(result) => result,
         Err(error) => {
             eprintln!("Error: {}", error);
@@ -109,9 +146,32 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         eprintln!("{}", notice);
     }
 
+    let policy_evaluation = match evaluate_pr_policy(
+        &mut result.findings,
+        result.pr_security_policy,
+        result.args.pr_security_policy.policy_output.as_deref(),
+    ) {
+        Ok(evaluation) => evaluation,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            return 2;
+        }
+    };
+    if let Err(error) = write_pr_policy_not_evaluated_output(
+        result.args.pr_security_policy.policy_output.as_deref(),
+        result.pr_security_policy_not_evaluated.as_ref(),
+    ) {
+        eprintln!("Error: {}", error);
+        return 2;
+    }
+    let findings = policy_evaluation
+        .as_ref()
+        .map(|evaluation| evaluation.findings.as_slice())
+        .unwrap_or(result.findings.as_slice());
+
     // Apply auto-fixes if --fix is set
-    if scan.fix && !result.findings.is_empty() {
-        let files_fixed = foxguard::fix::apply_all_fixes(&result.findings, &scan.path);
+    if scan.fix && !findings.is_empty() {
+        let files_fixed = foxguard::fix::apply_all_fixes(findings, &scan.path);
         if files_fixed > 0 {
             eprintln!("Fixed findings in {} file(s)", files_fixed);
         }
@@ -126,7 +186,7 @@ fn run_scan(scan: &ScanArgs) -> i32 {
             if !result.args.quiet {
                 foxguard::report::terminal::clear_banner();
                 foxguard::report::terminal::print_findings_full(
-                    &result.findings,
+                    findings,
                     result.files_scanned,
                     result.duration,
                     foxguard::report::terminal::ReportOptions {
@@ -139,10 +199,14 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         }
         _ => {
             if let Err(error) = foxguard::output::emit_scan_report(
-                &result.findings,
+                findings,
                 &result.args,
                 result.files_scanned,
                 result.duration,
+                policy_evaluation
+                    .as_ref()
+                    .map(|evaluation| evaluation.report()),
+                result.pr_security_policy_not_evaluated.as_ref(),
             ) {
                 eprintln!("Error: {}", error);
                 return 2;
@@ -152,20 +216,17 @@ fn run_scan(scan: &ScanArgs) -> i32 {
 
     if let Some(pr_number) = result.args.github_pr {
         let scan_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        if let Err(e) = foxguard::report::github_pr::post_pr_review(
-            &result.findings,
-            pr_number,
-            Some(&scan_root),
-        ) {
-            eprintln!("Warning: failed to post PR review: {}", e);
+        if let Err(error) =
+            foxguard::report::github_pr::post_pr_review(findings, pr_number, Some(&scan_root))
+        {
+            eprintln!("Warning: failed to post PR review: {}", error);
         }
     }
 
-    if !result.findings.is_empty() {
-        return 1;
-    }
-
-    0
+    policy_evaluation
+        .as_ref()
+        .map(|evaluation| evaluation.report().decision.exit_code())
+        .unwrap_or_else(|| if findings.is_empty() { 0 } else { 1 })
 }
 
 fn run_baseline(args: &BaselineArgs) -> i32 {
@@ -275,7 +336,7 @@ fn run_secrets(args: &SecretsArgs) -> i32 {
 }
 
 fn run_diff_cmd(args: &DiffArgs) -> i32 {
-    let result = match execute_diff(args) {
+    let mut result = match execute_diff(args) {
         Ok(result) => result,
         Err(error) => {
             eprintln!("Error: {}", error);
@@ -287,7 +348,28 @@ fn run_diff_cmd(args: &DiffArgs) -> i32 {
         eprintln!("{}", notice);
     }
 
-    let new_count = result.findings.len();
+    let policy_evaluation = match evaluate_pr_policy(
+        &mut result.findings,
+        result.pr_security_policy,
+        result.args.pr_security_policy.policy_output.as_deref(),
+    ) {
+        Ok(evaluation) => evaluation,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            return 2;
+        }
+    };
+    if let Err(error) = write_pr_policy_not_evaluated_output(
+        result.args.pr_security_policy.policy_output.as_deref(),
+        result.pr_security_policy_not_evaluated.as_ref(),
+    ) {
+        eprintln!("Error: {}", error);
+        return 2;
+    }
+    let findings = policy_evaluation
+        .as_ref()
+        .map(|evaluation| evaluation.findings.as_slice())
+        .unwrap_or(result.findings.as_slice());
 
     match result.args.format {
         OutputFormat::Terminal => {
@@ -296,17 +378,21 @@ fn run_diff_cmd(args: &DiffArgs) -> i32 {
                 return 2;
             }
             foxguard::report::terminal::print_findings(
-                &result.findings,
+                findings,
                 result.files_scanned,
                 result.duration,
             );
         }
         _ => {
             if let Err(error) = foxguard::output::emit_diff_report(
-                &result.findings,
+                findings,
                 &result.args,
                 result.files_scanned,
                 result.duration,
+                policy_evaluation
+                    .as_ref()
+                    .map(|evaluation| evaluation.report()),
+                result.pr_security_policy_not_evaluated.as_ref(),
             ) {
                 eprintln!("Error: {}", error);
                 return 2;
@@ -316,20 +402,17 @@ fn run_diff_cmd(args: &DiffArgs) -> i32 {
 
     if let Some(pr_number) = result.args.github_pr {
         let scan_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        if let Err(e) = foxguard::report::github_pr::post_pr_review(
-            &result.findings,
-            pr_number,
-            Some(&scan_root),
-        ) {
-            eprintln!("Warning: failed to post PR review: {}", e);
+        if let Err(error) =
+            foxguard::report::github_pr::post_pr_review(findings, pr_number, Some(&scan_root))
+        {
+            eprintln!("Warning: failed to post PR review: {}", error);
         }
     }
 
-    if new_count > 0 {
-        return 1;
-    }
-
-    0
+    policy_evaluation
+        .as_ref()
+        .map(|evaluation| evaluation.report().decision.exit_code())
+        .unwrap_or_else(|| if findings.is_empty() { 0 } else { 1 })
 }
 
 fn run_init(args: &InitArgs) -> i32 {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 use crate::cli::{DiffArgs, OutputFormat, ScanArgs, SecretsArgs};
+use crate::pr_policy::{PrPolicyNotEvaluated, PrPolicyReport};
 use crate::report::json::{
     build_json_report, JsonConfigMetadata, JsonReportMetadata, JsonTargetMetadata,
 };
@@ -19,6 +20,8 @@ pub fn emit_scan_report(
     args: &ScanArgs,
     files_scanned: usize,
     duration: Duration,
+    pr_security_policy: Option<&PrPolicyReport>,
+    pr_security_policy_not_evaluated: Option<&PrPolicyNotEvaluated>,
 ) -> Result<(), String> {
     match args.format {
         OutputFormat::Terminal => validate_terminal_output_path(args.output.as_deref()),
@@ -42,6 +45,8 @@ pub fn emit_scan_report(
                     diff_base: None,
                 },
                 duration,
+                pr_security_policy,
+                pr_security_policy_not_evaluated,
             },
         ),
         OutputFormat::Sarif => emit_sarif(findings, args.output.as_deref()),
@@ -72,6 +77,8 @@ pub fn emit_secrets_report(
                     diff_base: None,
                 },
                 duration,
+                pr_security_policy: None,
+                pr_security_policy_not_evaluated: None,
             },
         ),
         OutputFormat::Sarif => emit_sarif(findings, args.output.as_deref()),
@@ -85,6 +92,8 @@ pub fn emit_diff_report(
     args: &DiffArgs,
     files_scanned: usize,
     duration: Duration,
+    pr_security_policy: Option<&PrPolicyReport>,
+    pr_security_policy_not_evaluated: Option<&PrPolicyNotEvaluated>,
 ) -> Result<(), String> {
     match args.format {
         OutputFormat::Terminal => validate_terminal_output_path(args.output.as_deref()),
@@ -102,6 +111,8 @@ pub fn emit_diff_report(
                     diff_base: Some(&args.target),
                 },
                 duration,
+                pr_security_policy,
+                pr_security_policy_not_evaluated,
             },
         ),
         OutputFormat::Sarif => emit_sarif(findings, args.output.as_deref()),

--- a/src/path_identity.rs
+++ b/src/path_identity.rs
@@ -7,11 +7,20 @@ use std::process::Command;
 /// then the scan root. Callers use this as the base for stable baseline and
 /// suppression keys while leaving reported finding paths unchanged.
 pub fn project_root(scan_path: &Path, configured_root: Option<&Path>) -> PathBuf {
-    if let Some(root) = configured_root {
-        return resolve_path_for_boundary(root);
-    }
+    configured_root
+        .map(resolve_path_for_boundary)
+        .or_else(|| git_repo_root(scan_path))
+        .unwrap_or_else(|| resolve_scan_root(scan_path))
+}
 
-    git_repo_root(scan_path).unwrap_or_else(|| resolve_scan_root(scan_path))
+/// Resolve the canonical root for repository-scoped policy evaluation.
+///
+/// A Git checkout is the authoritative repository boundary even when a config
+/// was supplied from an ancestor or nested directory. Without Git metadata, a
+/// discovered config directory establishes the project boundary. Unlike
+/// [`project_root`], this intentionally does not fall back to the scan target.
+pub fn pr_policy_root(scan_path: &Path, configured_root: Option<&Path>) -> Option<PathBuf> {
+    git_repo_root(scan_path).or_else(|| configured_root.map(resolve_path_for_boundary))
 }
 
 pub fn resolve_scan_root(scan_path: &Path) -> PathBuf {

--- a/src/pr_policy.rs
+++ b/src/pr_policy.rs
@@ -1,0 +1,569 @@
+use crate::{Finding, Severity};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for the first PR-security-policy contract.
+pub const PR_SECURITY_POLICY_V1: &str = "v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+pub enum PrSecurityPolicyVersion {
+    #[serde(rename = "v1")]
+    #[value(name = "v1")]
+    V1,
+}
+
+impl Default for PrSecurityPolicyVersion {
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+impl std::fmt::Display for PrSecurityPolicyVersion {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(PR_SECURITY_POLICY_V1)
+    }
+}
+
+/// The set of findings a v1 policy evaluates.
+///
+/// V1 deliberately evaluates the complete result of a PR scan. This is the
+/// only scope every current surface can derive identically; a future policy
+/// version can add a diff-specific scope without changing this contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+pub enum PrSecurityPolicyScope {
+    #[serde(rename = "repository")]
+    #[value(name = "repository")]
+    Repository,
+}
+
+impl Default for PrSecurityPolicyScope {
+    fn default() -> Self {
+        Self::Repository
+    }
+}
+
+impl std::fmt::Display for PrSecurityPolicyScope {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("repository")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+pub enum PrBlockingThreshold {
+    #[serde(rename = "none")]
+    #[value(name = "none")]
+    None,
+    #[serde(rename = "low")]
+    #[value(name = "low")]
+    Low,
+    #[serde(rename = "medium")]
+    #[value(name = "medium")]
+    Medium,
+    #[serde(rename = "high")]
+    #[value(name = "high")]
+    High,
+    #[serde(rename = "critical")]
+    #[value(name = "critical")]
+    Critical,
+}
+
+impl PrBlockingThreshold {
+    pub fn severity(self) -> Option<Severity> {
+        match self {
+            Self::None => None,
+            Self::Low => Some(Severity::Low),
+            Self::Medium => Some(Severity::Medium),
+            Self::High => Some(Severity::High),
+            Self::Critical => Some(Severity::Critical),
+        }
+    }
+}
+
+impl Default for PrBlockingThreshold {
+    fn default() -> Self {
+        Self::High
+    }
+}
+
+impl std::fmt::Display for PrBlockingThreshold {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::None => "none",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        })
+    }
+}
+
+/// Optional policy values from `.foxguard.yml` or a surface adapter.
+///
+/// Later inputs override earlier inputs. Keeping the optional wire shape
+/// separate from [`PrSecurityPolicy`] makes the resolved defaults explicit in
+/// every emitted result.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PrSecurityPolicyInput {
+    pub version: Option<PrSecurityPolicyVersion>,
+    pub scope: Option<PrSecurityPolicyScope>,
+    pub reporting_threshold: Option<Severity>,
+    pub blocking_threshold: Option<PrBlockingThreshold>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrSecurityPolicy {
+    pub version: PrSecurityPolicyVersion,
+    pub scope: PrSecurityPolicyScope,
+    pub reporting_threshold: Severity,
+    pub blocking_threshold: PrBlockingThreshold,
+}
+
+impl Default for PrSecurityPolicy {
+    fn default() -> Self {
+        Self {
+            version: PrSecurityPolicyVersion::V1,
+            scope: PrSecurityPolicyScope::Repository,
+            reporting_threshold: Severity::Medium,
+            blocking_threshold: PrBlockingThreshold::High,
+        }
+    }
+}
+
+/// Resolve configuration and surface overrides into the one policy evaluated by
+/// every PR surface. Surface values win over repository configuration.
+pub fn resolve(
+    configured: Option<&PrSecurityPolicyInput>,
+    overrides: &PrSecurityPolicyInput,
+) -> Result<PrSecurityPolicy, String> {
+    let defaults = PrSecurityPolicy::default();
+    let version = overrides
+        .version
+        .or_else(|| configured.and_then(|policy| policy.version))
+        .unwrap_or(defaults.version);
+    let scope = overrides
+        .scope
+        .or_else(|| configured.and_then(|policy| policy.scope))
+        .unwrap_or(defaults.scope);
+    let reporting_threshold = overrides
+        .reporting_threshold
+        .or_else(|| configured.and_then(|policy| policy.reporting_threshold))
+        .unwrap_or(defaults.reporting_threshold);
+    let blocking_threshold = overrides
+        .blocking_threshold
+        .or_else(|| configured.and_then(|policy| policy.blocking_threshold))
+        .unwrap_or(defaults.blocking_threshold);
+
+    if let Some(blocking) = blocking_threshold.severity() {
+        if blocking < reporting_threshold {
+            return Err(format!(
+                "pr_security_policy.blocking_threshold ({blocking}) must be at least \
+                 pr_security_policy.reporting_threshold ({reporting_threshold})"
+            ));
+        }
+    }
+
+    Ok(PrSecurityPolicy {
+        version,
+        scope,
+        reporting_threshold,
+        blocking_threshold,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrPolicyDecision {
+    #[serde(rename = "pass")]
+    Pass,
+    #[serde(rename = "neutral")]
+    Neutral,
+    #[serde(rename = "fail")]
+    Fail,
+}
+
+impl PrPolicyDecision {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Pass | Self::Neutral => 0,
+            Self::Fail => 1,
+        }
+    }
+
+    pub fn github_check_conclusion(self) -> &'static str {
+        match self {
+            Self::Pass => "success",
+            Self::Neutral => "neutral",
+            Self::Fail => "failure",
+        }
+    }
+}
+
+impl std::fmt::Display for PrPolicyDecision {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Pass => "pass",
+            Self::Neutral => "neutral",
+            Self::Fail => "fail",
+        })
+    }
+}
+
+/// Machine-readable result exposed by CLI JSON output, Action outputs, and the
+/// GitHub App check-run summary. Findings themselves remain in the normal
+/// report/transport payload, preserving the existing finding schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrPolicyReport {
+    pub version: PrSecurityPolicyVersion,
+    pub scope: PrSecurityPolicyScope,
+    pub reporting_threshold: Severity,
+    pub blocking_threshold: PrBlockingThreshold,
+    pub decision: PrPolicyDecision,
+    pub scoped_findings: usize,
+    pub included_findings: usize,
+    pub blocking_findings: usize,
+}
+
+/// Why a policy request did not produce a v1 repository decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PrPolicyNotEvaluatedReason {
+    ChangedOnlyScan,
+    PartialScan,
+    DiffScan,
+    ChangedFilesFallback,
+}
+
+impl std::fmt::Display for PrPolicyNotEvaluatedReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::ChangedOnlyScan => "the scan was limited to changed files",
+            Self::PartialScan => "the scan did not cover a repository root",
+            Self::DiffScan => "the scan produced only diff findings",
+            Self::ChangedFilesFallback => {
+                "the full-repository scan timed out and used a changed-files fallback"
+            }
+        })
+    }
+}
+
+/// Explicit status for a requested policy that cannot evaluate a complete
+/// repository finding set. This is not a policy report and has no decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrPolicyNotEvaluated {
+    pub version: PrSecurityPolicyVersion,
+    pub requested_scope: PrSecurityPolicyScope,
+    pub reporting_threshold: Severity,
+    pub blocking_threshold: PrBlockingThreshold,
+    pub reason: PrPolicyNotEvaluatedReason,
+}
+
+impl PrPolicyNotEvaluated {
+    pub fn new(policy: PrSecurityPolicy, reason: PrPolicyNotEvaluatedReason) -> Self {
+        Self {
+            version: policy.version,
+            requested_scope: policy.scope,
+            reporting_threshold: policy.reporting_threshold,
+            blocking_threshold: policy.blocking_threshold,
+            reason,
+        }
+    }
+}
+
+impl std::fmt::Display for PrPolicyNotEvaluated {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "PR security policy {} was not evaluated: {}. No repository-scope policy decision was made.",
+            self.version, self.reason
+        )
+    }
+}
+
+/// Result of evaluating a complete repository finding set. `findings` is the
+/// exact reporting set every policy decision surface must use.
+#[derive(Debug, Clone)]
+pub struct PrPolicyEvaluation {
+    pub findings: Vec<Finding>,
+    report: PrPolicyReport,
+}
+
+impl PrPolicyEvaluation {
+    pub fn report(&self) -> &PrPolicyReport {
+        &self.report
+    }
+}
+
+/// Evaluate one already-resolved complete repository scan result.
+///
+/// Callers MUST use [`PrPolicyNotEvaluated`] instead when their input is a
+/// diff, changed-file subset, or other partial result. V1's repository scope
+/// means all input findings are in scope. Findings below the reporting
+/// threshold are omitted. A clean reporting set passes; a reportable set that
+/// contains no blocking finding is neutral; otherwise the policy fails.
+pub fn evaluate(policy: PrSecurityPolicy, findings: Vec<Finding>) -> PrPolicyEvaluation {
+    let scoped_findings = findings.len();
+    let findings: Vec<Finding> = findings
+        .into_iter()
+        .filter(|finding| finding.severity >= policy.reporting_threshold)
+        .collect();
+    let blocking_findings = match policy.blocking_threshold.severity() {
+        Some(threshold) => findings
+            .iter()
+            .filter(|finding| finding.severity >= threshold)
+            .count(),
+        None => 0,
+    };
+    let decision = if findings.is_empty() {
+        PrPolicyDecision::Pass
+    } else if blocking_findings > 0 {
+        PrPolicyDecision::Fail
+    } else {
+        PrPolicyDecision::Neutral
+    };
+    let report = PrPolicyReport {
+        version: policy.version,
+        scope: policy.scope,
+        reporting_threshold: policy.reporting_threshold,
+        blocking_threshold: policy.blocking_threshold,
+        decision,
+        scoped_findings,
+        included_findings: findings.len(),
+        blocking_findings,
+    };
+
+    PrPolicyEvaluation { findings, report }
+}
+
+/// Write an evaluated or explicitly not-evaluated policy result for the CLI
+/// `--pr-policy-output` contract.
+pub fn write_pr_policy_result<T: Serialize>(
+    output: Option<&str>,
+    result: &T,
+) -> Result<(), String> {
+    let Some(path) = output else {
+        return Ok(());
+    };
+
+    let content = serde_json::to_string_pretty(result)
+        .map_err(|error| format!("failed to serialize PR policy result: {error}"))?;
+    std::fs::write(path, content)
+        .map_err(|error| format!("failed to write PR policy result '{path}': {error}"))
+}
+
+#[cfg(test)]
+pub(crate) mod contract_fixture {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Fixture {
+        policy: PrSecurityPolicy,
+        findings: Vec<Severity>,
+        expected: Expected,
+    }
+
+    #[derive(Deserialize)]
+    struct Expected {
+        scoped_findings: usize,
+        included_findings: usize,
+        blocking_findings: usize,
+        decision: PrPolicyDecision,
+    }
+
+    pub(crate) fn mixed_v1() -> (PrSecurityPolicy, Vec<Finding>, PrPolicyReport) {
+        let fixture: Fixture =
+            serde_json::from_str(include_str!("../tests/fixtures/pr-policy-v1-mixed.json"))
+                .expect("valid shared PR policy fixture");
+        let findings = fixture
+            .findings
+            .into_iter()
+            .enumerate()
+            .map(|(index, severity)| finding(severity, index + 1))
+            .collect();
+        (
+            fixture.policy,
+            findings,
+            PrPolicyReport {
+                version: fixture.policy.version,
+                scope: fixture.policy.scope,
+                reporting_threshold: fixture.policy.reporting_threshold,
+                blocking_threshold: fixture.policy.blocking_threshold,
+                decision: fixture.expected.decision,
+                scoped_findings: fixture.expected.scoped_findings,
+                included_findings: fixture.expected.included_findings,
+                blocking_findings: fixture.expected.blocking_findings,
+            },
+        )
+    }
+
+    fn finding(severity: Severity, line: usize) -> Finding {
+        Finding {
+            rule_id: format!("fixture/{severity}"),
+            severity,
+            cwe: None,
+            description: "fixture finding".to_string(),
+            file: "src/app.rs".to_string(),
+            line,
+            column: 1,
+            end_line: line,
+            end_column: 1,
+            snippet: String::new(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            tags: Vec::new(),
+            crypto_algorithm: None,
+            cnsa2_deadline: None,
+            dep_name: None,
+            dep_version: None,
+            dep_ecosystem: None,
+            dep_purl: None,
+            dep_vulnerability_id: None,
+            dep_fixed_version: None,
+            dep_source: None,
+            dep_vulnerability_severity: None,
+            dep_path: Vec::new(),
+            crypto_material: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finding(severity: Severity) -> Finding {
+        Finding {
+            rule_id: format!("test/{severity}"),
+            severity,
+            cwe: None,
+            description: "test finding".to_string(),
+            file: "src/app.rs".to_string(),
+            line: 1,
+            column: 1,
+            end_line: 1,
+            end_column: 1,
+            snippet: String::new(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            tags: Vec::new(),
+            crypto_algorithm: None,
+            cnsa2_deadline: None,
+            dep_name: None,
+            dep_version: None,
+            dep_ecosystem: None,
+            dep_purl: None,
+            dep_vulnerability_id: None,
+            dep_fixed_version: None,
+            dep_source: None,
+            dep_vulnerability_severity: None,
+            dep_path: Vec::new(),
+            crypto_material: None,
+        }
+    }
+
+    #[test]
+    fn v1_defaults_are_explicit_and_stable() {
+        let policy = PrSecurityPolicy::default();
+        assert_eq!(policy.version.to_string(), PR_SECURITY_POLICY_V1);
+        assert_eq!(policy.scope, PrSecurityPolicyScope::Repository);
+        assert_eq!(policy.reporting_threshold, Severity::Medium);
+        assert_eq!(policy.blocking_threshold, PrBlockingThreshold::High);
+    }
+
+    #[test]
+    fn resolver_applies_surface_overrides_and_validates_threshold_order() {
+        let configured = PrSecurityPolicyInput {
+            reporting_threshold: Some(Severity::Low),
+            blocking_threshold: Some(PrBlockingThreshold::Medium),
+            ..PrSecurityPolicyInput::default()
+        };
+        let overrides = PrSecurityPolicyInput {
+            blocking_threshold: Some(PrBlockingThreshold::High),
+            ..PrSecurityPolicyInput::default()
+        };
+        let policy = resolve(Some(&configured), &overrides).expect("valid policy");
+        assert_eq!(policy.reporting_threshold, Severity::Low);
+        assert_eq!(policy.blocking_threshold, PrBlockingThreshold::High);
+
+        let invalid = PrSecurityPolicyInput {
+            reporting_threshold: Some(Severity::High),
+            blocking_threshold: Some(PrBlockingThreshold::Medium),
+            ..PrSecurityPolicyInput::default()
+        };
+        assert!(resolve(Some(&invalid), &PrSecurityPolicyInput::default()).is_err());
+    }
+
+    #[test]
+    fn evaluation_filters_reports_and_distinguishes_all_decisions() {
+        let policy = PrSecurityPolicy::default();
+        let failed = evaluate(
+            policy,
+            vec![
+                finding(Severity::Low),
+                finding(Severity::Medium),
+                finding(Severity::High),
+            ],
+        );
+        assert_eq!(failed.findings.len(), 2);
+        assert_eq!(failed.report().decision, PrPolicyDecision::Fail);
+
+        let neutral = evaluate(
+            policy,
+            vec![finding(Severity::Low), finding(Severity::Medium)],
+        );
+        assert_eq!(neutral.report().decision, PrPolicyDecision::Neutral);
+
+        let passed = evaluate(policy, vec![finding(Severity::Low)]);
+        assert_eq!(passed.report().decision, PrPolicyDecision::Pass);
+    }
+
+    #[test]
+    fn no_blocking_threshold_reports_without_failing() {
+        let policy = PrSecurityPolicy {
+            blocking_threshold: PrBlockingThreshold::None,
+            ..PrSecurityPolicy::default()
+        };
+        let evaluation = evaluate(policy, vec![finding(Severity::High)]);
+
+        assert_eq!(evaluation.report().included_findings, 1);
+        assert_eq!(evaluation.report().blocking_findings, 0);
+        assert_eq!(evaluation.report().decision, PrPolicyDecision::Neutral);
+    }
+
+    #[test]
+    fn shared_mixed_fixture_matches_v1_contract() {
+        let (policy, findings, expected) = contract_fixture::mixed_v1();
+        let evaluation = evaluate(policy, findings);
+
+        assert_eq!(evaluation.report(), &expected);
+        assert_eq!(evaluation.findings.len(), expected.included_findings);
+    }
+
+    #[test]
+    fn cli_pr_policy_output_matches_shared_mixed_policy_contract() {
+        let (policy, findings, expected) = contract_fixture::mixed_v1();
+        let evaluation = evaluate(policy, findings);
+        let temp = tempfile::tempdir().expect("temporary output directory");
+        let output = temp.path().join("policy.json");
+
+        write_pr_policy_result(output.to_str(), evaluation.report())
+            .expect("write CLI policy output");
+
+        let written: PrPolicyReport =
+            serde_json::from_str(&std::fs::read_to_string(output).expect("read CLI policy output"))
+                .expect("parse CLI policy output");
+        assert_eq!(written, expected);
+    }
+}

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,3 +1,4 @@
+use crate::pr_policy::{PrPolicyNotEvaluated, PrPolicyReport};
 use crate::{Finding, Severity, FINDING_SCHEMA_VERSION};
 use serde::Serialize;
 use std::time::Duration;
@@ -10,6 +11,8 @@ pub struct JsonReportMetadata<'a> {
     pub config: JsonConfigMetadata,
     pub target: JsonTargetMetadata<'a>,
     pub duration: Duration,
+    pub pr_security_policy: Option<&'a PrPolicyReport>,
+    pub pr_security_policy_not_evaluated: Option<&'a PrPolicyNotEvaluated>,
 }
 
 #[derive(Debug, Clone)]
@@ -37,6 +40,10 @@ struct JsonReportEnvelope<'a> {
     timing: TimingMetadata,
     finding_counts: FindingCounts,
     findings: &'a [Finding],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr_security_policy: Option<&'a PrPolicyReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr_security_policy_not_evaluated: Option<&'a PrPolicyNotEvaluated>,
 }
 
 #[derive(Debug, Serialize)]
@@ -111,6 +118,8 @@ pub fn build_json_report(
         },
         finding_counts: counts,
         findings,
+        pr_security_policy: metadata.pr_security_policy,
+        pr_security_policy_not_evaluated: metadata.pr_security_policy_not_evaluated,
     };
 
     serde_json::to_value(envelope).expect("Failed to serialize JSON report")
@@ -202,6 +211,8 @@ mod tests {
                     diff_base: None,
                 },
                 duration: Duration::from_millis(420),
+                pr_security_policy: None,
+                pr_security_policy_not_evaluated: None,
             },
         );
 
@@ -226,6 +237,44 @@ mod tests {
             Some(1)
         );
         assert_eq!(report["findings"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn partial_scan_emits_not_evaluated_policy_status_not_repository_report() {
+        let policy = crate::pr_policy::PrPolicyNotEvaluated::new(
+            crate::pr_policy::PrSecurityPolicy::default(),
+            crate::pr_policy::PrPolicyNotEvaluatedReason::ChangedOnlyScan,
+        );
+        let report = build_json_report(
+            &[],
+            JsonReportMetadata {
+                command: "scan",
+                config: JsonConfigMetadata {
+                    source: "none",
+                    path: None,
+                },
+                target: JsonTargetMetadata {
+                    path: ".",
+                    kind: "directory",
+                    changed_only: true,
+                    files_scanned: 1,
+                    diff_base: None,
+                },
+                duration: Duration::default(),
+                pr_security_policy: None,
+                pr_security_policy_not_evaluated: Some(&policy),
+            },
+        );
+
+        assert!(report.get("pr_security_policy").is_none());
+        assert_eq!(
+            report["pr_security_policy_not_evaluated"]["reason"].as_str(),
+            Some("changed-only-scan")
+        );
+        assert_eq!(
+            report["pr_security_policy_not_evaluated"]["requested_scope"].as_str(),
+            Some("repository")
+        );
     }
 
     #[test]

--- a/tests/fixtures/pr-policy-v1-mixed.json
+++ b/tests/fixtures/pr-policy-v1-mixed.json
@@ -1,0 +1,15 @@
+{
+  "policy": {
+    "version": "v1",
+    "scope": "repository",
+    "reporting_threshold": "medium",
+    "blocking_threshold": "high"
+  },
+  "findings": ["low", "medium", "high", "critical"],
+  "expected": {
+    "scoped_findings": 4,
+    "included_findings": 3,
+    "blocking_findings": 2,
+    "decision": "fail"
+  }
+}


### PR DESCRIPTION
Fixes #580\n\n- Resolve one versioned policy across CLI, adapter, and GitHub App paths.\n- Emit policy metadata with machine-readable and check-run results.\n- Cover reporting, blocking, and scope decisions with focused tests.