### PR TITLE
feat(claude-code): preserve findings across compaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,14 @@ jobs:
       - run: bash -n benchmarks/run.sh
       - run: bash -n scripts/linux-codeql-dirty-frag.sh
       - run: bash -n scripts/smoke-github-app-image.sh
+      - run: bash -n plugins/claude-code/scripts/finding-state.sh
+      - run: perl -MFcntl=:flock -e 'exit !eval { defined(Fcntl::O_NOFOLLOW()) && LOCK_EX }'
+      - run: perl -c plugins/claude-code/scripts/with-state-lock.pl
+      - run: bash -n plugins/claude-code/scripts/restore-unresolved-findings.sh
+      - run: bash -n plugins/claude-code/scripts/scan-edited-file.sh
+      - run: bash -n plugins/claude-code/tests/test-compaction-state.sh
+      - run: jq empty plugins/claude-code/hooks/hooks.json
+      - run: bash plugins/claude-code/tests/test-compaction-state.sh
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -7,6 +7,7 @@ foxguard ships a Claude Code plugin in [`plugins/claude-code`](../plugins/claude
 - Runs a `PostToolUse` hook after `Write`, `Edit`, `MultiEdit`, and `NotebookEdit` so files Claude changes are scanned immediately.
 - Emits medium-and-above findings back to Claude so the agent can fix them before the issue lands in the repo.
 - Adds a `SessionStart` secure-coding preamble covering command execution, SQL, SSRF, path traversal, secrets, randomness, crypto, and deserialization.
+- Restores a bounded, metadata-only reminder of unresolved findings after Claude Code compaction.
 - Provides namespaced `/foxguard:*` skills for setup, full scans, diff scans, PQ audits, secrets scans, and TUI triage.
 
 ## Local Install
@@ -46,8 +47,29 @@ foxguard --format json --severity medium <edited-file>
 
 If findings are present, the hook exits `2` and prints a compact finding summary to stderr. Missing binaries, unreadable files, invalid hook input, and clean scans exit `0` so plugin machinery does not block Claude by itself.
 
-The hook uses `jq` to parse Claude Code's hook JSON. Run `/foxguard:setup` after
-loading the plugin to verify both `jq` and the active `foxguard` binary.
+When capacity allows, successful single-file scans keep only relative paths,
+thresholds, rule IDs, severities, locations, and stable fingerprints derived
+from that metadata in a private user cache outside the repository. Records are
+namespaced by a one-way repository-root identifier and session ID; raw roots
+are not stored. If the bounded cache reaches capacity, it retains bounded
+opaque omitted-path identifiers, or a conservative overflow flag if even those
+cannot fit, and compaction reports that some successful scans were omitted.
+A hook keeps every workspace record for its session and refreshes its own
+repository/session record; only sessions inactive for one day are pruned when a
+later hook runs. On `SessionStart` after compaction, foxguard returns a concise
+advisory reminder with only opaque fingerprint IDs, severities, and locations,
+not stored paths or rule IDs. This keeps untrusted filenames and rule text out
+of model context; run `/foxguard:scan` to review current findings. It
+never replays snippets, descriptions, secrets, scanner JSON, transcripts, or
+credentials. The cache does not affect foxguard baselines.
+
+This is live feedback, not a final enforcement gate. Use full or diff scans plus
+pre-commit or CI for final coverage.
+
+The hook uses `jq` to parse Claude Code's hook JSON. Perl with `Fcntl`
+no-follow locking is required only for continuity state; if it is unavailable,
+scanning still works and continuity fails open. Run `/foxguard:setup` after
+loading the plugin to verify `jq`, Perl, and the active `foxguard` binary.
 
 Tune the threshold with:
 

--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -78,6 +78,9 @@ The hook was validated directly with:
 
 ```sh
 jq --version
+perl -MFcntl=:flock -e 'exit !eval { defined(Fcntl::O_NOFOLLOW()) && LOCK_EX }'
+
+bash plugins/claude-code/tests/test-compaction-state.sh
 
 printf '{"tool_input":{"file_path":"tests/fixtures/safe.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
@@ -103,7 +106,7 @@ printf '{"tool_input":{"file_path":"/does/not/exist.py"}}' \
 
 Expected results:
 
-- `jq --version` succeeds.
+- `jq --version` and Perl no-follow `Fcntl` locking support succeed.
 - Clean supported files exit `0` and stay silent.
 - Missing files exit `0` and stay silent.
 - Finding input exits `2` and emits a compact finding summary to stderr.
@@ -112,6 +115,11 @@ Expected results:
   `tool_response.file_path`.
 - Scanner JSON parsing accepts the current `schema_version` object with a
   `findings` array.
+- The compaction-state test verifies metadata-only persistence and fingerprints,
+  cross-workspace isolation, clean-state removal, fail-open corrupt/error and
+  unavailable-lock handling, active-session liveness, per-path capacity
+  omissions, kernel-lock crash/concurrency recovery, and bounded opaque-ID
+  reminders. Run `/foxguard:scan` to review current findings.
 
 `claude plugin validate plugins/claude-code` passed with Claude Code `2.1.143`.
 Older local Claude Code builds have been observed hanging during validation;

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -6,6 +6,7 @@ Live security scanning inside [Claude Code](https://code.claude.com). Every file
 
 - **PostToolUse auto-scan** — every `Write` / `Edit` / `MultiEdit` triggers `foxguard --format json` on the changed file. Medium+ findings are surfaced to Claude on stderr; clean files are silent.
 - **SessionStart preamble** — Claude starts each session with foxguard's secure-coding defaults already in context.
+- **Compaction continuity** — successful file scans retain a bounded metadata-only reminder and restore it only after Claude Code compaction.
 - **Slash commands** for on-demand scans:
   - `/foxguard:setup` — verify install, set severity threshold
   - `/foxguard:scan [path]` — full scan, grouped and triaged by severity
@@ -85,8 +86,11 @@ plugins/claude-code/
 ├── .claude-plugin/plugin.json     # manifest
 ├── hooks/hooks.json               # PostToolUse + SessionStart
 ├── scripts/
+│   ├── finding-state.sh           # private metadata cache helpers
+│   ├── restore-unresolved-findings.sh  # compact-only SessionStart reminder
 │   ├── scan-edited-file.sh        # the PostToolUse scanner
-│   └── secure-defaults.txt        # SessionStart preamble
+│   ├── secure-defaults.txt        # SessionStart preamble
+│   └── with-state-lock.pl         # kernel-backed state lock wrapper
 ├── skills/
 │   ├── setup/SKILL.md             # /foxguard:setup
 │   ├── scan/SKILL.md              # /foxguard:scan
@@ -101,10 +105,27 @@ plugins/claude-code/
 
 ## Notes
 
-- The hook intentionally never blocks Claude on its own machinery: missing binary, parse errors, or unreadable inputs all exit `0`. Only real findings exit `2`.
-- The hook calls `foxguard` from `PATH` first, then falls back to `npx --yes foxguard`. It uses `jq` to parse Claude Code's hook JSON. If either dependency is unavailable it stays silent — run `/foxguard:setup` to fix that.
+- The hook intentionally never blocks Claude on its own machinery: missing binary, parse errors, unreadable inputs, or unavailable continuity locking all exit `0`. Only real findings exit `2`.
+- The hook calls `foxguard` from `PATH` first, then falls back to `npx --yes foxguard`. It uses `jq` to parse Claude Code's hook JSON. `jq` is required for scanning; Perl with `Fcntl` no-follow locking is required only for compaction continuity. If a dependency is unavailable, the affected hook behavior stays silent — run `/foxguard:setup` to fix that.
 - `--severity medium` is the default cutoff. Drop to `low` for stricter coverage; raise to `high` for noisier projects.
 - foxguard's exit codes: `0` clean, `1` findings, `2` error. The hook checks for findings via the JSON, not the exit code, so a piped error doesn't trigger a false alarm.
+- When capacity allows, successful scans keep only relative file paths,
+  thresholds, rule IDs, severities, locations, and fingerprints derived from
+  that metadata in a private user cache outside the repository—never snippets,
+  descriptions, scanner JSON, transcripts, credentials, or baselines. Cache
+  records are namespaced by a one-way repository-root identifier and session
+  ID, not a raw root path. Capacity pressure retains bounded opaque
+  omitted-path identifiers; if even those cannot fit, it retains a conservative
+  overflow flag so compaction can still warn.
+- Compaction output deliberately includes only opaque fingerprint IDs, severities,
+  and locations—not stored paths or rule IDs—so untrusted filenames and rule
+  text cannot enter model context. Run `/foxguard:scan` to review current
+  findings.
+- A hook keeps every workspace record for its session and refreshes its own
+  repository/session record, including on resumed compaction. Only sessions
+  inactive for one day are pruned when a later hook runs.
+- Compaction restoration is advisory feedback only. It does not replace a full
+  scan, diff scan, pre-commit hook, or CI enforcement.
 - This package is scoped to Claude Code. Broader agent or editor integration
   design should be tracked separately from the Claude Code marketplace release.
 

--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/scan-edited-file.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/scan-edited-file.sh\""
           }
         ]
       }
@@ -17,6 +17,15 @@
           {
             "type": "command",
             "command": "cat \"${CLAUDE_PLUGIN_ROOT}/scripts/secure-defaults.txt\""
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/restore-unresolved-findings.sh\""
           }
         ]
       }

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -1,0 +1,670 @@
+#!/usr/bin/env bash
+# Metadata-only state helpers for Claude Code hook continuity.
+
+FG_STATE_MAX_FILES=64
+FG_STATE_MAX_FINDINGS=64
+FG_STATE_MAX_OMITTED=64
+FG_STATE_MAX_TOTAL=10000
+FG_STATE_MAX_BYTES=131072
+# Reserve space for a bounded omitted-path marker when a normal record reaches capacity.
+FG_STATE_OVERFLOW_RESERVE=128
+FG_STATE_MAX_SUMMARY_FILES=6
+FG_STATE_MAX_SUMMARY_FINDINGS=2
+FG_STATE_SUMMARY_MAX_BYTES=3072
+
+fg_state_repository_root() {
+  local cwd=$1 root
+
+  [ -n "$cwd" ] || return 1
+  root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || return 1
+  (cd -P "$root" 2>/dev/null && pwd -P)
+}
+
+fg_state_normalize_file_path() {
+  local cwd=$1 file_path=$2 repo_root=$3 resolved_cwd candidate file_dir file_name resolved_dir resolved_path
+
+  case "$cwd" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  case "$repo_root" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  resolved_cwd=$(cd -P "$cwd" 2>/dev/null && pwd -P) || return 1
+  case "$file_path" in
+    /*) candidate=$file_path ;;
+    *) candidate="$resolved_cwd/$file_path" ;;
+  esac
+  file_dir=${candidate%/*}
+  file_name=${candidate##*/}
+  [ "$file_dir" != "$candidate" ] && [ -n "$file_name" ] || return 1
+  [ -n "$file_dir" ] || file_dir=/
+  resolved_dir=$(cd -P "$file_dir" 2>/dev/null && pwd -P) || return 1
+  resolved_path="$resolved_dir/$file_name"
+  [ ! -L "$resolved_path" ] || return 1
+
+  case "$resolved_path" in
+    "$repo_root"/*) printf '%s\n' "$resolved_path" ;;
+    *) return 1 ;;
+  esac
+}
+
+fg_state_relative_path() {
+  local file_path=$1 repo_root=$2 file_dir file_name resolved_path
+
+  case "$file_path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+
+  file_dir=${file_path%/*}
+  file_name=${file_path##*/}
+  [ "$file_dir" != "$file_path" ] && [ -n "$file_name" ] || return 1
+  [ -n "$file_dir" ] || file_dir=/
+  file_dir=$(cd -P "$file_dir" 2>/dev/null && pwd -P) || return 1
+  resolved_path="$file_dir/$file_name"
+
+  case "$resolved_path" in
+    "$repo_root"/*) printf '%s\n' "${resolved_path#"$repo_root"/}" ;;
+    *) return 1 ;;
+  esac
+}
+
+fg_state_cache_path_outside_repository() {
+  local candidate=$1 repo_root=$2 probe=$1 parent physical
+
+  # Start at the nearest existing ancestor, then compare physical filesystem
+  # identities while walking upward so case-folding aliases cannot bypass this.
+  while [ ! -e "$probe" ] && [ ! -L "$probe" ]; do
+    parent=${probe%/*}
+    [ "$parent" != "$probe" ] || return 1
+    [ -n "$parent" ] || parent=/
+    probe=$parent
+  done
+  [ -d "$probe" ] || return 1
+  physical=$(cd -P "$probe" 2>/dev/null && pwd -P) || return 1
+
+  while :; do
+    [[ "$physical" -ef "$repo_root" ]] && return 1
+    [ "$physical" = / ] && return 0
+    parent=$(cd -P "$physical/.." 2>/dev/null && pwd -P) || return 1
+    [ "$parent" != "$physical" ] || return 1
+    physical=$parent
+  done
+}
+
+
+fg_state_root() {
+  local repo_root=$1 cache_home state_root resolved_state resolved_repo
+
+  resolved_repo=$(cd -P "$repo_root" 2>/dev/null && pwd -P) || return 1
+
+  if [ -n "${XDG_CACHE_HOME:-}" ]; then
+    cache_home=$XDG_CACHE_HOME
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    cache_home="${HOME:-}/Library/Caches"
+  else
+    cache_home="${HOME:-}/.cache"
+  fi
+
+  case "$cache_home" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+
+  state_root="$cache_home/foxguard/claude-code"
+  fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
+  (umask 077; mkdir -p "$state_root" >/dev/null 2>&1) || return 1
+  [ -d "$state_root" ] && [ ! -L "$state_root" ] || return 1
+  fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
+  chmod 700 "$state_root" >/dev/null 2>&1 || return 1
+
+  resolved_state=$(cd -P "$state_root" 2>/dev/null && pwd -P) || return 1
+  fg_state_cache_path_outside_repository "$resolved_state" "$resolved_repo" || return 1
+  printf '%s\n' "$resolved_state"
+}
+
+fg_state_session_key() {
+  [[ "$1" =~ ^[A-Za-z0-9_-]{1,128}$ ]] || return 1
+  fg_state_sha256 "foxguard-claude-code-session-v1" "$1"
+}
+
+fg_state_session_file() {
+  local state_root=$1 repo_root=$2 session_id=$3 workspace_key session_key
+
+  workspace_key=$(fg_state_workspace_key "$repo_root") || return 1
+  session_key=$(fg_state_session_key "$session_id") || return 1
+  printf '%s/%s-%s.json\n' "$state_root" "$workspace_key" "$session_key"
+}
+
+fg_state_valid_threshold() {
+  case "$1" in
+    low|medium|high|critical) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fg_state_sha256() {
+  local digest
+
+  if command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s\0' "$@" | shasum -a 256 | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s\0' "$@" | sha256sum | awk '{print $1}')
+  elif command -v openssl >/dev/null 2>&1; then
+    digest=$(printf '%s\0' "$@" | openssl dgst -sha256 | awk '{print $NF}')
+  else
+    return 1
+  fi
+
+  [[ "$digest" =~ ^[a-f0-9]{64}$ ]] || return 1
+  printf '%s\n' "$digest"
+}
+
+fg_state_workspace_key() {
+  fg_state_sha256 "foxguard-claude-code-workspace-v1" "$1"
+}
+
+fg_state_fingerprint() {
+  # The fingerprint input is limited to the metadata that is retained in state.
+  fg_state_sha256 "$@"
+}
+
+fg_state_omitted_path_key() {
+  fg_state_fingerprint "foxguard-claude-code-omitted-path-v1" "$1"
+}
+
+fg_state_add_omitted_path() {
+  local state=$1 relative_path=$2 omitted_key
+
+  omitted_key=$(fg_state_omitted_path_key "$relative_path") || return 1
+  printf '%s' "$state" | jq -ce --arg key "$omitted_key" --argjson max_omitted "$FG_STATE_MAX_OMITTED" '
+    if (.omitted | index($key)) then .
+    elif (.omitted | length) < $max_omitted then .omitted += [$key]
+    else .overflow = 1
+    end
+  '
+}
+
+fg_state_remove_omitted_path() {
+  local state=$1 relative_path=$2 omitted_key
+
+  omitted_key=$(fg_state_omitted_path_key "$relative_path") || return 1
+  printf '%s' "$state" | jq -ce --arg key "$omitted_key" '.omitted |= map(select(. != $key))'
+}
+
+fg_state_mark_untracked_overflow() {
+  printf '%s' "$1" | jq -ce '.overflow = 1'
+}
+
+fg_state_is_empty() {
+  printf '%s' "$1" | jq -e '(.files | length) == 0 and (.omitted | length) == 0 and .overflow == 0' >/dev/null 2>&1
+}
+
+fg_state_validate() {
+  jq -ce --argjson max_omitted "$FG_STATE_MAX_OMITTED" '
+    def valid_path:
+      type == "string"
+      and length > 0
+      and length <= 240
+      and (startswith("/") | not)
+      and (test("^[A-Za-z]:[\\\\/]") | not)
+      and (contains("\\") | not)
+      and (test("[\\x00-\\x1F\\x7F]") | not)
+      and (split("/") | all(. != "" and . != "." and . != ".."));
+    def valid_rule:
+      type == "string"
+      and length > 0
+      and length <= 128
+      and test("^[A-Za-z0-9][A-Za-z0-9._/@:+-]*$");
+    def valid_severity:
+      type == "string"
+      and (. == "low" or . == "medium" or . == "high" or . == "critical");
+    def valid_position:
+      type == "number"
+      and floor == .
+      and . >= 1
+      and . <= 2147483647;
+    def valid_count:
+      type == "number"
+      and floor == .
+      and . >= 1
+      and . <= 10000;
+    def valid_overflow:
+      type == "number"
+      and floor == .
+      and (. == 0 or . == 1);
+    def valid_omitted:
+      type == "array"
+      and length <= $max_omitted
+      and all(.[]; type == "string" and test("^[a-f0-9]{64}$"))
+      and (length == (unique | length));
+    def valid_finding:
+      type == "object"
+      and ((keys | sort) == ["column", "fingerprint", "line", "rule_id", "severity"])
+      and (.fingerprint | type == "string" and test("^[a-f0-9]{64}$"))
+      and (.rule_id | valid_rule)
+      and (.severity | valid_severity)
+      and (.line | valid_position)
+      and (.column | valid_position);
+    def valid_entry:
+      type == "object"
+      and ((keys | sort) == ["findings", "threshold", "total", "truncated"])
+      and (.threshold | valid_severity)
+      and (.total | valid_count)
+      and (.truncated | type == "boolean")
+      and (.findings | type == "array" and length > 0 and length <= 64 and all(.[]; valid_finding))
+      and ((.findings | length) as $count |
+        .total >= $count
+        and (if .truncated then .total > $count else .total == $count end));
+    if type != "object" then
+      error("invalid foxguard Claude Code state")
+    elif .version == 1
+      and ((keys | sort) == ["files", "version"])
+      and (.files | type == "object" and length <= 64)
+      and (.files | all(to_entries[]; (.key | valid_path) and (.value | valid_entry)))
+    then
+      {version: 3, overflow: 0, omitted: [], files: .files}
+    elif .version == 2
+      and ((keys | sort) == ["files", "overflow", "version"])
+      and (.overflow | type == "number" and floor == . and . >= 0 and . <= 10000)
+      and (.files | type == "object" and length <= 64)
+      and (.files | all(to_entries[]; (.key | valid_path) and (.value | valid_entry)))
+    then
+      {version: 3, overflow: (if .overflow > 0 then 1 else 0 end), omitted: [], files: .files}
+    elif .version == 3
+      and ((keys | sort) == ["files", "omitted", "overflow", "version"])
+      and (.overflow | valid_overflow)
+      and (.omitted | valid_omitted)
+      and (.files | type == "object" and length <= 64)
+      and (.files | all(to_entries[]; (.key | valid_path) and (.value | valid_entry)))
+    then .
+    else
+      error("invalid foxguard Claude Code state")
+    end
+  '
+}
+
+fg_state_normalize_findings() {
+  jq -ce --argjson max_findings "$FG_STATE_MAX_FINDINGS" --argjson max_total "$FG_STATE_MAX_TOTAL" '
+    def valid_rule:
+      type == "string"
+      and length > 0
+      and length <= 128
+      and test("^[A-Za-z0-9][A-Za-z0-9._/@:+-]*$");
+    def valid_severity:
+      type == "string"
+      and (. == "low" or . == "medium" or . == "high" or . == "critical");
+    def valid_position:
+      type == "number"
+      and floor == .
+      and . >= 1
+      and . <= 2147483647;
+    def valid_finding:
+      type == "object"
+      and (.rule_id | valid_rule)
+      and (.severity | valid_severity)
+      and (.line | valid_position)
+      and (.column | valid_position);
+    if type != "array" or (all(.[]; valid_finding) | not) then
+      error("invalid scanner finding metadata")
+    else
+      [ .[] | {rule_id, severity, line, column} ]
+      | sort_by(.severity, .rule_id, .line, .column)
+      | unique_by([.rule_id, .severity, .line, .column])
+      | . as $findings
+      | ($findings | length) as $count
+      | {
+          total: (if $count > $max_total then $max_total else $count end),
+          truncated: ($count > $max_findings or $count > $max_total),
+          findings: $findings[0:$max_findings]
+        }
+    end
+  '
+}
+
+fg_state_add_fingerprints() {
+  local relative_path=$1 record=$2
+  local total truncated entries= rule_id severity line column fingerprint entry status=0
+
+  total=$(printf '%s' "$record" | jq -er '.total' 2>/dev/null) || return 1
+  truncated=$(printf '%s' "$record" | jq -r '.truncated' 2>/dev/null) || return 1
+
+  while IFS=$'\t' read -r rule_id severity line column; do
+    fingerprint=$(fg_state_fingerprint "$relative_path" "$rule_id" "$severity" "$line" "$column") || {
+      status=1
+      break
+    }
+    entry=$(jq -cn \
+      --arg fingerprint "$fingerprint" \
+      --arg rule_id "$rule_id" \
+      --arg severity "$severity" \
+      --argjson line "$line" \
+      --argjson column "$column" \
+      '{fingerprint: $fingerprint, rule_id: $rule_id, severity: $severity, line: $line, column: $column}') || {
+      status=1
+      break
+    }
+    entries="${entries}${entries:+$'\n'}${entry}"
+  done < <(printf '%s' "$record" | jq -r '.findings[] | [.rule_id, .severity, (.line | tostring), (.column | tostring)] | @tsv')
+
+  [ "$status" = "0" ] && [ -n "$entries" ] || return 1
+  printf '%s\n' "$entries" | jq -sce \
+    --argjson total "$total" \
+    --argjson truncated "$truncated" \
+    '{total: $total, truncated: $truncated, findings: .}'
+}
+
+fg_state_prune_locked() {
+  local state_root=$1 active_session_key=${2:-}
+
+  if [ -n "$active_session_key" ]; then
+    [[ "$active_session_key" =~ ^[a-f0-9]{64}$ ]] || return 1
+    find "$state_root" -type f -name "*-${active_session_key}.json" -exec touch {} \; 2>/dev/null || :
+    find "$state_root" -type f -name '*.json' ! -name "*-${active_session_key}.json" -mtime +0 -exec rm -f {} \; 2>/dev/null || :
+  else
+    find "$state_root" -type f -name '*.json' -mtime +0 -exec rm -f {} \; 2>/dev/null || :
+  fi
+  # The kernel lock serializes state writes, so no live writer owns one of these.
+  find "$state_root" -type f -name '.state.*' -exec rm -f {} \; 2>/dev/null || :
+}
+
+fg_state_script_path() {
+  local script_path=${BASH_SOURCE[0]} script_dir
+
+  script_dir=$(CDPATH= cd -- "$(dirname -- "$script_path")" 2>/dev/null && pwd -P) || return 1
+  [ -f "$script_dir/finding-state.sh" ] && [ ! -L "$script_dir/finding-state.sh" ] || return 1
+  printf '%s/finding-state.sh\n' "$script_dir"
+}
+
+fg_state_lock_wrapper_path() {
+  local state_script
+
+  state_script=$(fg_state_script_path) || return 1
+  [ -r "${state_script%/*}/with-state-lock.pl" ] || return 1
+  printf '%s/with-state-lock.pl\n' "${state_script%/*}"
+}
+
+fg_state_apply_lock_limits() {
+  local max_bytes=$1 max_omitted=$2
+
+  [[ "$max_bytes" =~ ^[0-9]{1,6}$ ]] || return 1
+  [[ "$max_omitted" =~ ^[0-9]{1,2}$ ]] || return 1
+  [ "$max_bytes" -ge "$FG_STATE_OVERFLOW_RESERVE" ] && [ "$max_bytes" -le 131072 ] || return 1
+  [ "$max_omitted" -le 64 ] || return 1
+  FG_STATE_MAX_BYTES=$max_bytes
+  FG_STATE_MAX_OMITTED=$max_omitted
+}
+
+fg_state_with_root_lock() {
+  local state_root=$1 callback=$2 action state_script lock_wrapper
+  shift 2
+
+  case "$callback" in
+    fg_state_update_file_locked) action=--locked-update ;;
+    fg_state_remove_file_locked) action=--locked-remove ;;
+    fg_state_emit_compact_summary_locked) action=--locked-summary ;;
+    *) return 1 ;;
+  esac
+  command -v perl >/dev/null 2>&1 || return 1
+  state_script=$(fg_state_script_path) || return 1
+  lock_wrapper=$(fg_state_lock_wrapper_path) || return 1
+  [ -x "$state_script" ] || return 1
+
+  # The wrapper holds an inherited flock through the self-invoked action.
+  perl "$lock_wrapper" "$state_root/.lock" "$state_script" "$action" \
+    "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$@"
+}
+
+fg_state_atomic_write() (
+  local state_root=$1 state_file=$2 content=$3 allow_overflow_reserve=${4:-0} temp_file= size limit
+
+  fg_state_atomic_cleanup() {
+    [ -n "$temp_file" ] && rm -f "$temp_file" 2>/dev/null || :
+  }
+  trap fg_state_atomic_cleanup EXIT
+  trap 'exit 1' HUP INT TERM
+
+  case "$allow_overflow_reserve" in
+    0) limit=$((FG_STATE_MAX_BYTES - FG_STATE_OVERFLOW_RESERVE)) ;;
+    1) limit=$FG_STATE_MAX_BYTES ;;
+    *) return 1 ;;
+  esac
+
+  temp_file=$(mktemp "$state_root/.state.XXXXXX" 2>/dev/null) || return 1
+  printf '%s\n' "$content" > "$temp_file" || return 1
+  chmod 600 "$temp_file" || return 1
+
+  size=$(wc -c < "$temp_file") || return 1
+  size=${size//[[:space:]]/}
+  case "$size" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$size" -le "$limit" ] || return 2
+
+  mv -f "$temp_file" "$state_file" || return 1
+  temp_file=
+)
+
+fg_state_write_omitted_fallback() {
+  local state_root=$1 state_file=$2 state=$3 relative_path=$4 next write_status
+
+  next=$(fg_state_add_omitted_path "$state" "$relative_path") || return 1
+  printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
+  if fg_state_atomic_write "$state_root" "$state_file" "$next" 1; then
+    return 0
+  else
+    write_status=$?
+  fi
+  [ "$write_status" = "2" ] || return 1
+
+  next=$(fg_state_mark_untracked_overflow "$state") || return 1
+  printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
+  fg_state_atomic_write "$state_root" "$state_file" "$next" 1
+}
+
+fg_state_update_file_locked() {
+  local state_root=$1 state_file=$2 session_key=$3 relative_path=$4 threshold=$5 record=$6
+  local current entry next fallback_state write_status can_store=0 existing=0
+
+  fg_state_prune_locked "$state_root" "$session_key"
+  if [ -e "$state_file" ]; then
+    if [ -f "$state_file" ] && [ ! -L "$state_file" ]; then
+      current=$(fg_state_validate < "$state_file" 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
+    else
+      return 1
+    fi
+  else
+    current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
+  fi
+
+  entry=$(printf '%s' "$record" | jq -ce --arg threshold "$threshold" '. + {threshold: $threshold}' 2>/dev/null) || return 1
+  if printf '%s' "$current" | jq -e --arg path "$relative_path" '.files | has($path)' >/dev/null 2>&1; then
+    existing=1
+  fi
+  if [ "$existing" = "1" ] || printf '%s' "$current" | jq -e \
+    --argjson max_files "$FG_STATE_MAX_FILES" '(.files | length) < $max_files' >/dev/null 2>&1; then
+    can_store=1
+  fi
+
+  if [ "$can_store" != "1" ]; then
+    fg_state_write_omitted_fallback "$state_root" "$state_file" "$current" "$relative_path"
+    return $?
+  fi
+
+  next=$(printf '%s' "$current" | jq -ce \
+    --arg path "$relative_path" \
+    --argjson entry "$entry" '.files[$path] = $entry' 2>/dev/null) || return 1
+  next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
+  printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
+  if fg_state_atomic_write "$state_root" "$state_file" "$next" 0; then
+    return 0
+  else
+    write_status=$?
+  fi
+  [ "$write_status" = "2" ] || return 1
+
+  fallback_state=$current
+  if [ "$existing" = "1" ]; then
+    fallback_state=$(printf '%s' "$fallback_state" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
+  fi
+  fg_state_write_omitted_fallback "$state_root" "$state_file" "$fallback_state" "$relative_path"
+}
+
+fg_state_update_file() {
+  local session_id=$1 repo_root=$2 relative_path=$3 threshold=$4 record=$5
+  local state_root state_file session_key
+
+  fg_state_valid_threshold "$threshold" || return 1
+  state_root=$(fg_state_root "$repo_root") || return 1
+  session_key=$(fg_state_session_key "$session_id") || return 1
+  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
+  fg_state_with_root_lock "$state_root" fg_state_update_file_locked \
+    "$state_root" "$state_file" "$session_key" "$relative_path" "$threshold" "$record"
+}
+
+fg_state_remove_file_locked() {
+  local state_root=$1 state_file=$2 session_key=$3 relative_path=$4
+  local current next status=1
+
+  fg_state_prune_locked "$state_root" "$session_key"
+  [ -e "$state_file" ] || return 0
+  [ -f "$state_file" ] && [ ! -L "$state_file" ] || return 1
+  current=$(fg_state_validate < "$state_file" 2>/dev/null) || return 1
+
+  next=$(printf '%s' "$current" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
+  next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
+  if fg_state_is_empty "$next"; then
+    rm -f "$state_file" && status=0
+  elif printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 \
+    && fg_state_atomic_write "$state_root" "$state_file" "$next"; then
+    status=0
+  fi
+  return "$status"
+}
+
+fg_state_remove_file() {
+  local session_id=$1 repo_root=$2 relative_path=$3
+  local state_root state_file session_key
+
+  state_root=$(fg_state_root "$repo_root") || return 1
+  session_key=$(fg_state_session_key "$session_id") || return 1
+  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
+  fg_state_with_root_lock "$state_root" fg_state_remove_file_locked \
+    "$state_root" "$state_file" "$session_key" "$relative_path"
+}
+
+fg_state_record_findings() {
+  local session_id=$1 cwd=$2 file_path=$3 threshold=$4 findings=$5
+  local repo_root relative_path record
+
+  repo_root=$(fg_state_repository_root "$cwd") || return 1
+  file_path=$(fg_state_normalize_file_path "$cwd" "$file_path" "$repo_root") || return 1
+  relative_path=$(fg_state_relative_path "$file_path" "$repo_root") || return 1
+  record=$(printf '%s' "$findings" | fg_state_normalize_findings 2>/dev/null) || return 1
+  record=$(fg_state_add_fingerprints "$relative_path" "$record" 2>/dev/null) || return 1
+  fg_state_update_file "$session_id" "$repo_root" "$relative_path" "$threshold" "$record"
+}
+
+fg_state_clear_findings() {
+  local session_id=$1 cwd=$2 file_path=$3
+  local repo_root relative_path
+
+  repo_root=$(fg_state_repository_root "$cwd") || return 1
+  file_path=$(fg_state_normalize_file_path "$cwd" "$file_path" "$repo_root") || return 1
+  relative_path=$(fg_state_relative_path "$file_path" "$repo_root") || return 1
+  fg_state_remove_file "$session_id" "$repo_root" "$relative_path"
+}
+
+fg_state_emit_compact_summary_locked() {
+  local state_root=$1 state_file=$2 session_key=$3
+  local state details header footer truncated_footer body detail_limit
+
+  fg_state_prune_locked "$state_root" "$session_key"
+  [ -f "$state_file" ] && [ ! -L "$state_file" ] || return 1
+  state=$(fg_state_validate < "$state_file" 2>/dev/null) || return 1
+
+  details=$(printf '%s' "$state" | jq -r \
+    --argjson max_files "$FG_STATE_MAX_SUMMARY_FILES" \
+    --argjson max_findings "$FG_STATE_MAX_SUMMARY_FINDINGS" '
+      [.files | to_entries[] |
+        {
+          total: .value.total,
+          truncated: .value.truncated,
+          findings: (.value.findings | sort_by(.severity, .fingerprint, .line, .column) | .[0:$max_findings])
+        }
+      ] as $files
+      | ($files | sort_by(.findings[0].fingerprint) | .[0:$max_files]) as $shown
+      | (if .overflow > 0 or (.omitted | length) > 0
+         then "- Some successful scan results were omitted because the local continuity cache reached capacity."
+         else empty
+         end),
+        ($shown[] | .findings[] |
+          "- [\(.severity | ascii_upcase)] finding \(.fingerprint[0:12]) at line \(.line), column \(.column)"
+        ),
+        (if (($files | length) > ($shown | length))
+          or ($shown | any(.[]; .truncated or (.total > (.findings | length))))
+         then "- Additional finding details omitted."
+         else empty
+         end)
+    ' 2>/dev/null) || return 1
+  [ -n "$details" ] || return 1
+
+  header='foxguard unresolved findings from this session are advisory feedback, not a final enforcement gate. Finding IDs are opaque; run `/foxguard:scan` to review current findings.'
+  footer='Run `/foxguard:scan` to review current findings.'
+  truncated_footer='Additional finding details omitted. Run `/foxguard:scan` to review current findings.'
+  body="$header"$'\n'"$details"$'\n'"$footer"
+
+  if [ $(( ${#body} + 1 )) -gt "$FG_STATE_SUMMARY_MAX_BYTES" ]; then
+    detail_limit=$((FG_STATE_SUMMARY_MAX_BYTES - ${#header} - ${#truncated_footer} - 3))
+    [ "$detail_limit" -gt 0 ] || return 1
+    details="${details:0:$detail_limit}"
+    body="$header"$'\n'"$details"$'\n'"$truncated_footer"
+  fi
+
+  printf '%s\n' "$body"
+}
+
+fg_state_emit_compact_summary() {
+  local session_id=$1 cwd=$2
+  local repo_root state_root state_file session_key
+
+  repo_root=$(fg_state_repository_root "$cwd") || return 1
+  state_root=$(fg_state_root "$repo_root") || return 1
+  session_key=$(fg_state_session_key "$session_id") || return 1
+  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
+  fg_state_with_root_lock "$state_root" fg_state_emit_compact_summary_locked \
+    "$state_root" "$state_file" "$session_key"
+}
+
+fg_state_run_locked_action() {
+  local action=${1:-}
+  shift || return 1
+
+  case "$action" in
+    --locked-update)
+      [ "$#" -eq 8 ] || return 1
+      fg_state_apply_lock_limits "$1" "$2" || return 1
+      shift 2
+      fg_state_update_file_locked "$@"
+      ;;
+    --locked-remove)
+      [ "$#" -eq 6 ] || return 1
+      fg_state_apply_lock_limits "$1" "$2" || return 1
+      shift 2
+      fg_state_remove_file_locked "$@"
+      ;;
+    --locked-summary)
+      [ "$#" -eq 5 ] || return 1
+      fg_state_apply_lock_limits "$1" "$2" || return 1
+      shift 2
+      fg_state_emit_compact_summary_locked "$@"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  fg_state_run_locked_action "$@"
+fi

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -72,7 +72,7 @@ fg_state_relative_path() {
 }
 
 fg_state_cache_path_outside_repository() {
-  local candidate=$1 repo_root=$2 probe=$1 parent physical
+  local candidate=$1 repo_root=$2 probe=$1 parent physical candidate_physical
 
   # Start at the nearest existing ancestor, then compare physical filesystem
   # identities while walking upward so case-folding aliases cannot bypass this.
@@ -87,11 +87,23 @@ fg_state_cache_path_outside_repository() {
 
   while :; do
     [[ "$physical" -ef "$repo_root" ]] && return 1
-    [ "$physical" = / ] && return 0
+    [ "$physical" = / ] && break
     parent=$(cd -P "$physical/.." 2>/dev/null && pwd -P) || return 1
     [ "$parent" != "$physical" ] || return 1
     physical=$parent
   done
+
+  if [ -d "$candidate" ] && [ ! -L "$candidate" ]; then
+    candidate_physical=$(cd -P "$candidate" 2>/dev/null && pwd -P) || return 1
+    physical=$(cd -P "$repo_root" 2>/dev/null && pwd -P) || return 1
+    while :; do
+      [[ "$physical" -ef "$candidate_physical" ]] && return 1
+      [ "$physical" = / ] && break
+      parent=$(cd -P "$physical/.." 2>/dev/null && pwd -P) || return 1
+      [ "$parent" != "$physical" ] || return 1
+      physical=$parent
+    done
+  fi
 }
 
 
@@ -166,9 +178,81 @@ fg_state_workspace_key() {
   fg_state_sha256 "foxguard-claude-code-workspace-v1" "$1"
 }
 
-fg_state_prepare_locked_state() {
-  local repo_identity=$1 session_id=$2 repo_root state_root workspace_key session_key state_file
+fg_state_file_operation() {
+  local action=$1
+  shift
 
+  command -v perl >/dev/null 2>&1 || return 1
+  perl -MFcntl=:DEFAULT,S_IFMT,S_IFREG -e '
+    sub is_regular_unlinked {
+      my ($file) = @_;
+      my @stat = stat($file);
+
+      return @stat
+        && (($stat[2] & S_IFMT) == S_IFREG)
+        && $stat[3] == 1;
+    }
+
+    my $action = shift @ARGV;
+    exit 1 unless defined($action) && @ARGV;
+    exit 1 if ($action eq q(read) || $action eq q(touch-read)) && @ARGV != 1;
+
+    my $no_follow = eval { Fcntl::O_NOFOLLOW() };
+    exit 1 if $@ || !defined($no_follow);
+    my @files;
+    for my $path (@ARGV) {
+      sysopen(my $file, $path, O_RDONLY | O_NONBLOCK | $no_follow) or exit 1;
+      exit 1 unless is_regular_unlinked($file);
+      my @stat = stat($file);
+      push @files, [$path, $file, $stat[0], $stat[1]];
+    }
+
+    if ($action eq q(check)) {
+      exit 0;
+    }
+    if ($action eq q(touch) || $action eq q(touch-read)) {
+      for my $entry (@files) {
+        exit 1 unless is_regular_unlinked($entry->[1]);
+        utime undef, undef, $entry->[1] or exit 1;
+      }
+      exit 0 if $action eq q(touch);
+    }
+    if ($action eq q(read) || $action eq q(touch-read)) {
+      my $buffer;
+      while (1) {
+        my $count = sysread($files[0][1], $buffer, 8192);
+        exit 1 unless defined($count);
+        last if $count == 0;
+        print $buffer or exit 1;
+      }
+      exit 0;
+    }
+    if ($action eq q(remove)) {
+      for my $entry (@files) {
+        my @path_stat = lstat($entry->[0]);
+        exit 1 unless @path_stat
+          && $path_stat[0] == $entry->[2]
+          && $path_stat[1] == $entry->[3]
+          && (($path_stat[2] & S_IFMT) == S_IFREG)
+          && $path_stat[3] == 1;
+      }
+      for my $entry (@files) {
+        unlink $entry->[0] or exit 1;
+      }
+      exit 0;
+    }
+    exit 1;
+  ' "$action" "$@"
+}
+
+
+fg_state_prepare_locked_state() {
+  local repo_identity=$1 session_id=$2 check_file=${3:-1} repo_root state_root workspace_key session_key state_file
+
+  case "$check_file" in
+    0|1) ;;
+    *) return 1 ;;
+  esac
   # Locked actions are executable; re-derive every filesystem path from identity.
   unset FG_STATE_LOCKED_REPOSITORY FG_STATE_LOCKED_SESSION_ID \
     FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE
@@ -179,6 +263,9 @@ fg_state_prepare_locked_state() {
   state_file="$state_root/$workspace_key-$session_key.json"
   [ ! -L "$state_file" ] || return 1
   [ ! -e "$state_file" ] || [ -f "$state_file" ] || return 1
+  if [ "$check_file" = "1" ] && [ -e "$state_file" ]; then
+    fg_state_file_operation check "$state_file" || return 1
+  fi
 
   FG_STATE_LOCKED_REPOSITORY=$repo_root
   FG_STATE_LOCKED_SESSION_ID=$session_id
@@ -379,13 +466,37 @@ fg_state_add_fingerprints() {
 }
 
 fg_state_prune_locked() {
-  local repo_identity=$1 session_id=$2
+  local repo_identity=$1 session_id=$2 candidate
+  local -a candidates
 
-  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
-  find "$FG_STATE_LOCKED_ROOT" -type f -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -exec touch {} \; 2>/dev/null || :
-  find "$FG_STATE_LOCKED_ROOT" -type f -name '*.json' ! -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -mtime +0 -exec rm -f {} \; 2>/dev/null || :
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
+  candidates=()
+  while IFS= read -r -d '' candidate; do
+    candidates[${#candidates[@]}]=$candidate
+  done < <(
+    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
+      -type f ! -path "$FG_STATE_LOCKED_FILE" -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -print0 2>/dev/null
+  )
+  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation touch "${candidates[@]}" || return 1
+
+  candidates=()
+  while IFS= read -r -d '' candidate; do
+    candidates[${#candidates[@]}]=$candidate
+  done < <(
+    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
+      -type f -name '*.json' ! -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -mtime +0 -print0 2>/dev/null
+  )
+  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation remove "${candidates[@]}" || return 1
+
   # The kernel lock serializes state writes, so no live writer owns one of these.
-  find "$FG_STATE_LOCKED_ROOT" -type f -name '.state.*' -exec rm -f {} \; 2>/dev/null || :
+  candidates=()
+  while IFS= read -r -d '' candidate; do
+    candidates[${#candidates[@]}]=$candidate
+  done < <(
+    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
+      -type f -name '.state.*' -print0 2>/dev/null
+  )
+  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation remove "${candidates[@]}" || return 1
 }
 
 
@@ -426,7 +537,7 @@ fg_state_with_root_lock() {
     fg_state_emit_compact_summary_locked) action=--locked-summary ;;
     *) return 1 ;;
   esac
-  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
   command -v perl >/dev/null 2>&1 || return 1
   state_script=$(fg_state_script_path) || return 1
   lock_wrapper=$(fg_state_lock_wrapper_path) || return 1
@@ -457,9 +568,9 @@ fg_state_atomic_write() (
     *) return 1 ;;
   esac
 
+  umask 077
   temp_file=$(mktemp "$FG_STATE_LOCKED_ROOT/.state.XXXXXX" 2>/dev/null) || return 1
   printf '%s\n' "$content" > "$temp_file" || return 1
-  chmod 600 "$temp_file" || return 1
 
   size=$(wc -c < "$temp_file") || return 1
   size=${size//[[:space:]]/}
@@ -497,11 +608,9 @@ fg_state_update_file_locked() {
 
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
   if [ -e "$FG_STATE_LOCKED_FILE" ]; then
-    if [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ]; then
-      current=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
-    else
-      return 1
-    fi
+    [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
+    current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+    current=$(printf '%s' "$current" | fg_state_validate 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
   else
     current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
   fi
@@ -558,7 +667,8 @@ fg_state_remove_file_locked() {
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
   [ -e "$FG_STATE_LOCKED_FILE" ] || return 0
   [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
-  current=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || return 1
+  current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+  current=$(printf '%s' "$current" | fg_state_validate 2>/dev/null) || return 1
 
   next=$(printf '%s' "$current" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
   next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
@@ -607,7 +717,8 @@ fg_state_emit_compact_summary_locked() {
 
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
   [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
-  state=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || return 1
+  state=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+  state=$(printf '%s' "$state" | fg_state_validate 2>/dev/null) || return 1
 
   details=$(printf '%s' "$state" | jq -r \
     --argjson max_files "$FG_STATE_MAX_SUMMARY_FILES" \

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -166,6 +166,28 @@ fg_state_workspace_key() {
   fg_state_sha256 "foxguard-claude-code-workspace-v1" "$1"
 }
 
+fg_state_prepare_locked_state() {
+  local repo_identity=$1 session_id=$2 repo_root state_root workspace_key session_key state_file
+
+  # Locked actions are executable; re-derive every filesystem path from identity.
+  unset FG_STATE_LOCKED_REPOSITORY FG_STATE_LOCKED_SESSION_ID \
+    FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE
+  repo_root=$(fg_state_repository_root "$repo_identity") || return 1
+  state_root=$(fg_state_root "$repo_root") || return 1
+  workspace_key=$(fg_state_workspace_key "$repo_root") || return 1
+  session_key=$(fg_state_session_key "$session_id") || return 1
+  state_file="$state_root/$workspace_key-$session_key.json"
+  [ ! -L "$state_file" ] || return 1
+  [ ! -e "$state_file" ] || [ -f "$state_file" ] || return 1
+
+  FG_STATE_LOCKED_REPOSITORY=$repo_root
+  FG_STATE_LOCKED_SESSION_ID=$session_id
+  FG_STATE_LOCKED_SESSION_KEY=$session_key
+  FG_STATE_LOCKED_ROOT=$state_root
+  FG_STATE_LOCKED_FILE=$state_file
+}
+
+
 fg_state_fingerprint() {
   # The fingerprint input is limited to the metadata that is retained in state.
   fg_state_sha256 "$@"
@@ -357,18 +379,15 @@ fg_state_add_fingerprints() {
 }
 
 fg_state_prune_locked() {
-  local state_root=$1 active_session_key=${2:-}
+  local repo_identity=$1 session_id=$2
 
-  if [ -n "$active_session_key" ]; then
-    [[ "$active_session_key" =~ ^[a-f0-9]{64}$ ]] || return 1
-    find "$state_root" -type f -name "*-${active_session_key}.json" -exec touch {} \; 2>/dev/null || :
-    find "$state_root" -type f -name '*.json' ! -name "*-${active_session_key}.json" -mtime +0 -exec rm -f {} \; 2>/dev/null || :
-  else
-    find "$state_root" -type f -name '*.json' -mtime +0 -exec rm -f {} \; 2>/dev/null || :
-  fi
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+  find "$FG_STATE_LOCKED_ROOT" -type f -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -exec touch {} \; 2>/dev/null || :
+  find "$FG_STATE_LOCKED_ROOT" -type f -name '*.json' ! -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -mtime +0 -exec rm -f {} \; 2>/dev/null || :
   # The kernel lock serializes state writes, so no live writer owns one of these.
-  find "$state_root" -type f -name '.state.*' -exec rm -f {} \; 2>/dev/null || :
+  find "$FG_STATE_LOCKED_ROOT" -type f -name '.state.*' -exec rm -f {} \; 2>/dev/null || :
 }
+
 
 fg_state_script_path() {
   local script_path=${BASH_SOURCE[0]} script_dir
@@ -398,8 +417,8 @@ fg_state_apply_lock_limits() {
 }
 
 fg_state_with_root_lock() {
-  local state_root=$1 callback=$2 action state_script lock_wrapper
-  shift 2
+  local repo_identity=$1 session_id=$2 callback=$3 action state_script lock_wrapper cache_home
+  shift 3
 
   case "$callback" in
     fg_state_update_file_locked) action=--locked-update ;;
@@ -407,19 +426,25 @@ fg_state_with_root_lock() {
     fg_state_emit_compact_summary_locked) action=--locked-summary ;;
     *) return 1 ;;
   esac
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
   command -v perl >/dev/null 2>&1 || return 1
   state_script=$(fg_state_script_path) || return 1
   lock_wrapper=$(fg_state_lock_wrapper_path) || return 1
   [ -x "$state_script" ] || return 1
+  cache_home=${FG_STATE_LOCKED_ROOT%/foxguard/claude-code}
+  [ -n "$cache_home" ] || cache_home=/
 
   # The wrapper holds an inherited flock through the self-invoked action.
-  perl "$lock_wrapper" "$state_root/.lock" "$state_script" "$action" \
-    "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$@"
+  XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT/.lock" "$state_script" "$action" \
+    "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$FG_STATE_LOCKED_REPOSITORY" \
+    "$FG_STATE_LOCKED_SESSION_ID" "$@"
 }
 
-fg_state_atomic_write() (
-  local state_root=$1 state_file=$2 content=$3 allow_overflow_reserve=${4:-0} temp_file= size limit
 
+fg_state_atomic_write() (
+  local repo_identity=$1 session_id=$2 content=$3 allow_overflow_reserve=${4:-0} temp_file= size limit
+
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
   fg_state_atomic_cleanup() {
     [ -n "$temp_file" ] && rm -f "$temp_file" 2>/dev/null || :
   }
@@ -432,7 +457,7 @@ fg_state_atomic_write() (
     *) return 1 ;;
   esac
 
-  temp_file=$(mktemp "$state_root/.state.XXXXXX" 2>/dev/null) || return 1
+  temp_file=$(mktemp "$FG_STATE_LOCKED_ROOT/.state.XXXXXX" 2>/dev/null) || return 1
   printf '%s\n' "$content" > "$temp_file" || return 1
   chmod 600 "$temp_file" || return 1
 
@@ -443,16 +468,17 @@ fg_state_atomic_write() (
   esac
   [ "$size" -le "$limit" ] || return 2
 
-  mv -f "$temp_file" "$state_file" || return 1
+  mv -f "$temp_file" "$FG_STATE_LOCKED_FILE" || return 1
   temp_file=
 )
 
+
 fg_state_write_omitted_fallback() {
-  local state_root=$1 state_file=$2 state=$3 relative_path=$4 next write_status
+  local repo_identity=$1 session_id=$2 state=$3 relative_path=$4 next write_status
 
   next=$(fg_state_add_omitted_path "$state" "$relative_path") || return 1
   printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
-  if fg_state_atomic_write "$state_root" "$state_file" "$next" 1; then
+  if fg_state_atomic_write "$repo_identity" "$session_id" "$next" 1; then
     return 0
   else
     write_status=$?
@@ -461,17 +487,18 @@ fg_state_write_omitted_fallback() {
 
   next=$(fg_state_mark_untracked_overflow "$state") || return 1
   printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
-  fg_state_atomic_write "$state_root" "$state_file" "$next" 1
+  fg_state_atomic_write "$repo_identity" "$session_id" "$next" 1
 }
 
+
 fg_state_update_file_locked() {
-  local state_root=$1 state_file=$2 session_key=$3 relative_path=$4 threshold=$5 record=$6
+  local repo_identity=$1 session_id=$2 relative_path=$3 threshold=$4 record=$5
   local current entry next fallback_state write_status can_store=0 existing=0
 
-  fg_state_prune_locked "$state_root" "$session_key"
-  if [ -e "$state_file" ]; then
-    if [ -f "$state_file" ] && [ ! -L "$state_file" ]; then
-      current=$(fg_state_validate < "$state_file" 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
+  fg_state_prune_locked "$repo_identity" "$session_id" || return 1
+  if [ -e "$FG_STATE_LOCKED_FILE" ]; then
+    if [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ]; then
+      current=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
     else
       return 1
     fi
@@ -489,7 +516,8 @@ fg_state_update_file_locked() {
   fi
 
   if [ "$can_store" != "1" ]; then
-    fg_state_write_omitted_fallback "$state_root" "$state_file" "$current" "$relative_path"
+    fg_state_write_omitted_fallback "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" \
+      "$current" "$relative_path"
     return $?
   fi
 
@@ -498,7 +526,7 @@ fg_state_update_file_locked() {
     --argjson entry "$entry" '.files[$path] = $entry' 2>/dev/null) || return 1
   next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
   printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 || return 1
-  if fg_state_atomic_write "$state_root" "$state_file" "$next" 0; then
+  if fg_state_atomic_write "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$next" 0; then
     return 0
   else
     write_status=$?
@@ -509,51 +537,47 @@ fg_state_update_file_locked() {
   if [ "$existing" = "1" ]; then
     fallback_state=$(printf '%s' "$fallback_state" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
   fi
-  fg_state_write_omitted_fallback "$state_root" "$state_file" "$fallback_state" "$relative_path"
+  fg_state_write_omitted_fallback "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" \
+    "$fallback_state" "$relative_path"
 }
+
 
 fg_state_update_file() {
   local session_id=$1 repo_root=$2 relative_path=$3 threshold=$4 record=$5
-  local state_root state_file session_key
 
   fg_state_valid_threshold "$threshold" || return 1
-  state_root=$(fg_state_root "$repo_root") || return 1
-  session_key=$(fg_state_session_key "$session_id") || return 1
-  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
-  fg_state_with_root_lock "$state_root" fg_state_update_file_locked \
-    "$state_root" "$state_file" "$session_key" "$relative_path" "$threshold" "$record"
+  fg_state_with_root_lock "$repo_root" "$session_id" fg_state_update_file_locked \
+    "$relative_path" "$threshold" "$record"
 }
 
+
 fg_state_remove_file_locked() {
-  local state_root=$1 state_file=$2 session_key=$3 relative_path=$4
+  local repo_identity=$1 session_id=$2 relative_path=$3
   local current next status=1
 
-  fg_state_prune_locked "$state_root" "$session_key"
-  [ -e "$state_file" ] || return 0
-  [ -f "$state_file" ] && [ ! -L "$state_file" ] || return 1
-  current=$(fg_state_validate < "$state_file" 2>/dev/null) || return 1
+  fg_state_prune_locked "$repo_identity" "$session_id" || return 1
+  [ -e "$FG_STATE_LOCKED_FILE" ] || return 0
+  [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
+  current=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || return 1
 
   next=$(printf '%s' "$current" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
   next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
   if fg_state_is_empty "$next"; then
-    rm -f "$state_file" && status=0
+    rm -f "$FG_STATE_LOCKED_FILE" && status=0
   elif printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 \
-    && fg_state_atomic_write "$state_root" "$state_file" "$next"; then
+    && fg_state_atomic_write "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$next"; then
     status=0
   fi
   return "$status"
 }
 
+
 fg_state_remove_file() {
   local session_id=$1 repo_root=$2 relative_path=$3
-  local state_root state_file session_key
 
-  state_root=$(fg_state_root "$repo_root") || return 1
-  session_key=$(fg_state_session_key "$session_id") || return 1
-  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
-  fg_state_with_root_lock "$state_root" fg_state_remove_file_locked \
-    "$state_root" "$state_file" "$session_key" "$relative_path"
+  fg_state_with_root_lock "$repo_root" "$session_id" fg_state_remove_file_locked "$relative_path"
 }
+
 
 fg_state_record_findings() {
   local session_id=$1 cwd=$2 file_path=$3 threshold=$4 findings=$5
@@ -578,12 +602,12 @@ fg_state_clear_findings() {
 }
 
 fg_state_emit_compact_summary_locked() {
-  local state_root=$1 state_file=$2 session_key=$3
+  local repo_identity=$1 session_id=$2
   local state details header footer truncated_footer body detail_limit
 
-  fg_state_prune_locked "$state_root" "$session_key"
-  [ -f "$state_file" ] && [ ! -L "$state_file" ] || return 1
-  state=$(fg_state_validate < "$state_file" 2>/dev/null) || return 1
+  fg_state_prune_locked "$repo_identity" "$session_id" || return 1
+  [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
+  state=$(fg_state_validate < "$FG_STATE_LOCKED_FILE" 2>/dev/null) || return 1
 
   details=$(printf '%s' "$state" | jq -r \
     --argjson max_files "$FG_STATE_MAX_SUMMARY_FILES" \
@@ -626,40 +650,50 @@ fg_state_emit_compact_summary_locked() {
   printf '%s\n' "$body"
 }
 
+
 fg_state_emit_compact_summary() {
   local session_id=$1 cwd=$2
-  local repo_root state_root state_file session_key
+  local repo_root
 
   repo_root=$(fg_state_repository_root "$cwd") || return 1
-  state_root=$(fg_state_root "$repo_root") || return 1
-  session_key=$(fg_state_session_key "$session_id") || return 1
-  state_file=$(fg_state_session_file "$state_root" "$repo_root" "$session_id") || return 1
-  fg_state_with_root_lock "$state_root" fg_state_emit_compact_summary_locked \
-    "$state_root" "$state_file" "$session_key"
+  fg_state_with_root_lock "$repo_root" "$session_id" fg_state_emit_compact_summary_locked
 }
+
 
 fg_state_run_locked_action() {
   local action=${1:-}
+  local repo_identity session_id
   shift || return 1
 
   case "$action" in
     --locked-update)
-      [ "$#" -eq 8 ] || return 1
+      [ "$#" -eq 7 ] || return 1
       fg_state_apply_lock_limits "$1" "$2" || return 1
       shift 2
-      fg_state_update_file_locked "$@"
+      repo_identity=$1
+      session_id=$2
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      shift 2
+      fg_state_update_file_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$@"
       ;;
     --locked-remove)
-      [ "$#" -eq 6 ] || return 1
-      fg_state_apply_lock_limits "$1" "$2" || return 1
-      shift 2
-      fg_state_remove_file_locked "$@"
-      ;;
-    --locked-summary)
       [ "$#" -eq 5 ] || return 1
       fg_state_apply_lock_limits "$1" "$2" || return 1
       shift 2
-      fg_state_emit_compact_summary_locked "$@"
+      repo_identity=$1
+      session_id=$2
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      shift 2
+      fg_state_remove_file_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$@"
+      ;;
+    --locked-summary)
+      [ "$#" -eq 4 ] || return 1
+      fg_state_apply_lock_limits "$1" "$2" || return 1
+      shift 2
+      repo_identity=$1
+      session_id=$2
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      fg_state_emit_compact_summary_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID"
       ;;
     *) return 1 ;;
   esac

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -106,9 +106,39 @@ fg_state_cache_path_outside_repository() {
   fi
 }
 
+fg_state_canonical_cache_home() {
+  local cache_home=$1 probe=$1 parent suffix= resolved
+
+  case "$cache_home" in
+    /|/*) ;;
+    *) return 1 ;;
+  esac
+  case "$cache_home" in
+    *'//'|*/./*|*/../*|*/.|*/..) return 1 ;;
+  esac
+  while [ ! -e "$probe" ] && [ ! -L "$probe" ]; do
+    parent=${probe%/*}
+    [ "$parent" != "$probe" ] || return 1
+    [ -n "$parent" ] || parent=/
+    suffix="${probe##*/}${suffix:+/$suffix}"
+    probe=$parent
+  done
+  [ -d "$probe" ] || return 1
+  resolved=$(cd -P "$probe" 2>/dev/null && pwd -P) || return 1
+  if [ -n "$suffix" ]; then
+    if [ "$resolved" = / ]; then
+      printf '/%s\n' "$suffix"
+    else
+      printf '%s/%s\n' "$resolved" "$suffix"
+    fi
+  else
+    printf '%s\n' "$resolved"
+  fi
+}
+
 
 fg_state_root() {
-  local repo_root=$1 cache_home state_root resolved_state resolved_repo
+  local repo_root=$1 cache_home state_root resolved_repo
 
   resolved_repo=$(cd -P "$repo_root" 2>/dev/null && pwd -P) || return 1
 
@@ -124,16 +154,18 @@ fg_state_root() {
     /*) ;;
     *) return 1 ;;
   esac
+  cache_home=${cache_home%/}
+  [ -n "$cache_home" ] || cache_home=/
+  cache_home=$(fg_state_canonical_cache_home "$cache_home") || return 1
+  case "$cache_home" in
+    /) state_root="/foxguard/claude-code" ;;
+    *) state_root="$cache_home/foxguard/claude-code" ;;
+  esac
 
-  state_root="$cache_home/foxguard/claude-code"
   fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
-  (umask 077; mkdir -p "$state_root" >/dev/null 2>&1) || return 1
-  [ -d "$state_root" ] && [ ! -L "$state_root" ] || return 1
+  fg_state_ensure_root "$state_root" || return 1
   fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
-
-  resolved_state=$(cd -P "$state_root" 2>/dev/null && pwd -P) || return 1
-  fg_state_cache_path_outside_repository "$resolved_state" "$resolved_repo" || return 1
-  printf '%s\n' "$resolved_state"
+  printf '%s\n' "$state_root"
 }
 
 fg_state_session_key() {
@@ -186,18 +218,22 @@ fg_state_file_operation_path() {
   printf '%s/state-file-operation.pl\n' "${state_script%/*}"
 }
 
+fg_state_ensure_root() {
+  local state_root=$1 helper
+
+  command -v perl >/dev/null 2>&1 || return 1
+  helper=$(fg_state_file_operation_path) || return 1
+  perl "$helper" --root "$state_root" ensure-root
+}
+
 fg_state_file_operation() {
   local action=$1 helper
   shift
 
   command -v perl >/dev/null 2>&1 || return 1
   helper=$(fg_state_file_operation_path) || return 1
-  if [[ "${FG_STATE_LOCK_DIR_FD:-}" =~ ^[0-9]+$ ]]; then
-    perl "$helper" --fd "$FG_STATE_LOCK_DIR_FD" "$action" "$@"
-  else
-    [ -n "${FG_STATE_LOCKED_ROOT:-}" ] || return 1
-    perl "$helper" --root "$FG_STATE_LOCKED_ROOT" "$action" "$@"
-  fi
+  [ -n "${FG_STATE_LOCKED_ROOT:-}" ] || return 1
+  perl "$helper" --root "$FG_STATE_LOCKED_ROOT" "$action" "$@"
 }
 
 
@@ -205,7 +241,8 @@ fg_state_prepare_locked_state() {
   local repo_identity=$1 session_id=$2 repo_root state_root workspace_key session_key state_file
   # Locked actions are executable; re-derive every filesystem path from identity.
   unset FG_STATE_LOCKED_REPOSITORY FG_STATE_LOCKED_SESSION_ID \
-    FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE
+    FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE \
+    FG_STATE_LOCK_DIR_FD
   repo_root=$(fg_state_repository_root "$repo_identity") || return 1
   state_root=$(fg_state_root "$repo_root") || return 1
   workspace_key=$(fg_state_workspace_key "$repo_root") || return 1
@@ -465,10 +502,13 @@ fg_state_with_root_lock() {
   cache_home=${FG_STATE_LOCKED_ROOT%/foxguard/claude-code}
   [ -n "$cache_home" ] || cache_home=/
 
-  # The wrapper holds an inherited flock through the self-invoked action.
-  XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT" .lock "$state_script" "$action" \
-    "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$FG_STATE_LOCKED_REPOSITORY" \
-    "$FG_STATE_LOCKED_SESSION_ID" "$@"
+  # The wrapper holds only the flock; every mutation reopens the derived root.
+  (
+    unset FG_STATE_LOCK_DIR_FD
+    XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT" .lock "$state_script" "$action" \
+      "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$FG_STATE_LOCKED_REPOSITORY" \
+      "$FG_STATE_LOCKED_SESSION_ID" "$@"
+  )
 }
 
 
@@ -681,6 +721,7 @@ fg_state_run_locked_action() {
   local action=${1:-}
   local repo_identity session_id
   shift || return 1
+  [ -z "${FG_STATE_LOCK_DIR_FD+x}" ] || return 1
 
   case "$action" in
     --locked-update)

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -138,7 +138,12 @@ fg_state_canonical_cache_home() {
 
 
 fg_state_root() {
-  local repo_root=$1 cache_home state_root resolved_repo
+  local repo_root=$1 create_root=${2:-1} cache_home state_root resolved_repo
+
+  case "$create_root" in
+    0|1) ;;
+    *) return 1 ;;
+  esac
 
   resolved_repo=$(cd -P "$repo_root" 2>/dev/null && pwd -P) || return 1
 
@@ -163,7 +168,7 @@ fg_state_root() {
   esac
 
   fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
-  fg_state_ensure_root "$state_root" || return 1
+  [ "$create_root" = "0" ] || fg_state_ensure_root "$state_root" || return 1
   fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
   printf '%s\n' "$state_root"
 }
@@ -233,18 +238,19 @@ fg_state_file_operation() {
   command -v perl >/dev/null 2>&1 || return 1
   helper=$(fg_state_file_operation_path) || return 1
   [ -n "${FG_STATE_LOCKED_ROOT:-}" ] || return 1
+  [ -n "${FG_STATE_LOCK_DIR_FD:-}" ] || return 1
   perl "$helper" --root "$FG_STATE_LOCKED_ROOT" "$action" "$@"
 }
 
 
 fg_state_prepare_locked_state() {
-  local repo_identity=$1 session_id=$2 repo_root state_root workspace_key session_key state_file
+  local repo_identity=$1 session_id=$2 create_root=${3:-1}
+  local repo_root state_root workspace_key session_key state_file
   # Locked actions are executable; re-derive every filesystem path from identity.
   unset FG_STATE_LOCKED_REPOSITORY FG_STATE_LOCKED_SESSION_ID \
-    FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE \
-    FG_STATE_LOCK_DIR_FD
+    FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE
   repo_root=$(fg_state_repository_root "$repo_identity") || return 1
-  state_root=$(fg_state_root "$repo_root") || return 1
+  state_root=$(fg_state_root "$repo_root" "$create_root") || return 1
   workspace_key=$(fg_state_workspace_key "$repo_root") || return 1
   session_key=$(fg_state_session_key "$session_id") || return 1
   state_file="$workspace_key-$session_key.json"
@@ -502,7 +508,7 @@ fg_state_with_root_lock() {
   cache_home=${FG_STATE_LOCKED_ROOT%/foxguard/claude-code}
   [ -n "$cache_home" ] || cache_home=/
 
-  # The wrapper holds only the flock; every mutation reopens the derived root.
+  # The wrapper binds each child action to its locked root descriptor.
   (
     unset FG_STATE_LOCK_DIR_FD
     XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT" .lock "$state_script" "$action" \
@@ -721,7 +727,7 @@ fg_state_run_locked_action() {
   local action=${1:-}
   local repo_identity session_id
   shift || return 1
-  [ -z "${FG_STATE_LOCK_DIR_FD+x}" ] || return 1
+  [[ "${FG_STATE_LOCK_DIR_FD:-}" =~ ^(0|[1-9][0-9]*)$ ]] || return 1
 
   case "$action" in
     --locked-update)
@@ -730,7 +736,7 @@ fg_state_run_locked_action() {
       shift 2
       repo_identity=$1
       session_id=$2
-      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
       shift 2
       fg_state_update_file_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$@"
       ;;
@@ -740,7 +746,7 @@ fg_state_run_locked_action() {
       shift 2
       repo_identity=$1
       session_id=$2
-      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
       shift 2
       fg_state_remove_file_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$@"
       ;;
@@ -750,7 +756,7 @@ fg_state_run_locked_action() {
       shift 2
       repo_identity=$1
       session_id=$2
-      fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
+      fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
       fg_state_emit_compact_summary_locked "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID"
       ;;
     *) return 1 ;;

--- a/plugins/claude-code/scripts/finding-state.sh
+++ b/plugins/claude-code/scripts/finding-state.sh
@@ -130,7 +130,6 @@ fg_state_root() {
   (umask 077; mkdir -p "$state_root" >/dev/null 2>&1) || return 1
   [ -d "$state_root" ] && [ ! -L "$state_root" ] || return 1
   fg_state_cache_path_outside_repository "$state_root" "$resolved_repo" || return 1
-  chmod 700 "$state_root" >/dev/null 2>&1 || return 1
 
   resolved_state=$(cd -P "$state_root" 2>/dev/null && pwd -P) || return 1
   fg_state_cache_path_outside_repository "$resolved_state" "$resolved_repo" || return 1
@@ -178,81 +177,32 @@ fg_state_workspace_key() {
   fg_state_sha256 "foxguard-claude-code-workspace-v1" "$1"
 }
 
+fg_state_file_operation_path() {
+  local state_script
+
+  state_script=$(fg_state_script_path) || return 1
+  [ -r "${state_script%/*}/state-file-operation.pl" ] \
+    && [ ! -L "${state_script%/*}/state-file-operation.pl" ] || return 1
+  printf '%s/state-file-operation.pl\n' "${state_script%/*}"
+}
+
 fg_state_file_operation() {
-  local action=$1
+  local action=$1 helper
   shift
 
   command -v perl >/dev/null 2>&1 || return 1
-  perl -MFcntl=:DEFAULT,S_IFMT,S_IFREG -e '
-    sub is_regular_unlinked {
-      my ($file) = @_;
-      my @stat = stat($file);
-
-      return @stat
-        && (($stat[2] & S_IFMT) == S_IFREG)
-        && $stat[3] == 1;
-    }
-
-    my $action = shift @ARGV;
-    exit 1 unless defined($action) && @ARGV;
-    exit 1 if ($action eq q(read) || $action eq q(touch-read)) && @ARGV != 1;
-
-    my $no_follow = eval { Fcntl::O_NOFOLLOW() };
-    exit 1 if $@ || !defined($no_follow);
-    my @files;
-    for my $path (@ARGV) {
-      sysopen(my $file, $path, O_RDONLY | O_NONBLOCK | $no_follow) or exit 1;
-      exit 1 unless is_regular_unlinked($file);
-      my @stat = stat($file);
-      push @files, [$path, $file, $stat[0], $stat[1]];
-    }
-
-    if ($action eq q(check)) {
-      exit 0;
-    }
-    if ($action eq q(touch) || $action eq q(touch-read)) {
-      for my $entry (@files) {
-        exit 1 unless is_regular_unlinked($entry->[1]);
-        utime undef, undef, $entry->[1] or exit 1;
-      }
-      exit 0 if $action eq q(touch);
-    }
-    if ($action eq q(read) || $action eq q(touch-read)) {
-      my $buffer;
-      while (1) {
-        my $count = sysread($files[0][1], $buffer, 8192);
-        exit 1 unless defined($count);
-        last if $count == 0;
-        print $buffer or exit 1;
-      }
-      exit 0;
-    }
-    if ($action eq q(remove)) {
-      for my $entry (@files) {
-        my @path_stat = lstat($entry->[0]);
-        exit 1 unless @path_stat
-          && $path_stat[0] == $entry->[2]
-          && $path_stat[1] == $entry->[3]
-          && (($path_stat[2] & S_IFMT) == S_IFREG)
-          && $path_stat[3] == 1;
-      }
-      for my $entry (@files) {
-        unlink $entry->[0] or exit 1;
-      }
-      exit 0;
-    }
-    exit 1;
-  ' "$action" "$@"
+  helper=$(fg_state_file_operation_path) || return 1
+  if [[ "${FG_STATE_LOCK_DIR_FD:-}" =~ ^[0-9]+$ ]]; then
+    perl "$helper" --fd "$FG_STATE_LOCK_DIR_FD" "$action" "$@"
+  else
+    [ -n "${FG_STATE_LOCKED_ROOT:-}" ] || return 1
+    perl "$helper" --root "$FG_STATE_LOCKED_ROOT" "$action" "$@"
+  fi
 }
 
 
 fg_state_prepare_locked_state() {
-  local repo_identity=$1 session_id=$2 check_file=${3:-1} repo_root state_root workspace_key session_key state_file
-
-  case "$check_file" in
-    0|1) ;;
-    *) return 1 ;;
-  esac
+  local repo_identity=$1 session_id=$2 repo_root state_root workspace_key session_key state_file
   # Locked actions are executable; re-derive every filesystem path from identity.
   unset FG_STATE_LOCKED_REPOSITORY FG_STATE_LOCKED_SESSION_ID \
     FG_STATE_LOCKED_SESSION_KEY FG_STATE_LOCKED_ROOT FG_STATE_LOCKED_FILE
@@ -260,12 +210,8 @@ fg_state_prepare_locked_state() {
   state_root=$(fg_state_root "$repo_root") || return 1
   workspace_key=$(fg_state_workspace_key "$repo_root") || return 1
   session_key=$(fg_state_session_key "$session_id") || return 1
-  state_file="$state_root/$workspace_key-$session_key.json"
-  [ ! -L "$state_file" ] || return 1
-  [ ! -e "$state_file" ] || [ -f "$state_file" ] || return 1
-  if [ "$check_file" = "1" ] && [ -e "$state_file" ]; then
-    fg_state_file_operation check "$state_file" || return 1
-  fi
+  state_file="$workspace_key-$session_key.json"
+  [[ "$state_file" =~ ^[a-f0-9]{64}-[a-f0-9]{64}\.json$ ]] || return 1
 
   FG_STATE_LOCKED_REPOSITORY=$repo_root
   FG_STATE_LOCKED_SESSION_ID=$session_id
@@ -466,37 +412,11 @@ fg_state_add_fingerprints() {
 }
 
 fg_state_prune_locked() {
-  local repo_identity=$1 session_id=$2 candidate
-  local -a candidates
+  local repo_identity=$1 session_id=$2
 
-  fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
-  candidates=()
-  while IFS= read -r -d '' candidate; do
-    candidates[${#candidates[@]}]=$candidate
-  done < <(
-    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
-      -type f ! -path "$FG_STATE_LOCKED_FILE" -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -print0 2>/dev/null
-  )
-  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation touch "${candidates[@]}" || return 1
-
-  candidates=()
-  while IFS= read -r -d '' candidate; do
-    candidates[${#candidates[@]}]=$candidate
-  done < <(
-    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
-      -type f -name '*.json' ! -name "*-${FG_STATE_LOCKED_SESSION_KEY}.json" -mtime +0 -print0 2>/dev/null
-  )
-  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation remove "${candidates[@]}" || return 1
-
-  # The kernel lock serializes state writes, so no live writer owns one of these.
-  candidates=()
-  while IFS= read -r -d '' candidate; do
-    candidates[${#candidates[@]}]=$candidate
-  done < <(
-    find "$FG_STATE_LOCKED_ROOT" -type d ! -path "$FG_STATE_LOCKED_ROOT" -prune -o \
-      -type f -name '.state.*' -print0 2>/dev/null
-  )
-  [ "${#candidates[@]}" -eq 0 ] || fg_state_file_operation remove "${candidates[@]}" || return 1
+  [ "$repo_identity" = "${FG_STATE_LOCKED_REPOSITORY:-}" ] || return 1
+  [ "$session_id" = "${FG_STATE_LOCKED_SESSION_ID:-}" ] || return 1
+  fg_state_file_operation prune "$FG_STATE_LOCKED_FILE" "$FG_STATE_LOCKED_SESSION_KEY"
 }
 
 
@@ -537,7 +457,7 @@ fg_state_with_root_lock() {
     fg_state_emit_compact_summary_locked) action=--locked-summary ;;
     *) return 1 ;;
   esac
-  fg_state_prepare_locked_state "$repo_identity" "$session_id" 0 || return 1
+  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
   command -v perl >/dev/null 2>&1 || return 1
   state_script=$(fg_state_script_path) || return 1
   lock_wrapper=$(fg_state_lock_wrapper_path) || return 1
@@ -546,42 +466,25 @@ fg_state_with_root_lock() {
   [ -n "$cache_home" ] || cache_home=/
 
   # The wrapper holds an inherited flock through the self-invoked action.
-  XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT/.lock" "$state_script" "$action" \
+  XDG_CACHE_HOME="$cache_home" perl "$lock_wrapper" "$FG_STATE_LOCKED_ROOT" .lock "$state_script" "$action" \
     "$FG_STATE_MAX_BYTES" "$FG_STATE_MAX_OMITTED" "$FG_STATE_LOCKED_REPOSITORY" \
     "$FG_STATE_LOCKED_SESSION_ID" "$@"
 }
 
 
-fg_state_atomic_write() (
-  local repo_identity=$1 session_id=$2 content=$3 allow_overflow_reserve=${4:-0} temp_file= size limit
+fg_state_atomic_write() {
+  local repo_identity=$1 session_id=$2 content=$3 allow_overflow_reserve=${4:-0} limit
 
-  fg_state_prepare_locked_state "$repo_identity" "$session_id" || return 1
-  fg_state_atomic_cleanup() {
-    [ -n "$temp_file" ] && rm -f "$temp_file" 2>/dev/null || :
-  }
-  trap fg_state_atomic_cleanup EXIT
-  trap 'exit 1' HUP INT TERM
-
+  [ "$repo_identity" = "${FG_STATE_LOCKED_REPOSITORY:-}" ] || return 1
+  [ "$session_id" = "${FG_STATE_LOCKED_SESSION_ID:-}" ] || return 1
   case "$allow_overflow_reserve" in
     0) limit=$((FG_STATE_MAX_BYTES - FG_STATE_OVERFLOW_RESERVE)) ;;
     1) limit=$FG_STATE_MAX_BYTES ;;
     *) return 1 ;;
   esac
 
-  umask 077
-  temp_file=$(mktemp "$FG_STATE_LOCKED_ROOT/.state.XXXXXX" 2>/dev/null) || return 1
-  printf '%s\n' "$content" > "$temp_file" || return 1
-
-  size=$(wc -c < "$temp_file") || return 1
-  size=${size//[[:space:]]/}
-  case "$size" in
-    ''|*[!0-9]*) return 1 ;;
-  esac
-  [ "$size" -le "$limit" ] || return 2
-
-  mv -f "$temp_file" "$FG_STATE_LOCKED_FILE" || return 1
-  temp_file=
-)
+  printf '%s\n' "$content" | fg_state_file_operation write "$FG_STATE_LOCKED_FILE" "$limit"
+}
 
 
 fg_state_write_omitted_fallback() {
@@ -604,14 +507,14 @@ fg_state_write_omitted_fallback() {
 
 fg_state_update_file_locked() {
   local repo_identity=$1 session_id=$2 relative_path=$3 threshold=$4 record=$5
-  local current entry next fallback_state write_status can_store=0 existing=0
+  local current entry next fallback_state write_status read_status can_store=0 existing=0
 
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
-  if [ -e "$FG_STATE_LOCKED_FILE" ]; then
-    [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
-    current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+  if current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE" "$FG_STATE_MAX_BYTES"); then
     current=$(printf '%s' "$current" | fg_state_validate 2>/dev/null) || current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
   else
+    read_status=$?
+    [ "$read_status" = "3" ] || return 1
     current='{"version":3,"overflow":0,"omitted":[],"files":{}}'
   fi
 
@@ -662,18 +565,22 @@ fg_state_update_file() {
 
 fg_state_remove_file_locked() {
   local repo_identity=$1 session_id=$2 relative_path=$3
-  local current next status=1
+  local current next read_status status=1
 
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
-  [ -e "$FG_STATE_LOCKED_FILE" ] || return 0
-  [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
-  current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+  if current=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE" "$FG_STATE_MAX_BYTES"); then
+    :
+  else
+    read_status=$?
+    [ "$read_status" = "3" ] && return 0
+    return 1
+  fi
   current=$(printf '%s' "$current" | fg_state_validate 2>/dev/null) || return 1
 
   next=$(printf '%s' "$current" | jq -ce --arg path "$relative_path" 'del(.files[$path])' 2>/dev/null) || return 1
   next=$(fg_state_remove_omitted_path "$next" "$relative_path") || return 1
   if fg_state_is_empty "$next"; then
-    rm -f "$FG_STATE_LOCKED_FILE" && status=0
+    fg_state_file_operation remove "$FG_STATE_LOCKED_FILE" && status=0
   elif printf '%s' "$next" | fg_state_validate >/dev/null 2>&1 \
     && fg_state_atomic_write "$FG_STATE_LOCKED_REPOSITORY" "$FG_STATE_LOCKED_SESSION_ID" "$next"; then
     status=0
@@ -716,8 +623,7 @@ fg_state_emit_compact_summary_locked() {
   local state details header footer truncated_footer body detail_limit
 
   fg_state_prune_locked "$repo_identity" "$session_id" || return 1
-  [ -f "$FG_STATE_LOCKED_FILE" ] && [ ! -L "$FG_STATE_LOCKED_FILE" ] || return 1
-  state=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE") || return 1
+  state=$(fg_state_file_operation touch-read "$FG_STATE_LOCKED_FILE" "$FG_STATE_MAX_BYTES") || return 1
   state=$(printf '%s' "$state" | fg_state_validate 2>/dev/null) || return 1
 
   details=$(printf '%s' "$state" | jq -r \

--- a/plugins/claude-code/scripts/restore-unresolved-findings.sh
+++ b/plugins/claude-code/scripts/restore-unresolved-findings.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SessionStart hook: restore metadata-only finding reminders after compaction.
+
+set -uo pipefail
+
+input=$(cat)
+source=$(printf '%s' "$input" | jq -r '.source // empty' 2>/dev/null)
+[ "$source" = "compact" ] || exit 0
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "$session_id" ] && [ -n "$cwd" ] || exit 0
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
+if [ -n "$script_dir" ] && [ -r "$script_dir/finding-state.sh" ] \
+  && . "$script_dir/finding-state.sh" >/dev/null 2>&1; then
+  fg_state_emit_compact_summary "$session_id" "$cwd" 2>/dev/null || :
+fi
+
+exit 0

--- a/plugins/claude-code/scripts/scan-edited-file.sh
+++ b/plugins/claude-code/scripts/scan-edited-file.sh
@@ -10,6 +10,20 @@
 
 set -uo pipefail
 
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
+state_enabled=0
+if [ -n "$script_dir" ] && [ -r "$script_dir/finding-state.sh" ] \
+  && . "$script_dir/finding-state.sh" 2>/dev/null; then
+  state_enabled=1
+fi
+
+scan_status=0
+session_id=
+cwd=
+repo_root=
+normalized_file_path=
+state_active=0
+
 input=$(cat)
 
 file_path=$(printf '%s' "$input" | jq -r '
@@ -21,8 +35,18 @@ file_path=$(printf '%s' "$input" | jq -r '
   // empty
 ' 2>/dev/null)
 
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+
 [ -z "$file_path" ] && exit 0
+if [ "$state_enabled" = "1" ] \
+  && repo_root=$(fg_state_repository_root "$cwd") \
+  && normalized_file_path=$(fg_state_normalize_file_path "$cwd" "$file_path" "$repo_root"); then
+  file_path=$normalized_file_path
+  state_active=1
+fi
 [ ! -f "$file_path" ] && exit 0
+[ ! -r "$file_path" ] && exit 0
 
 # Resolve foxguard binary: prefer PATH, fall back to npx.
 if command -v foxguard >/dev/null 2>&1; then
@@ -35,26 +59,40 @@ fi
 
 min_severity="${FOXGUARD_HOOK_SEVERITY:-medium}"
 
-scan_output=$("${fg[@]}" --format json --severity "$min_severity" -- "$file_path" 2>/dev/null) || true
+if scan_output=$("${fg[@]}" --format json --severity "$min_severity" -- "$file_path" 2>/dev/null); then
+  scan_status=0
+else
+  scan_status=$?
+fi
 
 [ -z "$scan_output" ] && exit 0
 
-findings=$(printf '%s' "$scan_output" | jq -c '
+findings=$(printf '%s' "$scan_output" | jq -ce '
   if type == "array" then
     .
   elif type == "object" and (.findings | type == "array") then
     .findings
   else
-    []
+    error("invalid foxguard JSON")
   end
-' 2>/dev/null)
+' 2>/dev/null) || exit 0
 
-[ -z "$findings" ] && exit 0
-[ "$findings" = "[]" ] && exit 0
+if [ "$findings" = "[]" ]; then
+  if [ "$state_active" = "1" ] && [ "$scan_status" = "0" ]; then
+    fg_state_clear_findings "$session_id" "$cwd" "$file_path" || :
+  fi
+  exit 0
+fi
 
 count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null)
 if [ -z "$count" ] || [ "$count" = "0" ]; then
   exit 0
+fi
+
+if [ "$state_active" = "1" ]; then
+  case "$scan_status" in
+    0|1) fg_state_record_findings "$session_id" "$cwd" "$file_path" "$min_severity" "$findings" || : ;;
+  esac
 fi
 
 {

--- a/plugins/claude-code/scripts/state-file-operation.pl
+++ b/plugins/claude-code/scripts/state-file-operation.pl
@@ -1,0 +1,286 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Errno qw(ENOENT);
+use Fcntl qw(:DEFAULT S_IFMT S_IFREG S_IFDIR);
+use File::Temp qw(tempfile);
+
+my $no_follow = eval { Fcntl::O_NOFOLLOW() };
+exit 1 if $@ || !defined($no_follow);
+my $directory_only = eval { Fcntl::O_DIRECTORY() };
+exit 1 if $@ || !defined($directory_only);
+my ($temp_name, $temp_dev, $temp_ino);
+
+sub valid_basename {
+    my ($name) = @_;
+
+    return defined($name)
+        && length($name) > 0
+        && length($name) <= 255
+        && $name !~ m{/}
+        && $name !~ /\A\.{1,2}\z/
+        && $name =~ /\A[A-Za-z0-9._-]+\z/;
+}
+
+sub valid_test_basename {
+    my ($name) = @_;
+
+    return valid_basename($name) && $name =~ /\Atest-[A-Za-z0-9_-]+\z/;
+}
+
+sub valid_limit {
+    my ($limit) = @_;
+
+    return defined($limit)
+        && $limit =~ /\A[0-9]{1,6}\z/
+        && $limit <= 131072;
+}
+
+sub is_directory {
+    my ($file) = @_;
+    my @stat = stat($file);
+
+    return @stat && (($stat[2] & S_IFMT) == S_IFDIR);
+}
+
+sub is_regular_unlinked {
+    my (@stat) = @_;
+
+    return @stat
+        && (($stat[2] & S_IFMT) == S_IFREG)
+        && $stat[3] == 1;
+}
+
+sub open_root {
+    my ($kind, $value) = @_;
+    my $directory;
+
+    if ($kind eq q(--root)) {
+        exit 1 unless defined($value) && $value =~ m{\A/} && index($value, "\0") == -1;
+        sysopen($directory, $value, O_RDONLY | O_NONBLOCK | $directory_only | $no_follow)
+            or exit 1;
+    } elsif ($kind eq q(--fd)) {
+        exit 1 unless defined($value) && $value =~ /\A[0-9]+\z/;
+        open($directory, "<&=$value") or exit 1;
+    } else {
+        exit 1;
+    }
+
+    exit 1 unless is_directory($directory);
+    chdir($directory) or exit 1;
+    chmod 0700, q(.) or exit 1;
+    return $directory;
+}
+
+sub open_safe_entry {
+    my ($name) = @_;
+    my $file;
+
+    return (undef, 1) unless valid_basename($name);
+    if (!sysopen($file, $name, O_RDONLY | O_NONBLOCK | $no_follow)) {
+        my $error = $!;
+        return (undef, $error == ENOENT ? 3 : 1);
+    }
+    my @stat = stat($file);
+    return (undef, 1) unless is_regular_unlinked(@stat);
+    return ($file, 0);
+}
+
+sub target_is_safe_or_missing {
+    my ($name) = @_;
+    my @stat = lstat($name);
+
+    return 1 if !@stat && $! == ENOENT;
+    return is_regular_unlinked(@stat);
+}
+
+sub touch_file {
+    my ($file) = @_;
+    my @stat = stat($file);
+
+    return is_regular_unlinked(@stat) && utime undef, undef, $file;
+}
+
+sub remove_entry {
+    my ($name) = @_;
+    my ($file, $status) = open_safe_entry($name);
+
+    return 0 unless $file;
+    my @stat = stat($file);
+    my @path_stat = lstat($name);
+    return 0 unless is_regular_unlinked(@stat)
+        && is_regular_unlinked(@path_stat)
+        && $path_stat[0] == $stat[0]
+        && $path_stat[1] == $stat[1];
+    return unlink($name);
+}
+
+sub read_file {
+    my ($file, $limit) = @_;
+    my $size = 0;
+    my $buffer;
+
+    binmode STDOUT;
+    while (1) {
+        my $count = sysread($file, $buffer, 8192);
+        return 0 unless defined($count);
+        last if $count == 0;
+        $size += $count;
+        return 0 if $size > $limit;
+        print STDOUT $buffer or return 0;
+    }
+    return 1;
+}
+
+sub cleanup_temp {
+    return unless defined($temp_name);
+    my ($name, $dev, $ino) = ($temp_name, $temp_dev, $temp_ino);
+    $temp_name = undef;
+    $temp_dev = undef;
+    $temp_ino = undef;
+
+    my @stat = lstat($name);
+    unlink($name) if is_regular_unlinked(@stat)
+        && $stat[0] == $dev
+        && $stat[1] == $ino;
+}
+
+END {
+    cleanup_temp();
+}
+
+sub wait_for_test_release {
+    my $ready = $ENV{FG_STATE_TEST_TEMP_READY};
+    my $release = $ENV{FG_STATE_TEST_TEMP_RELEASE};
+
+    # Test-only rendezvous files are confined to the opened state directory.
+    return 1 unless defined($ready) && defined($release)
+        && valid_test_basename($ready) && valid_test_basename($release);
+    my ($ready_file, $ready_status) = open_safe_entry($ready);
+    my ($release_file, $release_status) = open_safe_entry($release);
+    return 1 unless $ready_file && $release_file;
+
+    sysopen(my $signal, $ready, O_WRONLY | O_NONBLOCK | $no_follow) or return 0;
+    my @signal_stat = stat($signal);
+    return 0 unless is_regular_unlinked(@signal_stat);
+    print {$signal} "$$\n" or return 0;
+    close($signal) or return 0;
+    for (1 .. 500) {
+        my ($file, $status) = open_safe_entry($release);
+        return 0 unless $file;
+        my $buffer = q();
+        my $count = sysread($file, $buffer, 16);
+        return 0 unless defined($count);
+        return 1 if $buffer eq "release\n";
+        select undef, undef, undef, 0.01;
+    }
+    return 0;
+}
+
+sub write_entry {
+    my ($name, $limit) = @_;
+
+    return 1 unless valid_basename($name) && valid_limit($limit) && target_is_safe_or_missing($name);
+    my $old_umask = umask 0077;
+    my ($temp, $path) = tempfile(q(.state.XXXXXX), DIR => q(.), UNLINK => 0);
+    umask $old_umask;
+    return 1 unless $temp;
+    $path =~ s{\A.*/}{};
+    return 1 unless valid_basename($path);
+
+    my @stat = stat($temp);
+    return 1 unless is_regular_unlinked(@stat);
+    ($temp_name, $temp_dev, $temp_ino) = ($path, $stat[0], $stat[1]);
+    binmode $temp;
+    $SIG{HUP} = sub { exit 1; };
+    $SIG{INT} = sub { exit 1; };
+    $SIG{TERM} = sub { exit 1; };
+
+    my $size = 0;
+    while (1) {
+        my $count = read(STDIN, my $buffer, 8192);
+        unless (defined($count)) {
+            cleanup_temp();
+            return 1;
+        }
+        last if $count == 0;
+        $size += $count;
+        if ($size > $limit) {
+            cleanup_temp();
+            return 2;
+        }
+        unless (print {$temp} $buffer) {
+            cleanup_temp();
+            return 1;
+        }
+    }
+    unless (close($temp) && wait_for_test_release()
+        && target_is_safe_or_missing($name)) {
+        cleanup_temp();
+        return 1;
+    }
+    my @temp_stat = lstat($temp_name);
+    unless (is_regular_unlinked(@temp_stat)
+        && $temp_stat[0] == $temp_dev
+        && $temp_stat[1] == $temp_ino
+        && rename($temp_name, $name)) {
+        cleanup_temp();
+        return 1;
+    }
+    $temp_name = undef;
+    $temp_dev = undef;
+    $temp_ino = undef;
+    return 0;
+}
+
+my ($anchor, $anchor_value, $action, @args) = @ARGV;
+exit 1 unless defined($anchor) && defined($anchor_value) && defined($action);
+my $directory = open_root($anchor, $anchor_value);
+
+if ($action eq q(touch-read)) {
+    exit 1 unless @args == 2 && valid_basename($args[0]) && valid_limit($args[1]);
+    my ($file, $status) = open_safe_entry($args[0]);
+    exit $status unless $file;
+    exit 1 unless touch_file($file);
+    exit(read_file($file, $args[1]) ? 0 : 1);
+}
+
+if ($action eq q(remove)) {
+    exit 1 unless @args == 1 && valid_basename($args[0]);
+    exit(remove_entry($args[0]) ? 0 : 1);
+}
+
+if ($action eq q(write)) {
+    exit 1 unless @args == 2;
+    exit write_entry(@args);
+}
+
+if ($action eq q(prune)) {
+    exit 1 unless @args == 2 && valid_basename($args[0]) && $args[1] =~ /\A[a-f0-9]{64}\z/;
+    my ($active, $session) = @args;
+    opendir(my $entries, q(.)) or exit 1;
+    my @names = sort grep { $_ ne q(.) && $_ ne q(..) } readdir($entries);
+    closedir($entries) or exit 1;
+
+    for my $name (@names) {
+        next unless $name ne $active && $name =~ /-\Q$session\E\.json\z/;
+        my ($file, $status) = open_safe_entry($name);
+        exit 1 unless $file && touch_file($file);
+    }
+    for my $name (@names) {
+        next unless $name !~ /-\Q$session\E\.json\z/ && $name =~ /\.json\z/;
+        exit 1 unless valid_basename($name);
+        my @stat = lstat($name);
+        exit 1 unless is_regular_unlinked(@stat);
+        next unless $stat[9] < time - 86400;
+        exit 1 unless remove_entry($name);
+    }
+    for my $name (@names) {
+        next unless $name =~ /\A\.state\./;
+        exit 1 unless valid_basename($name);
+        exit 1 unless target_is_safe_or_missing($name) && remove_entry($name);
+    }
+    exit 0;
+}
+
+exit 1;

--- a/plugins/claude-code/scripts/state-file-operation.pl
+++ b/plugins/claude-code/scripts/state-file-operation.pl
@@ -93,14 +93,42 @@ sub open_absolute_directory {
     return $current;
 }
 
+sub duplicate_locked_directory {
+    my $fd = $ENV{FG_STATE_LOCK_DIR_FD};
+    my $directory;
+
+    return unless defined($fd) && $fd =~ /\A(?:0|[1-9][0-9]*)\z/;
+    open($directory, q(<&), $fd) or return;
+    return $directory;
+}
+
+sub matches_locked_directory {
+    my ($directory, $locked_directory) = @_;
+    my @directory_stat = stat($directory);
+    my @locked_stat = stat($locked_directory);
+
+    return @directory_stat && @locked_stat
+        && (($directory_stat[2] & S_IFMT) == S_IFDIR)
+        && (($locked_stat[2] & S_IFMT) == S_IFDIR)
+        && $directory_stat[0] == $locked_stat[0]
+        && $directory_stat[1] == $locked_stat[1];
+}
+
+
 sub open_root {
     my ($kind, $value, $create) = @_;
 
     exit 1 unless $kind eq q(--root);
     my $directory = open_absolute_directory($value, $create);
     exit 1 unless $directory;
-    chmod 0700, q(.) or exit 1;
-    return $directory;
+    if ($create) {
+        chmod 0700, q(.) or exit 1;
+        return $directory;
+    }
+    my $locked_directory = duplicate_locked_directory();
+    exit 1 unless $locked_directory && matches_locked_directory($directory, $locked_directory);
+    chdir($locked_directory) or exit 1;
+    return $locked_directory;
 }
 
 sub open_safe_entry {

--- a/plugins/claude-code/scripts/state-file-operation.pl
+++ b/plugins/claude-code/scripts/state-file-operation.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use Errno qw(ENOENT);
+use Errno qw(ENOENT EEXIST);
 use Fcntl qw(:DEFAULT S_IFMT S_IFREG S_IFDIR);
 use File::Temp qw(tempfile);
 
@@ -22,11 +22,6 @@ sub valid_basename {
         && $name =~ /\A[A-Za-z0-9._-]+\z/;
 }
 
-sub valid_test_basename {
-    my ($name) = @_;
-
-    return valid_basename($name) && $name =~ /\Atest-[A-Za-z0-9_-]+\z/;
-}
 
 sub valid_limit {
     my ($limit) = @_;
@@ -51,23 +46,59 @@ sub is_regular_unlinked {
         && $stat[3] == 1;
 }
 
-sub open_root {
-    my ($kind, $value) = @_;
-    my $directory;
+sub absolute_components {
+    my ($path) = @_;
 
-    if ($kind eq q(--root)) {
-        exit 1 unless defined($value) && $value =~ m{\A/} && index($value, "\0") == -1;
-        sysopen($directory, $value, O_RDONLY | O_NONBLOCK | $directory_only | $no_follow)
-            or exit 1;
-    } elsif ($kind eq q(--fd)) {
-        exit 1 unless defined($value) && $value =~ /\A[0-9]+\z/;
-        open($directory, "<&=$value") or exit 1;
-    } else {
-        exit 1;
+    return unless defined($path)
+        && $path =~ m{\A/}
+        && index($path, "\0") == -1;
+    return [] if $path eq q(/);
+    return if $path =~ m{/\z} || $path =~ m{//};
+    my @components = split m{/}, substr($path, 1), -1;
+    return unless @components;
+    for my $component (@components) {
+        return if !length($component)
+            || $component eq q(.)
+            || $component eq q(..);
     }
+    return \@components;
+}
 
-    exit 1 unless is_directory($directory);
-    chdir($directory) or exit 1;
+sub open_absolute_directory {
+    my ($path, $create) = @_;
+    my $components = absolute_components($path);
+    return unless $components;
+    my $flags = O_RDONLY | O_NONBLOCK | $directory_only | $no_follow;
+    my $current;
+
+    sysopen($current, q(/), $flags) or return;
+    return unless is_directory($current);
+    for my $component (@{$components}) {
+        chdir($current) or return; # chdir FILEHANDLE uses fchdir.
+        my $next;
+        if (!sysopen($next, $component, $flags)) {
+            my $open_error = $!;
+            return unless $create && $open_error == ENOENT;
+            my $old_umask = umask 0077;
+            my $made = mkdir($component, 0700);
+            my $mkdir_error = $!;
+            umask $old_umask;
+            return unless $made || $mkdir_error == EEXIST;
+            sysopen($next, $component, $flags) or return;
+        }
+        return unless is_directory($next);
+        $current = $next;
+    }
+    chdir($current) or return;
+    return $current;
+}
+
+sub open_root {
+    my ($kind, $value, $create) = @_;
+
+    exit 1 unless $kind eq q(--root);
+    my $directory = open_absolute_directory($value, $create);
+    exit 1 unless $directory;
     chmod 0700, q(.) or exit 1;
     return $directory;
 }
@@ -149,33 +180,6 @@ END {
     cleanup_temp();
 }
 
-sub wait_for_test_release {
-    my $ready = $ENV{FG_STATE_TEST_TEMP_READY};
-    my $release = $ENV{FG_STATE_TEST_TEMP_RELEASE};
-
-    # Test-only rendezvous files are confined to the opened state directory.
-    return 1 unless defined($ready) && defined($release)
-        && valid_test_basename($ready) && valid_test_basename($release);
-    my ($ready_file, $ready_status) = open_safe_entry($ready);
-    my ($release_file, $release_status) = open_safe_entry($release);
-    return 1 unless $ready_file && $release_file;
-
-    sysopen(my $signal, $ready, O_WRONLY | O_NONBLOCK | $no_follow) or return 0;
-    my @signal_stat = stat($signal);
-    return 0 unless is_regular_unlinked(@signal_stat);
-    print {$signal} "$$\n" or return 0;
-    close($signal) or return 0;
-    for (1 .. 500) {
-        my ($file, $status) = open_safe_entry($release);
-        return 0 unless $file;
-        my $buffer = q();
-        my $count = sysread($file, $buffer, 16);
-        return 0 unless defined($count);
-        return 1 if $buffer eq "release\n";
-        select undef, undef, undef, 0.01;
-    }
-    return 0;
-}
 
 sub write_entry {
     my ($name, $limit) = @_;
@@ -214,8 +218,7 @@ sub write_entry {
             return 1;
         }
     }
-    unless (close($temp) && wait_for_test_release()
-        && target_is_safe_or_missing($name)) {
+    unless (close($temp) && target_is_safe_or_missing($name)) {
         cleanup_temp();
         return 1;
     }
@@ -235,8 +238,15 @@ sub write_entry {
 
 my ($anchor, $anchor_value, $action, @args) = @ARGV;
 exit 1 unless defined($anchor) && defined($anchor_value) && defined($action);
-my $directory = open_root($anchor, $anchor_value);
+exit 1 unless $action eq q(ensure-root)
+    || $action eq q(touch-read) || $action eq q(remove)
+    || $action eq q(write) || $action eq q(prune);
+exit 1 if $action eq q(ensure-root) && @args;
+my $directory = open_root($anchor, $anchor_value, $action eq q(ensure-root));
 
+if ($action eq q(ensure-root)) {
+    exit 0;
+}
 if ($action eq q(touch-read)) {
     exit 1 unless @args == 2 && valid_basename($args[0]) && valid_limit($args[1]);
     my ($file, $status) = open_safe_entry($args[0]);

--- a/plugins/claude-code/scripts/with-state-lock.pl
+++ b/plugins/claude-code/scripts/with-state-lock.pl
@@ -104,8 +104,11 @@ for (1 .. 40) {
 exit 1 unless $locked;
 exit 1 unless is_safe_lock($lock);
 
-close($directory) or exit 1;
+my $directory_fd = fileno($directory);
+exit 1 unless defined($directory_fd);
 chdir(q(/)) or exit 1;
+defined fcntl($directory, F_SETFD, 0) or exit 1;
 defined fcntl($lock, F_SETFD, 0) or exit 1;
+$ENV{FG_STATE_LOCK_DIR_FD} = $directory_fd;
 exec @command;
 exit 127;

--- a/plugins/claude-code/scripts/with-state-lock.pl
+++ b/plugins/claude-code/scripts/with-state-lock.pl
@@ -4,6 +4,11 @@ use warnings;
 use Errno qw(EAGAIN EWOULDBLOCK EEXIST);
 use Fcntl qw(:DEFAULT :flock F_SETFD S_IFMT S_IFREG S_IFDIR);
 
+my $no_follow = eval { Fcntl::O_NOFOLLOW() };
+exit 1 if $@ || !defined($no_follow);
+my $directory_only = eval { Fcntl::O_DIRECTORY() };
+exit 1 if $@ || !defined($directory_only);
+
 sub valid_basename {
     my ($name) = @_;
 
@@ -22,6 +27,44 @@ sub is_safe_directory {
     return @stat && (($stat[2] & S_IFMT) == S_IFDIR);
 }
 
+sub absolute_components {
+    my ($path) = @_;
+
+    return unless defined($path)
+        && $path =~ m{\A/}
+        && index($path, "\0") == -1;
+    return [] if $path eq q(/);
+    return if $path =~ m{/\z} || $path =~ m{//};
+    my @components = split m{/}, substr($path, 1), -1;
+    return unless @components;
+    for my $component (@components) {
+        return if !length($component)
+            || $component eq q(.)
+            || $component eq q(..);
+    }
+    return \@components;
+}
+
+sub open_absolute_directory {
+    my ($path) = @_;
+    my $components = absolute_components($path);
+    return unless $components;
+    my $flags = O_RDONLY | O_NONBLOCK | $directory_only | $no_follow;
+    my $current;
+
+    sysopen($current, q(/), $flags) or return;
+    return unless is_safe_directory($current);
+    for my $component (@{$components}) {
+        chdir($current) or return; # chdir FILEHANDLE uses fchdir.
+        my $next;
+        sysopen($next, $component, $flags) or return;
+        return unless is_safe_directory($next);
+        $current = $next;
+    }
+    chdir($current) or return;
+    return $current;
+}
+
 sub is_safe_lock {
     my ($lock) = @_;
     my @stat = stat($lock);
@@ -34,18 +77,10 @@ sub is_safe_lock {
 
 my ($root, $lock_name, @command) = @ARGV;
 exit 1 unless defined($root)
-    && $root =~ m{\A/}
-    && index($root, "\0") == -1
     && valid_basename($lock_name)
     && @command;
-my $no_follow = eval { Fcntl::O_NOFOLLOW() };
-exit 1 if $@ || !defined($no_follow);
-my $directory_only = eval { Fcntl::O_DIRECTORY() };
-exit 1 if $@ || !defined($directory_only);
-sysopen(my $directory, $root, O_RDONLY | O_NONBLOCK | $directory_only | $no_follow)
-    or exit 1;
-exit 1 unless is_safe_directory($directory);
-chdir($directory) or exit 1;
+my $directory = open_absolute_directory($root);
+exit 1 unless $directory;
 chmod 0700, q(.) or exit 1;
 
 my $old_umask = umask 0077;
@@ -69,9 +104,8 @@ for (1 .. 40) {
 exit 1 unless $locked;
 exit 1 unless is_safe_lock($lock);
 
-# Preserve the rooted directory and kernel-held lock through exec.
-defined fcntl($directory, F_SETFD, 0) or exit 1;
+close($directory) or exit 1;
+chdir(q(/)) or exit 1;
 defined fcntl($lock, F_SETFD, 0) or exit 1;
-$ENV{FG_STATE_LOCK_DIR_FD} = fileno($directory);
 exec @command;
 exit 127;

--- a/plugins/claude-code/scripts/with-state-lock.pl
+++ b/plugins/claude-code/scripts/with-state-lock.pl
@@ -1,18 +1,33 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use Errno qw(EAGAIN EWOULDBLOCK);
-use Fcntl qw(:DEFAULT :flock F_SETFD);
+use Errno qw(EAGAIN EWOULDBLOCK EEXIST);
+use Fcntl qw(:DEFAULT :flock F_SETFD S_IFMT S_IFREG);
+
+sub is_safe_lock {
+    my ($lock) = @_;
+    my @stat = stat($lock);
+
+    return @stat
+        && (($stat[2] & S_IFMT) == S_IFREG)
+        && $stat[3] == 1
+        && (($stat[2] & 0777) == 0600);
+}
 
 my ($lock_path, @command) = @ARGV;
 exit 1 unless defined($lock_path) && @command;
 my $no_follow = eval { Fcntl::O_NOFOLLOW() };
 exit 1 if $@ || !defined($no_follow);
 
-sysopen(my $lock, $lock_path, O_CREAT | O_RDWR | $no_follow, 0600) or exit 1;
-exit 1 unless -f $lock;
-chmod 0600, $lock or exit 1;
-
+my $old_umask = umask 0077;
+my $created = sysopen(my $lock, $lock_path, O_CREAT | O_EXCL | O_RDWR | $no_follow, 0600);
+my $create_errno = $! unless $created;
+umask $old_umask;
+if (!$created) {
+    exit 1 unless $create_errno == EEXIST;
+    sysopen($lock, $lock_path, O_RDWR | $no_follow) or exit 1;
+}
+exit 1 unless is_safe_lock($lock);
 my $locked = 0;
 for (1 .. 40) {
     if (flock($lock, LOCK_EX | LOCK_NB)) {
@@ -23,6 +38,8 @@ for (1 .. 40) {
     select undef, undef, undef, 0.05;
 }
 exit 1 unless $locked;
+
+exit 1 unless is_safe_lock($lock);
 
 # Preserve the kernel-held lock through exec; it releases when the action exits.
 defined fcntl($lock, F_SETFD, 0) or exit 1;

--- a/plugins/claude-code/scripts/with-state-lock.pl
+++ b/plugins/claude-code/scripts/with-state-lock.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Errno qw(EAGAIN EWOULDBLOCK);
+use Fcntl qw(:DEFAULT :flock F_SETFD);
+
+my ($lock_path, @command) = @ARGV;
+exit 1 unless defined($lock_path) && @command;
+my $no_follow = eval { Fcntl::O_NOFOLLOW() };
+exit 1 if $@ || !defined($no_follow);
+
+sysopen(my $lock, $lock_path, O_CREAT | O_RDWR | $no_follow, 0600) or exit 1;
+exit 1 unless -f $lock;
+chmod 0600, $lock or exit 1;
+
+my $locked = 0;
+for (1 .. 40) {
+    if (flock($lock, LOCK_EX | LOCK_NB)) {
+        $locked = 1;
+        last;
+    }
+    exit 1 unless $! == EAGAIN || $! == EWOULDBLOCK;
+    select undef, undef, undef, 0.05;
+}
+exit 1 unless $locked;
+
+# Preserve the kernel-held lock through exec; it releases when the action exits.
+defined fcntl($lock, F_SETFD, 0) or exit 1;
+exec @command;
+exit 127;

--- a/plugins/claude-code/scripts/with-state-lock.pl
+++ b/plugins/claude-code/scripts/with-state-lock.pl
@@ -2,7 +2,25 @@
 use strict;
 use warnings;
 use Errno qw(EAGAIN EWOULDBLOCK EEXIST);
-use Fcntl qw(:DEFAULT :flock F_SETFD S_IFMT S_IFREG);
+use Fcntl qw(:DEFAULT :flock F_SETFD S_IFMT S_IFREG S_IFDIR);
+
+sub valid_basename {
+    my ($name) = @_;
+
+    return defined($name)
+        && length($name) > 0
+        && length($name) <= 255
+        && $name !~ m{/}
+        && $name !~ /\A\.{1,2}\z/
+        && $name =~ /\A[A-Za-z0-9._-]+\z/;
+}
+
+sub is_safe_directory {
+    my ($directory) = @_;
+    my @stat = stat($directory);
+
+    return @stat && (($stat[2] & S_IFMT) == S_IFDIR);
+}
 
 sub is_safe_lock {
     my ($lock) = @_;
@@ -14,18 +32,29 @@ sub is_safe_lock {
         && (($stat[2] & 0777) == 0600);
 }
 
-my ($lock_path, @command) = @ARGV;
-exit 1 unless defined($lock_path) && @command;
+my ($root, $lock_name, @command) = @ARGV;
+exit 1 unless defined($root)
+    && $root =~ m{\A/}
+    && index($root, "\0") == -1
+    && valid_basename($lock_name)
+    && @command;
 my $no_follow = eval { Fcntl::O_NOFOLLOW() };
 exit 1 if $@ || !defined($no_follow);
+my $directory_only = eval { Fcntl::O_DIRECTORY() };
+exit 1 if $@ || !defined($directory_only);
+sysopen(my $directory, $root, O_RDONLY | O_NONBLOCK | $directory_only | $no_follow)
+    or exit 1;
+exit 1 unless is_safe_directory($directory);
+chdir($directory) or exit 1;
+chmod 0700, q(.) or exit 1;
 
 my $old_umask = umask 0077;
-my $created = sysopen(my $lock, $lock_path, O_CREAT | O_EXCL | O_RDWR | $no_follow, 0600);
+my $created = sysopen(my $lock, $lock_name, O_CREAT | O_EXCL | O_RDWR | $no_follow, 0600);
 my $create_errno = $! unless $created;
 umask $old_umask;
 if (!$created) {
     exit 1 unless $create_errno == EEXIST;
-    sysopen($lock, $lock_path, O_RDWR | $no_follow) or exit 1;
+    sysopen($lock, $lock_name, O_RDWR | $no_follow) or exit 1;
 }
 exit 1 unless is_safe_lock($lock);
 my $locked = 0;
@@ -38,10 +67,11 @@ for (1 .. 40) {
     select undef, undef, undef, 0.05;
 }
 exit 1 unless $locked;
-
 exit 1 unless is_safe_lock($lock);
 
-# Preserve the kernel-held lock through exec; it releases when the action exits.
+# Preserve the rooted directory and kernel-held lock through exec.
+defined fcntl($directory, F_SETFD, 0) or exit 1;
 defined fcntl($lock, F_SETFD, 0) or exit 1;
+$ENV{FG_STATE_LOCK_DIR_FD} = fileno($directory);
 exec @command;
 exit 127;

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -11,25 +11,29 @@ Walk the user through getting foxguard installed and the plugin working:
    user's package manager (`brew install jq`, `sudo apt-get install jq`,
    `sudo dnf install jq`, or `sudo apk add jq`) before calling the auto-scan
    ready. Do not install without confirmation.
-2. Run `foxguard --version` via the Bash tool. If it succeeds, also run
+2. Run `command -v perl` and `perl -MFcntl=:flock -e 'exit !eval { defined(Fcntl::O_NOFOLLOW()) && LOCK_EX }'`. If either
+   fails, explain that file scanning still works but compaction continuity is
+   unavailable and fails open. Recommend the system Perl package; do not
+   install without confirmation.
+3. Run `foxguard --version` via the Bash tool. If it succeeds, also run
    `foxguard --help` and verify the active binary exposes these subcommands:
    `secrets`, `diff`, `tui`, and `pqc`.
-3. If `foxguard` is installed but any required subcommand is missing, report
+4. If `foxguard` is installed but any required subcommand is missing, report
    that the binary is too old for the full Claude Code plugin. Recommend
    upgrading with the install options below before calling the plugin ready.
-4. If `foxguard` is not on PATH, offer the install options in this order:
+5. If `foxguard` is not on PATH, offer the install options in this order:
    - **Prebuilt binary (fastest)**: `curl -fsSL https://foxguard.dev/install.sh | sh`
    - **npm**: `npm i -g foxguard` or zero-install via `npx foxguard`
    - **cargo**: `cargo install foxguard`
    Ask which the user prefers; do NOT install without confirmation.
-5. If `jq` and all required foxguard subcommands are present, report the
-   version and tell the user the plugin is ready — every Write/Edit will now be
-   auto-scanned.
-6. Recommend the user run `foxguard init` inside their repo to add a pre-commit
+6. If `jq`, Perl locking support, and all required foxguard subcommands are
+   present, report the version and tell the user the plugin is ready — every
+   Write/Edit will now be auto-scanned with compaction continuity.
+7. Recommend the user run `foxguard init` inside their repo to add a pre-commit
    hook so foxguard also catches issues outside Claude Code sessions.
-7. Mention the env vars they can tune:
+8. Mention the env vars they can tune:
    - `FOXGUARD_HOOK_SEVERITY` — minimum severity for auto-scan (default `medium`; values: `low|medium|high|critical`)
 
-Finish with a one-line confirmation of which `jq` version is active, which
-foxguard version is active, whether the full command surface is available, and
-which severity threshold the auto-scan is using.
+Finish with a one-line confirmation of which `jq` and Perl locking support are
+active, which foxguard version is active, whether the full command surface is
+available, and which severity threshold the auto-scan is using.

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -51,6 +51,18 @@ assert_line() {
     *) fail "expected exact line $2" ;;
   esac
 }
+file_mtime() {
+  perl -e 'print((stat $ARGV[0])[9])' "$1"
+}
+
+file_links() {
+  perl -e 'print((stat $ARGV[0])[3])' "$1"
+}
+
+file_mode() {
+  perl -e 'printf "%04o", (stat $ARGV[0])[2] & 0777' "$1"
+}
+
 
 hash_for_test() {
   if command -v shasum >/dev/null 2>&1; then
@@ -572,6 +584,86 @@ run_locked_action --locked-update 131072 64 "$forged_locked_root" "$forged_locke
   || fail "direct locked update followed a state-file symlink"
 [ -L "$forged_locked_state_file" ] || fail "state-file symlink was replaced"
 rm -f "$forged_locked_state_file"
+nested_locked_root="$state_root/nested-locked-workspace"
+mkdir -p "$nested_locked_root"
+git init -q "$nested_locked_root"
+nested_locked_root=$(CDPATH= cd -- "$nested_locked_root" && pwd -P)
+nested_locked_session_id='nested-locked-session'
+nested_locked_session_key=$(session_key_for_test "$nested_locked_session_id")
+nested_locked_workspace_key=$(workspace_key_for_test "$nested_locked_root")
+nested_locked_state_file="$state_root/$nested_locked_workspace_key-$nested_locked_session_key.json"
+nested_locked_active_sentinel="$nested_locked_root/active-${nested_locked_session_key}.json"
+nested_locked_stale_sentinel="$nested_locked_root/stale.json"
+nested_locked_temp_sentinel="$nested_locked_root/.state.stale"
+printf 'sentinel\n' > "$nested_locked_active_sentinel"
+printf 'sentinel\n' > "$nested_locked_stale_sentinel"
+printf 'sentinel\n' > "$nested_locked_temp_sentinel"
+touch -t 200001010000 "$nested_locked_active_sentinel" "$nested_locked_stale_sentinel" "$nested_locked_temp_sentinel"
+nested_locked_active_mtime=$(file_mtime "$nested_locked_active_sentinel")
+run_locked_action --locked-update 131072 64 "$nested_locked_root" "$nested_locked_session_id" \
+  'direct.py' medium "$direct_locked_record"
+[ "$locked_action_status" -ne 0 ] || fail "nested cache repository direct locked update was accepted"
+run_locked_action --locked-remove 131072 64 "$nested_locked_root" "$nested_locked_session_id" 'direct.py'
+[ "$locked_action_status" -ne 0 ] || fail "nested cache repository direct locked remove was accepted"
+run_locked_action --locked-summary 131072 64 "$nested_locked_root" "$nested_locked_session_id"
+[ "$locked_action_status" -ne 0 ] || fail "nested cache repository direct locked summary was accepted"
+[ "$(cat "$nested_locked_active_sentinel")" = "sentinel" ] \
+  || fail "nested cache repository active JSON sentinel changed"
+[ "$(file_mtime "$nested_locked_active_sentinel")" = "$nested_locked_active_mtime" ] \
+  || fail "nested cache repository active JSON sentinel was touched"
+[ "$(cat "$nested_locked_stale_sentinel")" = "sentinel" ] \
+  || fail "nested cache repository stale JSON sentinel changed"
+[ "$(cat "$nested_locked_temp_sentinel")" = "sentinel" ] \
+  || fail "nested cache repository temporary sentinel changed"
+[ ! -e "$nested_locked_state_file" ] || fail "nested cache repository derived state was written"
+rm -rf "$nested_locked_root"
+
+locked_state_hardlink_sentinel="$tmp_dir/locked-state-hardlink-sentinel"
+state_for_path 'hard-link.py' > "$locked_state_hardlink_sentinel"
+chmod 600 "$locked_state_hardlink_sentinel"
+touch -t 200001010000 "$locked_state_hardlink_sentinel"
+locked_state_hardlink_content=$(cat "$locked_state_hardlink_sentinel")
+locked_state_hardlink_mtime=$(file_mtime "$locked_state_hardlink_sentinel")
+ln "$locked_state_hardlink_sentinel" "$forged_locked_state_file"
+locked_state_hardlink_links=$(file_links "$locked_state_hardlink_sentinel")
+run_locked_action --locked-summary 131072 64 "$forged_locked_root" "$forged_locked_session_id"
+[ "$locked_action_status" -ne 0 ] || fail "hard-linked direct summary state was accepted"
+[ "$(cat "$locked_state_hardlink_sentinel")" = "$locked_state_hardlink_content" ] \
+  || fail "direct locked summary changed an outside hard-linked state"
+[ "$(file_mtime "$locked_state_hardlink_sentinel")" = "$locked_state_hardlink_mtime" ] \
+  || fail "direct locked summary touched an outside hard-linked state"
+[ "$(file_links "$locked_state_hardlink_sentinel")" = "$locked_state_hardlink_links" ] \
+  || fail "direct locked summary changed an outside hard-linked state link count"
+rm -f "$forged_locked_state_file"
+
+hardlink_prune_root="$tmp_dir/hardlink-prune-workspace"
+mkdir -p "$hardlink_prune_root"
+git init -q "$hardlink_prune_root"
+hardlink_prune_root=$(CDPATH= cd -- "$hardlink_prune_root" && pwd -P)
+hardlink_prune_session_id='hardlink-prune-session'
+hardlink_prune_workspace_key=$(workspace_key_for_test "$hardlink_prune_root")
+hardlink_prune_session_key=$(session_key_for_test "$hardlink_prune_session_id")
+hardlink_prune_state_file="$state_root/$hardlink_prune_workspace_key-$hardlink_prune_session_key.json"
+state_for_path 'summary.py' > "$hardlink_prune_state_file"
+chmod 600 "$hardlink_prune_state_file"
+hardlink_prune_sentinel="$tmp_dir/hardlink-prune-sentinel"
+state_for_path 'stale.py' > "$hardlink_prune_sentinel"
+chmod 600 "$hardlink_prune_sentinel"
+touch -t 200001010000 "$hardlink_prune_sentinel"
+hardlink_prune_content=$(cat "$hardlink_prune_sentinel")
+hardlink_prune_mtime=$(file_mtime "$hardlink_prune_sentinel")
+ln "$hardlink_prune_sentinel" "$state_root/hardlink-prune.json"
+hardlink_prune_links=$(file_links "$hardlink_prune_sentinel")
+run_locked_action --locked-summary 131072 64 "$hardlink_prune_root" "$hardlink_prune_session_id"
+[ "$locked_action_status" -ne 0 ] || fail "hard-linked stale prune candidate was accepted"
+[ "$(cat "$hardlink_prune_sentinel")" = "$hardlink_prune_content" ] \
+  || fail "state prune changed an outside hard-linked candidate"
+[ "$(file_mtime "$hardlink_prune_sentinel")" = "$hardlink_prune_mtime" ] \
+  || fail "state prune touched an outside hard-linked candidate"
+[ "$(file_links "$hardlink_prune_sentinel")" = "$hardlink_prune_links" ] \
+  || fail "state prune changed an outside hard-linked candidate link count"
+rm -f "$state_root/hardlink-prune.json" "$hardlink_prune_state_file"
+
 
 forged_prune_root="$forged_locked_root/forged-prune-root"
 mkdir -p "$forged_prune_root"
@@ -712,6 +804,28 @@ if run_state_update "$concurrent_root" 'symlink.py' "$(record_for_rule test/syml
 fi
 [ "$(cat "$lock_sentinel")" = "sentinel" ] || fail "lock wrapper followed a symlink"
 rm -f "$state_root/.lock"
+lock_hardlink_sentinel="$tmp_dir/lock-hardlink-sentinel"
+printf 'sentinel\n' > "$lock_hardlink_sentinel"
+chmod 0644 "$lock_hardlink_sentinel"
+lock_hardlink_content=$(cat "$lock_hardlink_sentinel")
+lock_hardlink_mode=$(file_mode "$lock_hardlink_sentinel")
+rm -f "$state_root/.lock"
+ln "$lock_hardlink_sentinel" "$state_root/.lock"
+lock_hardlink_links=$(file_links "$lock_hardlink_sentinel")
+if perl "$lock_wrapper" "$state_root/.lock" /usr/bin/true; then
+  fail "hard-linked lock was accepted"
+fi
+[ "$(cat "$lock_hardlink_sentinel")" = "$lock_hardlink_content" ] \
+  || fail "lock wrapper changed an outside hard-linked lock"
+[ "$(file_mode "$lock_hardlink_sentinel")" = "$lock_hardlink_mode" ] \
+  || fail "lock wrapper changed an outside hard-linked lock mode"
+[ "$(file_links "$lock_hardlink_sentinel")" = "$lock_hardlink_links" ] \
+  || fail "lock wrapper changed an outside hard-linked lock link count"
+rm -f "$state_root/.lock"
+perl "$lock_wrapper" "$state_root/.lock" /usr/bin/true \
+  || fail "lock wrapper did not create a normal lock"
+[ "$(file_mode "$state_root/.lock")" = "0600" ] || fail "normal lock mode is not 0600"
+
 
 kernel_lock_ready="$tmp_dir/kernel-lock-ready"
 perl -MFcntl=:flock -e '

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -25,6 +25,7 @@ cleanup() {
   fi
   rm -rf "$tmp_dir"
 }
+trap cleanup EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -272,6 +272,15 @@ untracked_root=$(CDPATH= cd -- "$untracked_root" && pwd -P)
 untracked_workspace_key=$(workspace_key_for_test "$untracked_root")
 untracked_state_file="$state_root/$untracked_workspace_key-$session_key.json"
 
+forged_locked_root="$tmp_dir/forged-locked-workspace"
+mkdir -p "$forged_locked_root"
+git init -q "$forged_locked_root"
+forged_locked_root=$(CDPATH= cd -- "$forged_locked_root" && pwd -P)
+forged_locked_session_id='forged-locked-session'
+forged_locked_workspace_key=$(workspace_key_for_test "$forged_locked_root")
+forged_locked_session_key=$(session_key_for_test "$forged_locked_session_id")
+forged_locked_state_file="$state_root/$forged_locked_workspace_key-$forged_locked_session_key.json"
+
 plugin_root_with_spaces="$tmp_dir/plugin root"
 mkdir -p "$plugin_root_with_spaces"
 ln -s "$root/plugins/claude-code/scripts" "$plugin_root_with_spaces/scripts"
@@ -389,6 +398,14 @@ run_state_update() {
     fg_state_update_file "$state_session" "$repo_root" "$relative_path" medium "$record"
   )
 }
+
+run_locked_action() {
+  set +e
+  locked_action_output=$(XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" "$state_helper" "$@" 2>&1)
+  locked_action_status=$?
+  set -e
+}
+
 
 run_paused_state_update() {
   local repo_root=$1 relative_path=$2 record=$3 ready_file=$4 release_file=$5
@@ -512,6 +529,64 @@ assert_not_contains "$state_content" FINDING_SECRET
 assert_not_contains "$state_content" SOURCE_SNIPPET_SECRET
 assert_not_contains "$state_content" "$root"
 assert_not_contains "$(basename "$state_file")" "$session_id"
+direct_locked_record=$(record_for_rule test/direct-locked)
+locked_update_sentinel="$forged_locked_root/update-sentinel"
+printf 'sentinel\n' > "$locked_update_sentinel"
+run_locked_action --locked-update 131072 64 "$forged_locked_root" "$forged_locked_session_id" \
+  'direct.py' medium "$direct_locked_record"
+assert_status "$locked_action_status" 0
+[ "$(cat "$locked_update_sentinel")" = "sentinel" ] \
+  || fail "direct locked update modified an out-of-cache sentinel"
+[ -f "$forged_locked_state_file" ] || fail "direct locked update did not write its derived state file"
+forged_locked_state_content=$(cat "$forged_locked_state_file")
+run_locked_action --locked-update 131072 64 "$forged_locked_root" "$forged_locked_session_id" \
+  "$locked_update_sentinel" medium "$direct_locked_record"
+[ "$locked_action_status" -ne 0 ] || fail "hostile direct locked update was accepted"
+[ "$(cat "$locked_update_sentinel")" = "sentinel" ] \
+  || fail "hostile direct locked update modified an out-of-cache sentinel"
+[ "$(cat "$forged_locked_state_file")" = "$forged_locked_state_content" ] \
+  || fail "hostile direct locked update changed derived state"
+
+locked_remove_sentinel="$forged_locked_root/remove-sentinel"
+printf 'sentinel\n' > "$locked_remove_sentinel"
+run_locked_action --locked-remove 131072 64 "$forged_locked_root" "$forged_locked_session_id" \
+  "$locked_remove_sentinel"
+assert_status "$locked_action_status" 0
+[ "$(cat "$locked_remove_sentinel")" = "sentinel" ] \
+  || fail "hostile direct locked remove modified an out-of-cache sentinel"
+[ "$(cat "$forged_locked_state_file")" = "$forged_locked_state_content" ] \
+  || fail "hostile direct locked remove changed derived state"
+run_locked_action --locked-remove 131072 64 "$forged_locked_root" "$forged_locked_session_id" 'direct.py'
+assert_status "$locked_action_status" 0
+[ ! -e "$forged_locked_state_file" ] || fail "direct locked remove did not remove its derived state file"
+[ "$(cat "$locked_remove_sentinel")" = "sentinel" ] \
+  || fail "direct locked remove modified an out-of-cache sentinel"
+
+locked_state_symlink_sentinel="$forged_locked_root/state-symlink-sentinel"
+printf 'sentinel\n' > "$locked_state_symlink_sentinel"
+ln -s "$locked_state_symlink_sentinel" "$forged_locked_state_file"
+run_locked_action --locked-update 131072 64 "$forged_locked_root" "$forged_locked_session_id" \
+  'direct.py' medium "$direct_locked_record"
+[ "$locked_action_status" -ne 0 ] || fail "symlinked derived state file was accepted"
+[ "$(cat "$locked_state_symlink_sentinel")" = "sentinel" ] \
+  || fail "direct locked update followed a state-file symlink"
+[ -L "$forged_locked_state_file" ] || fail "state-file symlink was replaced"
+rm -f "$forged_locked_state_file"
+
+forged_prune_root="$forged_locked_root/forged-prune-root"
+mkdir -p "$forged_prune_root"
+forged_json_sentinel="$forged_prune_root/stale.json"
+forged_temp_sentinel="$forged_prune_root/.state.stale"
+printf 'sentinel\n' > "$forged_json_sentinel"
+printf 'sentinel\n' > "$forged_temp_sentinel"
+touch -t 200001010000 "$forged_json_sentinel" "$forged_temp_sentinel"
+run_locked_action --locked-summary 131072 64 "$forged_locked_root" "$forged_locked_session_id"
+[ "$locked_action_status" -ne 0 ] || fail "missing direct locked summary state was accepted"
+[ "$(cat "$forged_json_sentinel")" = "sentinel" ] \
+  || fail "direct locked summary pruned a forged-root JSON sentinel"
+[ "$(cat "$forged_temp_sentinel")" = "sentinel" ] \
+  || fail "direct locked summary pruned a forged-root temporary sentinel"
+
 
 run_scan_without_perl finding "$no_perl_payload"
 assert_status "$scan_status" 2
@@ -669,7 +744,10 @@ jq -e '.files | has("kernel-lock.py")' "$concurrent_state_file" >/dev/null \
 [ -f "$state_root/.lock" ] && [ ! -L "$state_root/.lock" ] \
   || fail "state lock is not a regular persistent file"
 atomic_ready="$tmp_dir/atomic-write-ready"
-atomic_target="$tmp_dir/atomic-write-target.json"
+atomic_session_id='atomic-write-interrupt'
+atomic_session_key=$(session_key_for_test "$atomic_session_id")
+atomic_target="$state_root/$workspace_key-$atomic_session_key.json"
+
 (
   XDG_CACHE_HOME="$cache_dir"
   PATH="$fake_bin:$PATH"
@@ -678,7 +756,7 @@ atomic_target="$tmp_dir/atomic-write-target.json"
     bash -c 'printf "%s\n" "$PPID"' > "$atomic_ready"
     while :; do sleep 1; done
   }
-  fg_state_atomic_write "$state_root" "$atomic_target" '{"metadata":"only"}'
+  fg_state_atomic_write "$root" "$atomic_session_id" '{"metadata":"only"}'
 ) &
 atomic_holder_pid=$!
 for _ in $(seq 1 80); do

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -11,6 +11,7 @@ hooks_json="$root/plugins/claude-code/hooks/hooks.json"
 fixture="$root/tests/fixtures/safe.py"
 session_id="compaction-test-588"
 tmp_dir=$(mktemp -d)
+tmp_dir=$(CDPATH= cd -- "$tmp_dir" && pwd -P)
 cache_dir="$tmp_dir/cache"
 fake_bin="$tmp_dir/bin"
 no_perl_bin="$tmp_dir/no-perl-bin"
@@ -409,19 +410,48 @@ run_locked_action() {
   set -e
 }
 
+run_locked_action_with_forged_fd() {
+  local outside_root=$1
+  shift
 
-run_paused_state_update() {
-  local repo_root=$1 relative_path=$2 record=$3 ready_file=$4 release_file=$5
-
-  (
-    export XDG_CACHE_HOME="$cache_dir"
-    export PATH="$fake_bin:$PATH"
-    export FG_STATE_TEST_TEMP_READY="$ready_file"
-    export FG_STATE_TEST_TEMP_RELEASE="$release_file"
-    . "$state_helper"
-    fg_state_update_file "$session_id" "$repo_root" "$relative_path" medium "$record"
-  )
+  set +e
+  locked_action_output=$(XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
+    perl -MFcntl=F_SETFD -e '
+      my $outside_root = shift @ARGV;
+      open my $directory, q(<), $outside_root or exit 1;
+      fcntl($directory, F_SETFD, 0) or exit 1;
+      $ENV{FG_STATE_LOCK_DIR_FD} = fileno($directory);
+      exec @ARGV;
+    ' "$outside_root" "$state_helper" "$@" 2>&1)
+  locked_action_status=$?
+  set -e
 }
+
+start_fifo_state_write() {
+  local directory=$1 target=$2 fifo=$3 output=$4
+
+  mkfifo "$fifo"
+  "$state_file_helper" --root "$directory" write "$target" 128 < "$fifo" > "$output" 2>&1 &
+  fifo_write_pid=$!
+  exec 9> "$fifo"
+}
+
+wait_for_state_temp() {
+  local directory=$1 description=$2 state_temp
+
+  for _ in $(seq 1 80); do
+    state_temp=$(find "$directory" -maxdepth 1 -type f -name '.state.*' -print)
+    [ -n "$state_temp" ] && return 0
+    sleep 0.05
+  done
+  fail "$description"
+}
+
+close_fifo_state_write() {
+  exec 9>&-
+}
+
+
 
 run_state_update_with_limit() {
   local limit=$1 repo_root=$2 relative_path=$3 record=$4 state_session=${5:-$session_id}
@@ -533,6 +563,65 @@ assert_not_contains "$state_content" SOURCE_SNIPPET_SECRET
 assert_not_contains "$state_content" "$root"
 assert_not_contains "$(basename "$state_file")" "$session_id"
 direct_locked_record=$(record_for_rule test/direct-locked)
+forged_fd_root="$tmp_dir/forged-fd-workspace"
+mkdir -p "$forged_fd_root"
+git init -q "$forged_fd_root"
+forged_fd_root=$(CDPATH= cd -- "$forged_fd_root" && pwd -P)
+forged_fd_session_id='forged-fd-session'
+forged_fd_workspace_key=$(workspace_key_for_test "$forged_fd_root")
+forged_fd_session_key=$(session_key_for_test "$forged_fd_session_id")
+forged_fd_state_file="$state_root/$forged_fd_workspace_key-$forged_fd_session_key.json"
+state_for_path 'cache-sentinel.py' > "$forged_fd_state_file"
+chmod 600 "$forged_fd_state_file"
+forged_fd_cache_content=$(cat "$forged_fd_state_file")
+forged_fd_outside="$tmp_dir/forged-fd-outside"
+mkdir -p "$forged_fd_outside"
+forged_fd_json_sentinel="$forged_fd_outside/stale.json"
+forged_fd_temp_sentinel="$forged_fd_outside/.state.stale"
+printf 'sentinel\n' > "$forged_fd_json_sentinel"
+printf 'sentinel\n' > "$forged_fd_temp_sentinel"
+touch -t 200001010000 "$forged_fd_json_sentinel" "$forged_fd_temp_sentinel"
+run_locked_action_with_forged_fd "$forged_fd_outside" --locked-update 131072 64 \
+  "$forged_fd_root" "$forged_fd_session_id" 'forged-fd.py' medium "$direct_locked_record"
+[ "$locked_action_status" -ne 0 ] || fail "forged inherited state directory fd was accepted"
+[ "$(cat "$forged_fd_state_file")" = "$forged_fd_cache_content" ] \
+  || fail "forged inherited state directory fd changed cache state"
+[ "$(cat "$forged_fd_json_sentinel")" = "sentinel" ] \
+  || fail "forged inherited state directory fd pruned outside JSON"
+[ "$(cat "$forged_fd_temp_sentinel")" = "sentinel" ] \
+  || fail "forged inherited state directory fd pruned outside temporary state"
+[ ! -e "$forged_fd_outside/${forged_fd_state_file##*/}" ] \
+  || fail "forged inherited state directory fd wrote outside state"
+
+intermediate_cache="$tmp_dir/intermediate-cache"
+intermediate_outside="$tmp_dir/intermediate-outside"
+mkdir -p "$intermediate_cache" "$intermediate_outside"
+printf 'sentinel\n' > "$intermediate_outside/sentinel"
+ln -s "$intermediate_outside" "$intermediate_cache/foxguard"
+intermediate_session_id='intermediate-symlink-session'
+if XDG_CACHE_HOME="$intermediate_cache" PATH="$fake_bin:$PATH" "$state_helper" \
+  --locked-update 131072 64 "$forged_locked_root" "$intermediate_session_id" \
+  'intermediate-direct.py' medium "$direct_locked_record"; then
+  fail "direct locked action accepted an intermediate cache symlink"
+fi
+if perl "$lock_wrapper" "$intermediate_cache/foxguard/claude-code" .lock /usr/bin/true; then
+  fail "lock wrapper accepted an intermediate cache symlink"
+fi
+if (
+  XDG_CACHE_HOME="$intermediate_cache"
+  PATH="$fake_bin:$PATH"
+  . "$state_helper"
+  fg_state_update_file "$intermediate_session_id" "$forged_locked_root" \
+    'intermediate-normal.py' medium "$direct_locked_record"
+); then
+  fail "normal state update accepted an intermediate cache symlink"
+fi
+[ "$(cat "$intermediate_outside/sentinel")" = "sentinel" ] \
+  || fail "intermediate cache symlink changed an outside sentinel"
+[ ! -e "$intermediate_outside/.lock" ] \
+  || fail "intermediate cache symlink created an outside lock"
+[ -z "$(find "$intermediate_outside" -type f -name '*.json' -print)" ] \
+  || fail "intermediate cache symlink wrote state outside the cache"
 locked_update_sentinel="$forged_locked_root/update-sentinel"
 printf 'sentinel\n' > "$locked_update_sentinel"
 run_locked_action --locked-update 131072 64 "$forged_locked_root" "$forged_locked_session_id" \
@@ -669,137 +758,42 @@ run_locked_action --locked-summary 131072 64 "$forged_locked_root" "$forged_lock
   || fail "direct locked summary pruned a forged-root JSON sentinel"
 [ "$(cat "$forged_temp_sentinel")" = "sentinel" ] \
   || fail "direct locked summary pruned a forged-root temporary sentinel"
-rendezvous_outside_ready="$tmp_dir/rendezvous-outside-ready"
-rendezvous_outside_release="$tmp_dir/rendezvous-outside-release"
-rendezvous_target="$state_root/rendezvous-inert.json"
-printf 'sentinel\n' > "$rendezvous_outside_ready"
-printf 'sentinel\n' > "$rendezvous_outside_release"
-printf '{}\n' | FG_STATE_TEST_TEMP_READY="$rendezvous_outside_ready" \
-  FG_STATE_TEST_TEMP_RELEASE="$rendezvous_outside_release" \
-  "$state_file_helper" --root "$state_root" write "${rendezvous_target##*/}" 128 \
-  || fail "invalid test rendezvous blocked an anchored write"
-[ "$(cat "$rendezvous_outside_ready")" = "sentinel" ] \
-  || fail "invalid test rendezvous wrote outside the state root"
-[ "$(cat "$rendezvous_outside_release")" = "sentinel" ] \
-  || fail "invalid test rendezvous read or wrote outside the state root"
-rm -f "$rendezvous_target"
-
-direct_race_root="$tmp_dir/direct-race-workspace"
-mkdir -p "$direct_race_root"
-git init -q "$direct_race_root"
-direct_race_root=$(CDPATH= cd -- "$direct_race_root" && pwd -P)
-direct_race_session_id='direct-final-symlink-race'
-direct_race_workspace_key=$(workspace_key_for_test "$direct_race_root")
-direct_race_session_key=$(session_key_for_test "$direct_race_session_id")
-direct_race_state_file="$state_root/$direct_race_workspace_key-$direct_race_session_key.json"
+direct_race_state_root="$tmp_dir/direct-race-cache/foxguard/claude-code"
+direct_race_target='direct-final-symlink-race.json'
 direct_race_outside="$tmp_dir/direct-race-outside"
-direct_race_ready='test-direct-race-ready'
-direct_race_release='test-direct-race-release'
-mkdir -p "$direct_race_outside"
-: > "$state_root/$direct_race_ready"
-: > "$state_root/$direct_race_release"
-(
-  XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
-    FG_STATE_TEST_TEMP_READY="$direct_race_ready" FG_STATE_TEST_TEMP_RELEASE="$direct_race_release" \
-    "$state_helper" --locked-update 131072 64 "$direct_race_root" "$direct_race_session_id" \
-      'direct-race.py' medium "$direct_locked_record"
-) > "$tmp_dir/direct-race-output" 2>&1 &
-direct_race_pid=$!
-for _ in $(seq 1 80); do
-  [ -s "$state_root/$direct_race_ready" ] && break
-  sleep 0.05
-done
-[ -s "$state_root/$direct_race_ready" ] || fail "direct symlink race did not reach state temp"
-ln -s "$direct_race_outside" "$direct_race_state_file"
-printf 'release\n' > "$state_root/$direct_race_release"
+direct_race_fifo="$tmp_dir/direct-race.fifo"
+mkdir -p "$direct_race_state_root" "$direct_race_outside"
+start_fifo_state_write "$direct_race_state_root" "$direct_race_target" "$direct_race_fifo" \
+  "$tmp_dir/direct-race-output"
+wait_for_state_temp "$direct_race_state_root" "direct symlink race did not reach state temp"
+ln -s "$direct_race_outside" "$direct_race_state_root/$direct_race_target"
+close_fifo_state_write
 set +e
-wait "$direct_race_pid"
+wait "$fifo_write_pid"
 direct_race_status=$?
 set -e
 [ "$direct_race_status" -ne 0 ] || fail "direct symlink race did not fail closed"
-[ -L "$direct_race_state_file" ] || fail "direct symlink race replaced its final symlink"
+[ -L "$direct_race_state_root/$direct_race_target" ] \
+  || fail "direct symlink race replaced its final symlink"
 [ -z "$(find "$direct_race_outside" -type f -print)" ] \
   || fail "direct symlink race wrote outside the cache"
-rm -f "$direct_race_state_file"
 
-normal_race_root="$tmp_dir/normal-race-workspace"
-mkdir -p "$normal_race_root"
-git init -q "$normal_race_root"
-normal_race_root=$(CDPATH= cd -- "$normal_race_root" && pwd -P)
-normal_race_session_id='normal-final-symlink-race'
-normal_race_workspace_key=$(workspace_key_for_test "$normal_race_root")
-normal_race_session_key=$(session_key_for_test "$normal_race_session_id")
-normal_race_state_file="$state_root/$normal_race_workspace_key-$normal_race_session_key.json"
-normal_race_outside="$tmp_dir/normal-race-outside"
-normal_race_ready='test-normal-race-ready'
-normal_race_release='test-normal-race-release'
-mkdir -p "$normal_race_outside"
-: > "$state_root/$normal_race_ready"
-: > "$state_root/$normal_race_release"
-(
-  export XDG_CACHE_HOME="$cache_dir"
-  export PATH="$fake_bin:$PATH"
-  export FG_STATE_TEST_TEMP_READY="$normal_race_ready"
-  export FG_STATE_TEST_TEMP_RELEASE="$normal_race_release"
-  . "$state_helper"
-  fg_state_update_file "$normal_race_session_id" "$normal_race_root" 'normal-race.py' medium "$direct_locked_record"
-) > "$tmp_dir/normal-race-output" 2>&1 &
-normal_race_pid=$!
-for _ in $(seq 1 80); do
-  [ -s "$state_root/$normal_race_ready" ] && break
-  sleep 0.05
-done
-[ -s "$state_root/$normal_race_ready" ] || fail "normal symlink race did not reach state temp"
-ln -s "$normal_race_outside" "$normal_race_state_file"
-printf 'release\n' > "$state_root/$normal_race_release"
-set +e
-wait "$normal_race_pid"
-normal_race_status=$?
-set -e
-[ "$normal_race_status" -ne 0 ] || fail "normal symlink race did not fail closed"
-[ -L "$normal_race_state_file" ] || fail "normal symlink race replaced its final symlink"
-[ -z "$(find "$normal_race_outside" -type f -print)" ] \
-  || fail "normal symlink race wrote outside the cache"
-rm -f "$normal_race_state_file"
-
-root_rename_cache="$tmp_dir/root-rename-cache"
-root_rename_root="$tmp_dir/root-rename-workspace"
-mkdir -p "$root_rename_root"
-git init -q "$root_rename_root"
-root_rename_root=$(CDPATH= cd -- "$root_rename_root" && pwd -P)
-root_rename_session_id='root-rename-race'
-root_rename_workspace_key=$(workspace_key_for_test "$root_rename_root")
-root_rename_session_key=$(session_key_for_test "$root_rename_session_id")
-root_rename_state_root="$root_rename_cache/foxguard/claude-code"
-root_rename_state_file="$root_rename_state_root/$root_rename_workspace_key-$root_rename_session_key.json"
+root_rename_state_root="$tmp_dir/root-rename-cache/foxguard/claude-code"
+root_rename_target='root-rename-race.json'
 root_rename_moved_root="$tmp_dir/root-rename-moved"
 root_rename_outside="$tmp_dir/root-rename-outside"
-root_rename_ready='test-root-rename-ready'
-root_rename_release='test-root-rename-release'
+root_rename_fifo="$tmp_dir/root-rename.fifo"
 mkdir -p "$root_rename_state_root" "$root_rename_outside"
-: > "$root_rename_state_root/$root_rename_ready"
-: > "$root_rename_state_root/$root_rename_release"
-(
-  export XDG_CACHE_HOME="$root_rename_cache"
-  export PATH="$fake_bin:$PATH"
-  export FG_STATE_TEST_TEMP_READY="$root_rename_ready"
-  export FG_STATE_TEST_TEMP_RELEASE="$root_rename_release"
-  . "$state_helper"
-  fg_state_update_file "$root_rename_session_id" "$root_rename_root" 'root-rename.py' medium "$direct_locked_record"
-) > "$tmp_dir/root-rename-output" 2>&1 &
-root_rename_pid=$!
-for _ in $(seq 1 80); do
-  [ -s "$root_rename_state_root/$root_rename_ready" ] && break
-  sleep 0.05
-done
-[ -s "$root_rename_state_root/$root_rename_ready" ] || fail "root replacement test did not reach state temp"
+start_fifo_state_write "$root_rename_state_root" "$root_rename_target" "$root_rename_fifo" \
+  "$tmp_dir/root-rename-output"
+wait_for_state_temp "$root_rename_state_root" "root replacement test did not reach state temp"
 mv "$root_rename_state_root" "$root_rename_moved_root"
 ln -s "$root_rename_outside" "$root_rename_state_root"
-printf 'release\n' > "$root_rename_moved_root/$root_rename_release"
-wait "$root_rename_pid"
-[ -f "$root_rename_moved_root/${root_rename_state_file##*/}" ] \
+close_fifo_state_write
+wait "$fifo_write_pid"
+[ -f "$root_rename_moved_root/$root_rename_target" ] \
   || fail "root replacement lost its anchored state write"
-[ ! -e "$root_rename_outside/${root_rename_state_file##*/}" ] \
+[ ! -e "$root_rename_outside/$root_rename_target" ] \
   || fail "root replacement wrote through its replacement"
 [ -z "$(find "$root_rename_outside" -type f -print)" ] \
   || fail "root replacement created a file outside the anchored root"
@@ -967,49 +961,29 @@ for _ in $(seq 1 80); do
   sleep 0.05
 done
 [ -f "$kernel_lock_ready" ] || fail "kernel lock holder did not start"
-run_state_update "$concurrent_root" 'kernel-lock.py' "$(record_for_rule test/kernel-lock)" &
-kernel_lock_update_pid=$!
-sleep 0.1
-kill -0 "$kernel_lock_update_pid" 2>/dev/null || fail "kernel lock did not exclude an update"
 kill -KILL "$kernel_lock_holder_pid"
 set +e
 wait "$kernel_lock_holder_pid"
 kernel_lock_holder_status=$?
 set -e
 [ "$kernel_lock_holder_status" -ne 0 ] || fail "crashed kernel lock holder exited cleanly"
-wait "$kernel_lock_update_pid"
+run_state_update "$concurrent_root" 'kernel-lock.py' "$(record_for_rule test/kernel-lock)"
 jq -e '.files | has("kernel-lock.py")' "$concurrent_state_file" >/dev/null \
   || fail "state update did not recover after a crashed lock holder"
 [ -f "$state_root/.lock" ] && [ ! -L "$state_root/.lock" ] \
   || fail "state lock is not a regular persistent file"
-atomic_ready='test-atomic-ready'
-atomic_release='test-atomic-release'
 atomic_session_id='atomic-write-interrupt'
 atomic_session_key=$(session_key_for_test "$atomic_session_id")
 atomic_target="$state_root/$workspace_key-$atomic_session_key.json"
-: > "$state_root/$atomic_ready"
-: > "$state_root/$atomic_release"
-
-(
-  export XDG_CACHE_HOME="$cache_dir"
-  export PATH="$fake_bin:$PATH"
-  export FG_STATE_TEST_TEMP_READY="$atomic_ready"
-  export FG_STATE_TEST_TEMP_RELEASE="$atomic_release"
-  . "$state_helper"
-  fg_state_prepare_locked_state "$root" "$atomic_session_id"
-  fg_state_atomic_write "$root" "$atomic_session_id" '{"metadata":"only"}'
-) &
-atomic_holder_pid=$!
-for _ in $(seq 1 80); do
-  [ -s "$state_root/$atomic_ready" ] && break
-  sleep 0.05
-done
-[ -s "$state_root/$atomic_ready" ] || fail "atomic write did not reach move"
-atomic_owner_pid=$(cat "$state_root/$atomic_ready")
+atomic_fifo="$tmp_dir/atomic-write.fifo"
+start_fifo_state_write "$state_root" "${atomic_target##*/}" "$atomic_fifo" "$tmp_dir/atomic-write-output"
+wait_for_state_temp "$state_root" "atomic write did not reach its temporary file"
+atomic_owner_pid=$fifo_write_pid
 kill -0 "$atomic_owner_pid" 2>/dev/null || fail "atomic write owner was not live"
 kill -TERM "$atomic_owner_pid"
+close_fifo_state_write
 set +e
-wait "$atomic_holder_pid"
+wait "$atomic_owner_pid"
 atomic_holder_status=$?
 set -e
 [ "$atomic_holder_status" -ne 0 ] || fail "interrupted atomic write exited cleanly"
@@ -1035,22 +1009,31 @@ jq -e '(.files | keys | sort) == ["kernel-lock.py", "one.py", "two.py"]' "$concu
   || fail "concurrent updates did not retain a regular lock file"
 
 paused_record=$(record_for_rule test/paused)
-paused_ready='test-paused-ready'
-paused_release='test-paused-release'
-: > "$state_root/$paused_ready"
-: > "$state_root/$paused_release"
-run_paused_state_update "$paused_root" 'one.py' "$paused_record" "$paused_ready" "$paused_release" &
-paused_one_pid=$!
+paused_ready="$tmp_dir/paused-lock-ready"
+paused_fifo="$tmp_dir/paused-lock.fifo"
+mkfifo "$paused_fifo"
+perl "$lock_wrapper" "$state_root" .lock perl -e '
+  open my $ready, q(>), $ARGV[0] or exit 1;
+  print {$ready} "ready\n" or exit 1;
+  close $ready or exit 1;
+  while (read(STDIN, my $buffer, 8192)) {}
+' "$paused_ready" < "$paused_fifo" > "$tmp_dir/paused-lock-output" 2>&1 &
+paused_lock_holder_pid=$!
+exec 8> "$paused_fifo"
 for _ in $(seq 1 80); do
-  [ -s "$state_root/$paused_ready" ] && break
+  [ -f "$paused_ready" ] && break
   sleep 0.05
 done
-[ -s "$state_root/$paused_ready" ] || fail "paused update did not reach rename"
-run_state_update "$paused_root" 'two.py' "$paused_record" &
+[ -f "$paused_ready" ] || fail "test lock holder did not acquire the state lock"
+( exec 8>&-; run_state_update "$paused_root" 'one.py' "$paused_record" ) &
+paused_one_pid=$!
+( exec 8>&-; run_state_update "$paused_root" 'two.py' "$paused_record" ) &
 paused_two_pid=$!
 sleep 0.1
-kill -0 "$paused_two_pid" 2>/dev/null || fail "second update bypassed the paused writer"
-printf 'release\n' > "$state_root/$paused_release"
+kill -0 "$paused_one_pid" 2>/dev/null || fail "first update bypassed the test lock"
+kill -0 "$paused_two_pid" 2>/dev/null || fail "second update bypassed the test lock"
+exec 8>&-
+wait "$paused_lock_holder_pid"
 wait "$paused_one_pid"
 wait "$paused_two_pid"
 jq -e '(.files | keys | sort) == ["one.py", "two.py"]' "$paused_state_file" >/dev/null \

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -5,6 +5,7 @@ root=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd -P)
 scan_hook="$root/plugins/claude-code/scripts/scan-edited-file.sh"
 restore_hook="$root/plugins/claude-code/scripts/restore-unresolved-findings.sh"
 state_helper="$root/plugins/claude-code/scripts/finding-state.sh"
+state_file_helper="$root/plugins/claude-code/scripts/state-file-operation.pl"
 lock_wrapper="$root/plugins/claude-code/scripts/with-state-lock.pl"
 hooks_json="$root/plugins/claude-code/hooks/hooks.json"
 fixture="$root/tests/fixtures/safe.py"
@@ -12,7 +13,6 @@ session_id="compaction-test-588"
 tmp_dir=$(mktemp -d)
 cache_dir="$tmp_dir/cache"
 fake_bin="$tmp_dir/bin"
-pause_bin="$tmp_dir/pause-bin"
 no_perl_bin="$tmp_dir/no-perl-bin"
 no_scanner_bin="$tmp_dir/no-scanner-bin"
 state_root="$cache_dir/foxguard/claude-code"
@@ -125,7 +125,7 @@ record_for_rule() {
   '
 }
 
-mkdir -p "$fake_bin" "$pause_bin" "$no_perl_bin" "$no_scanner_bin"
+mkdir -p "$fake_bin" "$no_perl_bin" "$no_scanner_bin"
 cat > "$fake_bin/foxguard" <<'EOF'
 #!/usr/bin/env bash
 case "${FOXGUARD_TEST_MODE:-finding}" in
@@ -182,15 +182,6 @@ cat > "$no_perl_bin/perl" <<'EOF'
 exit 99
 EOF
 chmod +x "$no_perl_bin/perl"
-cat > "$pause_bin/mv" <<'EOF'
-#!/usr/bin/env bash
-if [ "${FG_STATE_TEST_PAUSE_MV:-}" = "1" ]; then
-  : > "$FG_STATE_TEST_MV_READY"
-  while [ ! -f "$FG_STATE_TEST_MV_RELEASE" ]; do sleep 0.05; done
-fi
-exec /bin/mv "$@"
-EOF
-chmod +x "$pause_bin/mv"
 jq_path=$(command -v jq)
 case "$jq_path" in
   /*) ;;
@@ -424,10 +415,9 @@ run_paused_state_update() {
 
   (
     export XDG_CACHE_HOME="$cache_dir"
-    export PATH="$pause_bin:$fake_bin:$PATH"
-    export FG_STATE_TEST_PAUSE_MV=1
-    export FG_STATE_TEST_MV_READY="$ready_file"
-    export FG_STATE_TEST_MV_RELEASE="$release_file"
+    export PATH="$fake_bin:$PATH"
+    export FG_STATE_TEST_TEMP_READY="$ready_file"
+    export FG_STATE_TEST_TEMP_RELEASE="$release_file"
     . "$state_helper"
     fg_state_update_file "$session_id" "$repo_root" "$relative_path" medium "$record"
   )
@@ -495,6 +485,7 @@ restore_hook_command=$(jq -r '.hooks.SessionStart[] | select(.matcher == "compac
 bash -n "$scan_hook"
 bash -n "$state_helper"
 bash -n "$restore_hook"
+perl -c "$state_file_helper" >/dev/null
 perl -c "$lock_wrapper" >/dev/null
 jq empty "$hooks_json"
 for unsafe_path in '/absolute.py' 'C:/absolute.py' 'dir//empty.py' './dot.py' 'dir/../up.py' \
@@ -678,6 +669,140 @@ run_locked_action --locked-summary 131072 64 "$forged_locked_root" "$forged_lock
   || fail "direct locked summary pruned a forged-root JSON sentinel"
 [ "$(cat "$forged_temp_sentinel")" = "sentinel" ] \
   || fail "direct locked summary pruned a forged-root temporary sentinel"
+rendezvous_outside_ready="$tmp_dir/rendezvous-outside-ready"
+rendezvous_outside_release="$tmp_dir/rendezvous-outside-release"
+rendezvous_target="$state_root/rendezvous-inert.json"
+printf 'sentinel\n' > "$rendezvous_outside_ready"
+printf 'sentinel\n' > "$rendezvous_outside_release"
+printf '{}\n' | FG_STATE_TEST_TEMP_READY="$rendezvous_outside_ready" \
+  FG_STATE_TEST_TEMP_RELEASE="$rendezvous_outside_release" \
+  "$state_file_helper" --root "$state_root" write "${rendezvous_target##*/}" 128 \
+  || fail "invalid test rendezvous blocked an anchored write"
+[ "$(cat "$rendezvous_outside_ready")" = "sentinel" ] \
+  || fail "invalid test rendezvous wrote outside the state root"
+[ "$(cat "$rendezvous_outside_release")" = "sentinel" ] \
+  || fail "invalid test rendezvous read or wrote outside the state root"
+rm -f "$rendezvous_target"
+
+direct_race_root="$tmp_dir/direct-race-workspace"
+mkdir -p "$direct_race_root"
+git init -q "$direct_race_root"
+direct_race_root=$(CDPATH= cd -- "$direct_race_root" && pwd -P)
+direct_race_session_id='direct-final-symlink-race'
+direct_race_workspace_key=$(workspace_key_for_test "$direct_race_root")
+direct_race_session_key=$(session_key_for_test "$direct_race_session_id")
+direct_race_state_file="$state_root/$direct_race_workspace_key-$direct_race_session_key.json"
+direct_race_outside="$tmp_dir/direct-race-outside"
+direct_race_ready='test-direct-race-ready'
+direct_race_release='test-direct-race-release'
+mkdir -p "$direct_race_outside"
+: > "$state_root/$direct_race_ready"
+: > "$state_root/$direct_race_release"
+(
+  XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
+    FG_STATE_TEST_TEMP_READY="$direct_race_ready" FG_STATE_TEST_TEMP_RELEASE="$direct_race_release" \
+    "$state_helper" --locked-update 131072 64 "$direct_race_root" "$direct_race_session_id" \
+      'direct-race.py' medium "$direct_locked_record"
+) > "$tmp_dir/direct-race-output" 2>&1 &
+direct_race_pid=$!
+for _ in $(seq 1 80); do
+  [ -s "$state_root/$direct_race_ready" ] && break
+  sleep 0.05
+done
+[ -s "$state_root/$direct_race_ready" ] || fail "direct symlink race did not reach state temp"
+ln -s "$direct_race_outside" "$direct_race_state_file"
+printf 'release\n' > "$state_root/$direct_race_release"
+set +e
+wait "$direct_race_pid"
+direct_race_status=$?
+set -e
+[ "$direct_race_status" -ne 0 ] || fail "direct symlink race did not fail closed"
+[ -L "$direct_race_state_file" ] || fail "direct symlink race replaced its final symlink"
+[ -z "$(find "$direct_race_outside" -type f -print)" ] \
+  || fail "direct symlink race wrote outside the cache"
+rm -f "$direct_race_state_file"
+
+normal_race_root="$tmp_dir/normal-race-workspace"
+mkdir -p "$normal_race_root"
+git init -q "$normal_race_root"
+normal_race_root=$(CDPATH= cd -- "$normal_race_root" && pwd -P)
+normal_race_session_id='normal-final-symlink-race'
+normal_race_workspace_key=$(workspace_key_for_test "$normal_race_root")
+normal_race_session_key=$(session_key_for_test "$normal_race_session_id")
+normal_race_state_file="$state_root/$normal_race_workspace_key-$normal_race_session_key.json"
+normal_race_outside="$tmp_dir/normal-race-outside"
+normal_race_ready='test-normal-race-ready'
+normal_race_release='test-normal-race-release'
+mkdir -p "$normal_race_outside"
+: > "$state_root/$normal_race_ready"
+: > "$state_root/$normal_race_release"
+(
+  export XDG_CACHE_HOME="$cache_dir"
+  export PATH="$fake_bin:$PATH"
+  export FG_STATE_TEST_TEMP_READY="$normal_race_ready"
+  export FG_STATE_TEST_TEMP_RELEASE="$normal_race_release"
+  . "$state_helper"
+  fg_state_update_file "$normal_race_session_id" "$normal_race_root" 'normal-race.py' medium "$direct_locked_record"
+) > "$tmp_dir/normal-race-output" 2>&1 &
+normal_race_pid=$!
+for _ in $(seq 1 80); do
+  [ -s "$state_root/$normal_race_ready" ] && break
+  sleep 0.05
+done
+[ -s "$state_root/$normal_race_ready" ] || fail "normal symlink race did not reach state temp"
+ln -s "$normal_race_outside" "$normal_race_state_file"
+printf 'release\n' > "$state_root/$normal_race_release"
+set +e
+wait "$normal_race_pid"
+normal_race_status=$?
+set -e
+[ "$normal_race_status" -ne 0 ] || fail "normal symlink race did not fail closed"
+[ -L "$normal_race_state_file" ] || fail "normal symlink race replaced its final symlink"
+[ -z "$(find "$normal_race_outside" -type f -print)" ] \
+  || fail "normal symlink race wrote outside the cache"
+rm -f "$normal_race_state_file"
+
+root_rename_cache="$tmp_dir/root-rename-cache"
+root_rename_root="$tmp_dir/root-rename-workspace"
+mkdir -p "$root_rename_root"
+git init -q "$root_rename_root"
+root_rename_root=$(CDPATH= cd -- "$root_rename_root" && pwd -P)
+root_rename_session_id='root-rename-race'
+root_rename_workspace_key=$(workspace_key_for_test "$root_rename_root")
+root_rename_session_key=$(session_key_for_test "$root_rename_session_id")
+root_rename_state_root="$root_rename_cache/foxguard/claude-code"
+root_rename_state_file="$root_rename_state_root/$root_rename_workspace_key-$root_rename_session_key.json"
+root_rename_moved_root="$tmp_dir/root-rename-moved"
+root_rename_outside="$tmp_dir/root-rename-outside"
+root_rename_ready='test-root-rename-ready'
+root_rename_release='test-root-rename-release'
+mkdir -p "$root_rename_state_root" "$root_rename_outside"
+: > "$root_rename_state_root/$root_rename_ready"
+: > "$root_rename_state_root/$root_rename_release"
+(
+  export XDG_CACHE_HOME="$root_rename_cache"
+  export PATH="$fake_bin:$PATH"
+  export FG_STATE_TEST_TEMP_READY="$root_rename_ready"
+  export FG_STATE_TEST_TEMP_RELEASE="$root_rename_release"
+  . "$state_helper"
+  fg_state_update_file "$root_rename_session_id" "$root_rename_root" 'root-rename.py' medium "$direct_locked_record"
+) > "$tmp_dir/root-rename-output" 2>&1 &
+root_rename_pid=$!
+for _ in $(seq 1 80); do
+  [ -s "$root_rename_state_root/$root_rename_ready" ] && break
+  sleep 0.05
+done
+[ -s "$root_rename_state_root/$root_rename_ready" ] || fail "root replacement test did not reach state temp"
+mv "$root_rename_state_root" "$root_rename_moved_root"
+ln -s "$root_rename_outside" "$root_rename_state_root"
+printf 'release\n' > "$root_rename_moved_root/$root_rename_release"
+wait "$root_rename_pid"
+[ -f "$root_rename_moved_root/${root_rename_state_file##*/}" ] \
+  || fail "root replacement lost its anchored state write"
+[ ! -e "$root_rename_outside/${root_rename_state_file##*/}" ] \
+  || fail "root replacement wrote through its replacement"
+[ -z "$(find "$root_rename_outside" -type f -print)" ] \
+  || fail "root replacement created a file outside the anchored root"
 
 
 run_scan_without_perl finding "$no_perl_payload"
@@ -812,7 +937,7 @@ lock_hardlink_mode=$(file_mode "$lock_hardlink_sentinel")
 rm -f "$state_root/.lock"
 ln "$lock_hardlink_sentinel" "$state_root/.lock"
 lock_hardlink_links=$(file_links "$lock_hardlink_sentinel")
-if perl "$lock_wrapper" "$state_root/.lock" /usr/bin/true; then
+if perl "$lock_wrapper" "$state_root" .lock /usr/bin/true; then
   fail "hard-linked lock was accepted"
 fi
 [ "$(cat "$lock_hardlink_sentinel")" = "$lock_hardlink_content" ] \
@@ -822,7 +947,7 @@ fi
 [ "$(file_links "$lock_hardlink_sentinel")" = "$lock_hardlink_links" ] \
   || fail "lock wrapper changed an outside hard-linked lock link count"
 rm -f "$state_root/.lock"
-perl "$lock_wrapper" "$state_root/.lock" /usr/bin/true \
+perl "$lock_wrapper" "$state_root" .lock /usr/bin/true \
   || fail "lock wrapper did not create a normal lock"
 [ "$(file_mode "$state_root/.lock")" = "0600" ] || fail "normal lock mode is not 0600"
 
@@ -857,28 +982,30 @@ jq -e '.files | has("kernel-lock.py")' "$concurrent_state_file" >/dev/null \
   || fail "state update did not recover after a crashed lock holder"
 [ -f "$state_root/.lock" ] && [ ! -L "$state_root/.lock" ] \
   || fail "state lock is not a regular persistent file"
-atomic_ready="$tmp_dir/atomic-write-ready"
+atomic_ready='test-atomic-ready'
+atomic_release='test-atomic-release'
 atomic_session_id='atomic-write-interrupt'
 atomic_session_key=$(session_key_for_test "$atomic_session_id")
 atomic_target="$state_root/$workspace_key-$atomic_session_key.json"
+: > "$state_root/$atomic_ready"
+: > "$state_root/$atomic_release"
 
 (
-  XDG_CACHE_HOME="$cache_dir"
-  PATH="$fake_bin:$PATH"
+  export XDG_CACHE_HOME="$cache_dir"
+  export PATH="$fake_bin:$PATH"
+  export FG_STATE_TEST_TEMP_READY="$atomic_ready"
+  export FG_STATE_TEST_TEMP_RELEASE="$atomic_release"
   . "$state_helper"
-  mv() {
-    bash -c 'printf "%s\n" "$PPID"' > "$atomic_ready"
-    while :; do sleep 1; done
-  }
+  fg_state_prepare_locked_state "$root" "$atomic_session_id"
   fg_state_atomic_write "$root" "$atomic_session_id" '{"metadata":"only"}'
 ) &
 atomic_holder_pid=$!
 for _ in $(seq 1 80); do
-  [ -f "$atomic_ready" ] && break
+  [ -s "$state_root/$atomic_ready" ] && break
   sleep 0.05
 done
-[ -f "$atomic_ready" ] || fail "atomic write did not reach move"
-atomic_owner_pid=$(cat "$atomic_ready")
+[ -s "$state_root/$atomic_ready" ] || fail "atomic write did not reach move"
+atomic_owner_pid=$(cat "$state_root/$atomic_ready")
 kill -0 "$atomic_owner_pid" 2>/dev/null || fail "atomic write owner was not live"
 kill -TERM "$atomic_owner_pid"
 set +e
@@ -908,20 +1035,22 @@ jq -e '(.files | keys | sort) == ["kernel-lock.py", "one.py", "two.py"]' "$concu
   || fail "concurrent updates did not retain a regular lock file"
 
 paused_record=$(record_for_rule test/paused)
-paused_ready="$tmp_dir/paused-mv-ready"
-paused_release="$tmp_dir/paused-mv-release"
+paused_ready='test-paused-ready'
+paused_release='test-paused-release'
+: > "$state_root/$paused_ready"
+: > "$state_root/$paused_release"
 run_paused_state_update "$paused_root" 'one.py' "$paused_record" "$paused_ready" "$paused_release" &
 paused_one_pid=$!
 for _ in $(seq 1 80); do
-  [ -f "$paused_ready" ] && break
+  [ -s "$state_root/$paused_ready" ] && break
   sleep 0.05
 done
-[ -f "$paused_ready" ] || fail "paused update did not reach rename"
+[ -s "$state_root/$paused_ready" ] || fail "paused update did not reach rename"
 run_state_update "$paused_root" 'two.py' "$paused_record" &
 paused_two_pid=$!
 sleep 0.1
 kill -0 "$paused_two_pid" 2>/dev/null || fail "second update bypassed the paused writer"
-touch "$paused_release"
+printf 'release\n' > "$state_root/$paused_release"
 wait "$paused_one_pid"
 wait "$paused_two_pid"
 jq -e '(.files | keys | sort) == ["one.py", "two.py"]' "$paused_state_file" >/dev/null \

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -19,9 +19,12 @@ no_scanner_bin="$tmp_dir/no-scanner-bin"
 state_root="$cache_dir/foxguard/claude-code"
 
 cleanup() {
+  if [ -n "${binding_pid:-}" ]; then
+    kill "$binding_pid" 2>/dev/null || true
+    wait "$binding_pid" 2>/dev/null || true
+  fi
   rm -rf "$tmp_dir"
 }
-trap cleanup EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -405,7 +408,8 @@ run_state_update() {
 
 run_locked_action() {
   set +e
-  locked_action_output=$(XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" "$state_helper" "$@" 2>&1)
+  locked_action_output=$(XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
+    perl "$lock_wrapper" "$state_root" .lock "$state_helper" "$@" 2>&1)
   locked_action_status=$?
   set -e
 }
@@ -431,7 +435,8 @@ start_fifo_state_write() {
   local directory=$1 target=$2 fifo=$3 output=$4
 
   mkfifo "$fifo"
-  "$state_file_helper" --root "$directory" write "$target" 128 < "$fifo" > "$output" 2>&1 &
+  perl "$lock_wrapper" "$directory" .lock "$state_file_helper" --root "$directory" write "$target" 128 \
+    < "$fifo" > "$output" 2>&1 &
   fifo_write_pid=$!
   exec 9> "$fifo"
 }
@@ -563,6 +568,78 @@ assert_not_contains "$state_content" SOURCE_SNIPPET_SECRET
 assert_not_contains "$state_content" "$root"
 assert_not_contains "$(basename "$state_file")" "$session_id"
 direct_locked_record=$(record_for_rule test/direct-locked)
+if XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" "$state_helper" \
+  --locked-update 131072 64 "$root" "$session_id" 'direct-without-fd.py' medium "$direct_locked_record"; then
+  fail "direct locked action ran without an inherited state directory fd"
+fi
+[ "$(cat "$state_file")" = "$state_content" ] \
+  || fail "unverified direct locked action changed cache state"
+
+binding_cache="$tmp_dir/locked-binding-cache"
+binding_state_root="$binding_cache/foxguard/claude-code"
+binding_original_root="$tmp_dir/locked-binding-original"
+binding_workspace="$tmp_dir/locked-binding-workspace"
+binding_session_id='locked-binding-session'
+mkdir -p "$binding_state_root" "$binding_workspace"
+git init -q "$binding_workspace"
+binding_workspace=$(CDPATH= cd -- "$binding_workspace" && pwd -P)
+binding_workspace_key=$(workspace_key_for_test "$binding_workspace")
+binding_session_key=$(session_key_for_test "$binding_session_id")
+binding_state_name="$binding_workspace_key-$binding_session_key.json"
+binding_ready="$tmp_dir/locked-binding-ready"
+binding_fifo="$tmp_dir/locked-binding.fifo"
+binding_replacement_json="$binding_state_root/replacement-stale.json"
+binding_replacement_temp="$binding_state_root/.state.replacement"
+mkfifo "$binding_fifo"
+exec 7<> "$binding_fifo"
+XDG_CACHE_HOME="$binding_cache" PATH="$fake_bin:$PATH" \
+  perl "$lock_wrapper" "$binding_state_root" .lock /bin/bash -c '
+    exec 7>&-
+    printf "ready\n" > "$1" || exit 1
+    IFS= read -r _ < "$2" || exit 1
+    exec "$3" --locked-update 131072 64 "$4" "$5" replacement.py medium "$6"
+  ' bash "$binding_ready" "$binding_fifo" "$state_helper" "$binding_workspace" \
+  "$binding_session_id" "$direct_locked_record" > "$tmp_dir/locked-binding-output" 2>&1 &
+binding_pid=$!
+for _ in $(seq 1 80); do
+  [ -f "$binding_ready" ] && break
+  sleep 0.05
+done
+[ -f "$binding_ready" ] || fail "locked binding child did not reach FIFO gate"
+mv "$binding_state_root" "$binding_original_root"
+mkdir "$binding_state_root"
+state_for_path 'replacement-stale.py' > "$binding_replacement_json"
+chmod 600 "$binding_replacement_json"
+printf 'sentinel\n' > "$binding_replacement_temp"
+touch -t 200001010000 "$binding_replacement_json" "$binding_replacement_temp"
+binding_replacement_json_content=$(cat "$binding_replacement_json")
+binding_replacement_json_mtime=$(file_mtime "$binding_replacement_json")
+binding_replacement_temp_mtime=$(file_mtime "$binding_replacement_temp")
+printf 'release\n' >&7
+exec 7>&-
+set +e
+wait "$binding_pid"
+binding_status=$?
+set -e
+unset binding_pid
+[ "$(cat "$binding_replacement_json")" = "$binding_replacement_json_content" ] \
+  || fail "locked action changed replacement stale JSON"
+[ "$(file_mtime "$binding_replacement_json")" = "$binding_replacement_json_mtime" ] \
+  || fail "locked action touched replacement stale JSON"
+[ "$(cat "$binding_replacement_temp")" = "sentinel" ] \
+  || fail "locked action pruned replacement temporary state"
+[ "$(file_mtime "$binding_replacement_temp")" = "$binding_replacement_temp_mtime" ] \
+  || fail "locked action touched replacement temporary state"
+[ ! -e "$binding_state_root/$binding_state_name" ] \
+  || fail "locked action wrote replacement state"
+if [ "$binding_status" = 0 ]; then
+  [ -f "$binding_original_root/$binding_state_name" ] \
+    || fail "successful locked action did not use original state root"
+else
+  [ ! -e "$binding_original_root/$binding_state_name" ] \
+    || fail "failed locked action mutated original state root"
+fi
+
 forged_fd_root="$tmp_dir/forged-fd-workspace"
 mkdir -p "$forged_fd_root"
 git init -q "$forged_fd_root"

--- a/plugins/claude-code/tests/test-compaction-state.sh
+++ b/plugins/claude-code/tests/test-compaction-state.sh
@@ -1,0 +1,921 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd -P)
+scan_hook="$root/plugins/claude-code/scripts/scan-edited-file.sh"
+restore_hook="$root/plugins/claude-code/scripts/restore-unresolved-findings.sh"
+state_helper="$root/plugins/claude-code/scripts/finding-state.sh"
+lock_wrapper="$root/plugins/claude-code/scripts/with-state-lock.pl"
+hooks_json="$root/plugins/claude-code/hooks/hooks.json"
+fixture="$root/tests/fixtures/safe.py"
+session_id="compaction-test-588"
+tmp_dir=$(mktemp -d)
+cache_dir="$tmp_dir/cache"
+fake_bin="$tmp_dir/bin"
+pause_bin="$tmp_dir/pause-bin"
+no_perl_bin="$tmp_dir/no-perl-bin"
+no_scanner_bin="$tmp_dir/no-scanner-bin"
+state_root="$cache_dir/foxguard/claude-code"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_status() {
+  [ "$1" = "$2" ] || fail "expected exit $2, got $1"
+}
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) ;;
+    *) fail "expected output containing $2" ;;
+  esac
+}
+
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) fail "unexpected output containing $2" ;;
+    *) ;;
+  esac
+}
+
+assert_line() {
+  case $'\n'"$1"$'\n' in
+    *$'\n'"$2"$'\n'*) ;;
+    *) fail "expected exact line $2" ;;
+  esac
+}
+
+hash_for_test() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s\0' "$@" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s\0' "$@" | sha256sum | awk '{print $1}'
+  else
+    printf '%s\0' "$@" | openssl dgst -sha256 | awk '{print $NF}'
+  fi
+}
+
+fingerprint_for_test() {
+  hash_for_test "$@"
+}
+
+workspace_key_for_test() {
+  hash_for_test "foxguard-claude-code-workspace-v1" "$1"
+}
+
+session_key_for_test() {
+  hash_for_test "foxguard-claude-code-session-v1" "$1"
+}
+
+state_for_path() {
+  jq -cn --arg path "$1" '
+    {
+      version: 3,
+      overflow: 0,
+      omitted: [],
+      files: {
+        ($path): {
+          threshold: "medium",
+          total: 1,
+          truncated: false,
+          findings: [{
+            fingerprint: ([range(0;64) | "a"] | join("")),
+            rule_id: "test/no-danger",
+            severity: "high",
+            line: 1,
+            column: 1
+          }]
+        }
+      }
+    }
+  '
+}
+record_for_rule() {
+  jq -cn --arg rule_id "$1" '
+    {
+      total: 1,
+      truncated: false,
+      findings: [{
+        fingerprint: ([range(0;64) | "b"] | join("")),
+        rule_id: $rule_id,
+        severity: "high",
+        line: 7,
+        column: 3
+      }]
+    }
+  '
+}
+
+mkdir -p "$fake_bin" "$pause_bin" "$no_perl_bin" "$no_scanner_bin"
+cat > "$fake_bin/foxguard" <<'EOF'
+#!/usr/bin/env bash
+case "${FOXGUARD_TEST_MODE:-finding}" in
+  finding)
+    printf '%s\n' '{"findings":[{"rule_id":"test/no-danger","severity":"high","line":7,"column":3,"description":"FINDING_SECRET","cwe":"CWE-79","snippet":"SOURCE_SNIPPET_SECRET"}]}'
+    exit 1
+    ;;
+  alternate)
+    printf '%s\n' '{"findings":[{"rule_id":"test/no-danger","severity":"high","line":7,"column":3,"description":"OTHER_FINDING_SECRET","cwe":"CWE-79","snippet":"OTHER_SOURCE_SNIPPET_SECRET"}]}'
+    exit 1
+    ;;
+  other)
+    printf '%s\n' '{"findings":[{"rule_id":"test/other-danger","severity":"high","line":7,"column":3,"description":"OTHER_FINDING_SECRET","cwe":"CWE-79","snippet":"OTHER_SOURCE_SNIPPET_SECRET"}]}'
+    exit 1
+    ;;
+  hostile)
+    printf '%s\n' '{"findings":[{"rule_id":"test/hostile-rule","severity":"high","line":7,"column":3,"description":"HOSTILE_FINDING_SECRET","cwe":"CWE-79","snippet":"HOSTILE_SOURCE_SECRET"}]}'
+    exit 1
+    ;;
+  clean)
+    printf '%s\n' '{"findings":[]}'
+    exit 0
+    ;;
+  invalid)
+    printf '%s\n' 'not-json'
+    exit 2
+    ;;
+  empty_error)
+    printf '%s\n' '{"findings":[]}'
+    exit 2
+    ;;
+  error)
+    printf '%s\n' '{"error":"scanner failure"}'
+    exit 2
+    ;;
+  many)
+    jq -n '[range(0;90) | {rule_id:("test/rule-" + tostring), severity:"high", line:(. + 1), column:1, description:"FINDING_SECRET", snippet:"SOURCE_SNIPPET_SECRET"}]'
+    exit 1
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/foxguard"
+# State helpers must not rely on `sh` being Bash; CI commonly uses dash.
+cat > "$fake_bin/sh" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+chmod +x "$fake_bin/sh"
+cat > "$no_perl_bin/perl" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+chmod +x "$no_perl_bin/perl"
+cat > "$pause_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+if [ "${FG_STATE_TEST_PAUSE_MV:-}" = "1" ]; then
+  : > "$FG_STATE_TEST_MV_READY"
+  while [ ! -f "$FG_STATE_TEST_MV_RELEASE" ]; do sleep 0.05; done
+fi
+exec /bin/mv "$@"
+EOF
+chmod +x "$pause_bin/mv"
+jq_path=$(command -v jq)
+case "$jq_path" in
+  /*) ;;
+  *) fail "jq command is not an absolute path" ;;
+esac
+ln -s "$jq_path" "$no_scanner_bin/jq"
+cat > "$no_scanner_bin/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 2
+EOF
+chmod +x "$no_scanner_bin/npx"
+
+
+workspace_key=$(workspace_key_for_test "$root")
+session_key=$(session_key_for_test "$session_id")
+state_file="$state_root/$workspace_key-$session_key.json"
+other_root="$tmp_dir/other-workspace"
+mkdir -p "$other_root/.github"
+git init -q "$other_root"
+other_root=$(CDPATH= cd -- "$other_root" && pwd -P)
+other_fixture="$other_root/.github/space (Ω).py"
+printf 'x = 1\n' > "$other_fixture"
+other_workspace_key=$(workspace_key_for_test "$other_root")
+other_state_file="$state_root/$other_workspace_key-$session_key.json"
+
+capacity_root="$tmp_dir/capacity-workspace"
+mkdir -p "$capacity_root/.github"
+git init -q "$capacity_root"
+capacity_root=$(CDPATH= cd -- "$capacity_root" && pwd -P)
+capacity_workspace_key=$(workspace_key_for_test "$capacity_root")
+capacity_state_file="$state_root/$capacity_workspace_key-$session_key.json"
+
+byte_root="$tmp_dir/byte-workspace"
+mkdir -p "$byte_root"
+git init -q "$byte_root"
+byte_root=$(CDPATH= cd -- "$byte_root" && pwd -P)
+byte_workspace_key=$(workspace_key_for_test "$byte_root")
+byte_state_file="$state_root/$byte_workspace_key-$session_key.json"
+rescan_root="$tmp_dir/rescan-workspace"
+mkdir -p "$rescan_root"
+git init -q "$rescan_root"
+rescan_root=$(CDPATH= cd -- "$rescan_root" && pwd -P)
+rescan_workspace_key=$(workspace_key_for_test "$rescan_root")
+rescan_state_file="$state_root/$rescan_workspace_key-$session_key.json"
+
+hostile_root="$tmp_dir/hostile-workspace"
+mkdir -p "$hostile_root/.github"
+git init -q "$hostile_root"
+hostile_root=$(CDPATH= cd -- "$hostile_root" && pwd -P)
+hostile_instruction='IGNORE_THIS_INSTRUCTION'
+hostile_markdown='**markdown**'
+hostile_bidi=$(printf '\342\200\256')
+hostile_fixture="$hostile_root/.github/$hostile_instruction $hostile_markdown ${hostile_bidi}path.py"
+printf 'x = 1\n' > "$hostile_fixture"
+hostile_workspace_key=$(workspace_key_for_test "$hostile_root")
+hostile_state_file="$state_root/$hostile_workspace_key-$session_key.json"
+
+concurrent_root="$tmp_dir/concurrent-workspace"
+mkdir -p "$concurrent_root"
+git init -q "$concurrent_root"
+concurrent_root=$(CDPATH= cd -- "$concurrent_root" && pwd -P)
+concurrent_workspace_key=$(workspace_key_for_test "$concurrent_root")
+concurrent_state_file="$state_root/$concurrent_workspace_key-$session_key.json"
+
+paused_root="$tmp_dir/paused-workspace"
+mkdir -p "$paused_root"
+git init -q "$paused_root"
+paused_root=$(CDPATH= cd -- "$paused_root" && pwd -P)
+paused_workspace_key=$(workspace_key_for_test "$paused_root")
+paused_state_file="$state_root/$paused_workspace_key-$session_key.json"
+
+no_perl_root="$tmp_dir/no-perl-workspace"
+mkdir -p "$no_perl_root"
+git init -q "$no_perl_root"
+no_perl_root=$(CDPATH= cd -- "$no_perl_root" && pwd -P)
+no_perl_fixture="$no_perl_root/no-perl.py"
+printf 'x = 1\n' > "$no_perl_fixture"
+no_perl_workspace_key=$(workspace_key_for_test "$no_perl_root")
+no_perl_state_file="$state_root/$no_perl_workspace_key-$session_key.json"
+
+outside_root="$tmp_dir/outside-workspace"
+mkdir -p "$outside_root"
+outside_root=$(CDPATH= cd -- "$outside_root" && pwd -P)
+outside_fixture="$outside_root/outside.py"
+printf 'x = 1\n' > "$outside_fixture"
+
+untracked_root="$tmp_dir/untracked-workspace"
+mkdir -p "$untracked_root"
+git init -q "$untracked_root"
+untracked_root=$(CDPATH= cd -- "$untracked_root" && pwd -P)
+untracked_workspace_key=$(workspace_key_for_test "$untracked_root")
+untracked_state_file="$state_root/$untracked_workspace_key-$session_key.json"
+
+plugin_root_with_spaces="$tmp_dir/plugin root"
+mkdir -p "$plugin_root_with_spaces"
+ln -s "$root/plugins/claude-code/scripts" "$plugin_root_with_spaces/scripts"
+
+containment_root="$tmp_dir/containment-workspace"
+mkdir -p "$containment_root"
+git init -q "$containment_root"
+containment_root=$(CDPATH= cd -- "$containment_root" && pwd -P)
+containment_alias_name=$(printf '%s' "${containment_root##*/}" | tr '[:lower:]' '[:upper:]')
+containment_alias="${containment_root%/*}/$containment_alias_name"
+
+edit_payload=$(jq -cn --arg session "$session_id" --arg cwd "$root" --arg path "$fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+relative_edit_payload=$(jq -cn --arg session "$session_id" --arg cwd "$root" --arg path 'tests/fixtures/safe.py' \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+other_edit_payload=$(jq -cn --arg session "$session_id" --arg cwd "$other_root" --arg path "$other_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+other_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$other_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+capacity_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+byte_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$byte_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+rescan_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$rescan_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+hostile_edit_payload=$(jq -cn --arg session "$session_id" --arg cwd "$hostile_root" --arg path "$hostile_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+hostile_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$hostile_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+other_session_compact_payload=$(jq -cn --arg session 'prune-test-session' --arg cwd "$capacity_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+foo_compact_payload=$(jq -cn --arg session 'foo' --arg cwd "$root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+old_foo_session_key=$(session_key_for_test 'old-foo')
+old_foo_state_file="$state_root/$workspace_key-$old_foo_session_key.json"
+startup_payload=$(jq -cn --arg session "$session_id" --arg cwd "$root" \
+  '{session_id:$session, cwd:$cwd, source:"startup"}')
+no_perl_payload=$(jq -cn --arg session "$session_id" --arg cwd "$no_perl_root" --arg path "$no_perl_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+outside_payload=$(jq -cn --arg session "$session_id" --arg cwd "$outside_root" --arg path "$outside_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+missing_payload=$(jq -cn --arg session "$session_id" --arg cwd "$root" --arg path "$root/does-not-exist.py" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+
+run_scan() {
+  local mode=$1 payload
+
+  payload=${2:-"$edit_payload"}
+  set +e
+  scan_output=$(printf '%s' "$payload" | \
+    FOXGUARD_TEST_MODE="$mode" XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
+      "$scan_hook" 2>&1)
+  scan_status=$?
+  set -e
+}
+
+run_scan_without_perl() {
+  local mode=$1 payload=$2
+
+  set +e
+  scan_output=$(printf '%s' "$payload" | \
+    FOXGUARD_TEST_MODE="$mode" XDG_CACHE_HOME="$cache_dir" PATH="$no_perl_bin:$fake_bin:$PATH" \
+      "$scan_hook" 2>&1)
+  scan_status=$?
+  set -e
+}
+
+run_scan_without_scanner() {
+  local payload=$1
+
+  set +e
+  scan_output=$(printf '%s' "$payload" | \
+    XDG_CACHE_HOME="$cache_dir" PATH="$no_scanner_bin:/usr/bin:/bin" "$scan_hook" 2>&1)
+  scan_status=$?
+  set -e
+}
+
+run_restore_with_cache() {
+  local payload=$1 cache_home=$2
+
+  set +e
+  restore_output=$(printf '%s' "$payload" | \
+    XDG_CACHE_HOME="$cache_home" PATH="$fake_bin:$PATH" "$restore_hook" 2>&1)
+  restore_status=$?
+  set -e
+}
+
+run_restore() {
+  run_restore_with_cache "$1" "$cache_dir"
+}
+
+run_state_root() {
+  local cache_home=$1 repo_root=$2
+
+  set +e
+  state_root_output=$(
+    (
+      XDG_CACHE_HOME="$cache_home"
+      . "$state_helper"
+      fg_state_root "$repo_root"
+    ) 2>&1
+  )
+  state_root_status=$?
+  set -e
+}
+run_state_update() {
+  local repo_root=$1 relative_path=$2 record=$3 state_session=${4:-$session_id}
+
+  (
+    XDG_CACHE_HOME="$cache_dir"
+    PATH="$fake_bin:$PATH"
+    . "$state_helper"
+    fg_state_update_file "$state_session" "$repo_root" "$relative_path" medium "$record"
+  )
+}
+
+run_paused_state_update() {
+  local repo_root=$1 relative_path=$2 record=$3 ready_file=$4 release_file=$5
+
+  (
+    export XDG_CACHE_HOME="$cache_dir"
+    export PATH="$pause_bin:$fake_bin:$PATH"
+    export FG_STATE_TEST_PAUSE_MV=1
+    export FG_STATE_TEST_MV_READY="$ready_file"
+    export FG_STATE_TEST_MV_RELEASE="$release_file"
+    . "$state_helper"
+    fg_state_update_file "$session_id" "$repo_root" "$relative_path" medium "$record"
+  )
+}
+
+run_state_update_with_limit() {
+  local limit=$1 repo_root=$2 relative_path=$3 record=$4 state_session=${5:-$session_id}
+
+  (
+    XDG_CACHE_HOME="$cache_dir"
+    PATH="$fake_bin:$PATH"
+    . "$state_helper"
+    export FG_STATE_MAX_BYTES=$limit
+    fg_state_update_file "$state_session" "$repo_root" "$relative_path" medium "$record"
+  )
+}
+
+
+run_state_update_with_limits() {
+  local byte_limit=$1 omitted_limit=$2 repo_root=$3 relative_path=$4 record=$5
+
+  (
+    XDG_CACHE_HOME="$cache_dir"
+    PATH="$fake_bin:$PATH"
+    . "$state_helper"
+    export FG_STATE_MAX_BYTES=$byte_limit
+    export FG_STATE_MAX_OMITTED=$omitted_limit
+    fg_state_update_file "$session_id" "$repo_root" "$relative_path" medium "$record"
+  )
+}
+run_configured_post_hook() {
+  set +e
+  configured_post_output=$(printf '%s' "$edit_payload" | \
+    CLAUDE_PLUGIN_ROOT="$plugin_root_with_spaces" FOXGUARD_TEST_MODE=finding \
+      XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" bash -c "$post_hook_command" 2>&1)
+  configured_post_status=$?
+  set -e
+}
+
+run_configured_restore_hook() {
+  set +e
+  configured_restore_output=$(printf '%s' "$compact_payload" | \
+    CLAUDE_PLUGIN_ROOT="$plugin_root_with_spaces" XDG_CACHE_HOME="$cache_dir" PATH="$fake_bin:$PATH" \
+      bash -c "$restore_hook_command" 2>&1)
+  configured_restore_status=$?
+  set -e
+}
+jq -e '
+  ([.hooks.PostToolUse[] | .hooks[] |
+    select(.command == "\"${CLAUDE_PLUGIN_ROOT}/scripts/scan-edited-file.sh\"")
+  ] | length) == 1
+  and
+  ([.hooks.SessionStart[] |
+    select(.hooks | any(.[]; .command == "cat \"${CLAUDE_PLUGIN_ROOT}/scripts/secure-defaults.txt\""))
+  ] | length) == 1
+  and
+  ([.hooks.SessionStart[] |
+    select(.matcher == "compact"
+      and (.hooks | any(.[]; .command == "\"${CLAUDE_PLUGIN_ROOT}/scripts/restore-unresolved-findings.sh\"")))
+  ] | length) == 1
+' "$hooks_json" >/dev/null
+post_hook_command=$(jq -r '.hooks.PostToolUse[0].hooks[0].command' "$hooks_json")
+restore_hook_command=$(jq -r '.hooks.SessionStart[] | select(.matcher == "compact") | .hooks[0].command' "$hooks_json")
+
+bash -n "$scan_hook"
+bash -n "$state_helper"
+bash -n "$restore_hook"
+perl -c "$lock_wrapper" >/dev/null
+jq empty "$hooks_json"
+for unsafe_path in '/absolute.py' 'C:/absolute.py' 'dir//empty.py' './dot.py' 'dir/../up.py' \
+  $'control\001path.py' 'dir\backslash.py'; do
+  if state_for_path "$unsafe_path" | ( . "$state_helper"; fg_state_validate >/dev/null 2>&1 ); then
+    fail "unsafe relative path was accepted"
+  fi
+done
+
+run_state_root "$containment_root/.cache" "$containment_root"
+[ "$state_root_status" -ne 0 ] || fail "repository cache path was accepted"
+[ -z "$state_root_output" ] || fail "repository cache path emitted diagnostics"
+[ ! -e "$containment_root/.cache" ] || fail "state landed in checkout"
+if [[ "$containment_alias" -ef "$containment_root" ]]; then
+  run_state_root "$containment_alias/.case-cache" "$containment_root"
+  [ "$state_root_status" -ne 0 ] || fail "case-folded repository cache path was accepted"
+  [ -z "$state_root_output" ] || fail "case-folded repository cache path emitted diagnostics"
+  [ ! -e "$containment_root/.case-cache" ] || fail "case-folded state landed in checkout"
+fi
+run_configured_post_hook
+assert_status "$configured_post_status" 2
+assert_contains "$configured_post_output" FINDING_SECRET
+
+run_scan finding
+assert_status "$scan_status" 2
+assert_contains "$scan_output" FINDING_SECRET
+assert_contains "$scan_output" SOURCE_SNIPPET_SECRET
+[ -f "$state_file" ] || fail "finding scan did not create state"
+jq -e --arg path 'tests/fixtures/safe.py' '
+  .version == 3
+  and .overflow == 0
+  and .omitted == []
+  and (.files | keys == [$path])
+  and (.files[$path].threshold == "medium")
+  and (.files[$path].total == 1)
+  and (.files[$path].truncated == false)
+  and ((.files[$path].findings[0] | keys | sort) == ["column", "fingerprint", "line", "rule_id", "severity"])
+' "$state_file" >/dev/null || fail "state schema is not metadata-only"
+if jq -e '.. | objects | select(has("description") or has("snippet") or has("cwe") or has("dataflow"))' "$state_file" >/dev/null; then
+  fail "state retained a forbidden finding field"
+fi
+state_content=$(cat "$state_file")
+assert_not_contains "$state_content" FINDING_SECRET
+assert_not_contains "$state_content" SOURCE_SNIPPET_SECRET
+assert_not_contains "$state_content" "$root"
+assert_not_contains "$(basename "$state_file")" "$session_id"
+
+run_scan_without_perl finding "$no_perl_payload"
+assert_status "$scan_status" 2
+assert_contains "$scan_output" FINDING_SECRET
+[ ! -e "$no_perl_state_file" ] || fail "missing Perl persisted state"
+
+run_scan finding '{}'
+assert_status "$scan_status" 0
+[ -z "$scan_output" ] || fail "missing hook input produced feedback"
+run_scan finding "$missing_payload"
+assert_status "$scan_status" 0
+[ -z "$scan_output" ] || fail "missing file produced feedback"
+run_scan_without_scanner "$edit_payload"
+assert_status "$scan_status" 0
+[ -z "$scan_output" ] || fail "missing scanner produced feedback"
+[ "$(cat "$state_file")" = "$state_content" ] || fail "failed hook machinery changed state"
+
+run_scan finding "$outside_payload"
+assert_status "$scan_status" 2
+assert_contains "$scan_output" FINDING_SECRET
+
+finding_fingerprint=$(jq -r --arg path 'tests/fixtures/safe.py' '.files[$path].findings[0].fingerprint' "$state_file")
+expected_fingerprint=$(fingerprint_for_test 'tests/fixtures/safe.py' test/no-danger high 7 3)
+[ "$finding_fingerprint" = "$expected_fingerprint" ] || fail "fingerprint used non-metadata input"
+finding_identifier=${finding_fingerprint:0:12}
+run_configured_restore_hook
+assert_status "$configured_restore_status" 0
+assert_contains "$configured_restore_output" "finding $finding_identifier"
+assert_not_contains "$configured_restore_output" 'tests/fixtures/safe.py'
+assert_not_contains "$configured_restore_output" 'test/no-danger'
+run_scan clean "$relative_edit_payload"
+assert_status "$scan_status" 0
+[ ! -e "$state_file" ] || fail "relative clean re-scan did not clear an absolute finding"
+run_scan finding "$relative_edit_payload"
+assert_status "$scan_status" 2
+[ -f "$state_file" ] || fail "relative finding scan did not create state"
+run_scan alternate
+assert_status "$scan_status" 2
+[ "$(jq -r --arg path 'tests/fixtures/safe.py' '.files[$path].findings[0].fingerprint' "$state_file")" = "$finding_fingerprint" ] \
+  || fail "fingerprint was not stable across source-only changes"
+alternate_content=$(cat "$state_file")
+assert_not_contains "$alternate_content" OTHER_FINDING_SECRET
+assert_not_contains "$alternate_content" OTHER_SOURCE_SNIPPET_SECRET
+run_scan other "$other_edit_payload"
+assert_status "$scan_status" 2
+[ -f "$other_state_file" ] || fail "other workspace finding scan did not create state"
+jq -e --arg path '.github/space (Ω).py' '.files | keys == [$path]' "$other_state_file" >/dev/null \
+  || fail "valid .github, whitespace, Unicode, and parenthesized path was not retained"
+other_state_content=$(cat "$other_state_file")
+assert_not_contains "$other_state_content" "$other_root"
+
+run_restore "$compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'advisory feedback, not a final enforcement gate'
+assert_contains "$restore_output" "finding $finding_identifier"
+assert_contains "$restore_output" '/foxguard:scan'
+assert_line "$restore_output" "- [HIGH] finding $finding_identifier at line 7, column 3"
+assert_not_contains "$restore_output" FINDING_SECRET
+assert_not_contains "$restore_output" SOURCE_SNIPPET_SECRET
+assert_not_contains "$restore_output" 'test/no-danger'
+assert_not_contains "$restore_output" 'tests/fixtures/safe.py'
+
+other_finding_fingerprint=$(jq -r --arg path '.github/space (Ω).py' '.files[$path].findings[0].fingerprint' "$other_state_file")
+other_finding_identifier=${other_finding_fingerprint:0:12}
+run_restore "$other_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" "finding $other_finding_identifier"
+assert_not_contains "$restore_output" '.github/space ('
+assert_not_contains "$restore_output" 'test/other-danger'
+assert_not_contains "$restore_output" 'test/no-danger'
+run_scan hostile "$hostile_edit_payload"
+assert_status "$scan_status" 2
+[ -f "$hostile_state_file" ] || fail "hostile path scan did not create state"
+run_restore "$hostile_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'finding '
+assert_not_contains "$restore_output" "$hostile_instruction"
+assert_not_contains "$restore_output" "$hostile_markdown"
+assert_not_contains "$restore_output" "$hostile_bidi"
+assert_not_contains "$restore_output" 'test/hostile-rule'
+
+run_restore "$startup_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "ordinary SessionStart restored findings"
+stale_state_file="$state_root/expired-session.json"
+state_for_path 'stale.py' > "$stale_state_file"
+chmod 600 "$stale_state_file"
+touch -t 200001010000 "$state_file" "$other_state_file" "$stale_state_file"
+run_restore "$compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" "finding $finding_identifier"
+[ -f "$state_file" ] || fail "active session state expired before compaction"
+[ -f "$other_state_file" ] || fail "same-session workspace state was pruned"
+[ ! -e "$stale_state_file" ] || fail "inactive stale state was not pruned"
+[ -z "$(find "$state_file" -mtime +0 -print)" ] || fail "compaction did not refresh active state liveness"
+run_restore "$other_session_compact_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "unrelated session restored findings"
+[ -f "$state_file" ] || fail "active session state was pruned by another session"
+[ -f "$other_state_file" ] || fail "same-session workspace was pruned by another session"
+run_restore "$other_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" "finding $other_finding_identifier"
+[ -z "$(find "$other_state_file" -mtime +0 -print)" ] || fail "same-session workspace did not refresh on compaction"
+state_for_path 'old-foo.py' > "$old_foo_state_file"
+chmod 600 "$old_foo_state_file"
+touch -t 200001010000 "$old_foo_state_file"
+run_restore "$foo_compact_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "foo session restored another session's findings"
+[ ! -e "$old_foo_state_file" ] || fail "old-foo state matched foo session namespace"
+printf 'orphan\n' > "$state_root/.state.orphan-dead-owner"
+run_scan alternate
+assert_status "$scan_status" 2
+[ ! -e "$state_root/.state.orphan-dead-owner" ] || fail "orphan state temp was not pruned"
+
+lock_sentinel="$tmp_dir/lock-sentinel"
+printf 'sentinel\n' > "$lock_sentinel"
+rm -f "$state_root/.lock"
+ln -s "$lock_sentinel" "$state_root/.lock"
+if run_state_update "$concurrent_root" 'symlink.py' "$(record_for_rule test/symlink)"; then
+  fail "symlinked lock was accepted"
+fi
+[ "$(cat "$lock_sentinel")" = "sentinel" ] || fail "lock wrapper followed a symlink"
+rm -f "$state_root/.lock"
+
+kernel_lock_ready="$tmp_dir/kernel-lock-ready"
+perl -MFcntl=:flock -e '
+  open my $lock, ">>", $ARGV[0] or die $!;
+  flock($lock, LOCK_EX) or die $!;
+  open my $ready, ">", $ARGV[1] or die $!;
+  print {$ready} "ready\n";
+  close $ready or die $!;
+  sleep 30;
+' "$state_root/.lock" "$kernel_lock_ready" &
+kernel_lock_holder_pid=$!
+for _ in $(seq 1 80); do
+  [ -f "$kernel_lock_ready" ] && break
+  sleep 0.05
+done
+[ -f "$kernel_lock_ready" ] || fail "kernel lock holder did not start"
+run_state_update "$concurrent_root" 'kernel-lock.py' "$(record_for_rule test/kernel-lock)" &
+kernel_lock_update_pid=$!
+sleep 0.1
+kill -0 "$kernel_lock_update_pid" 2>/dev/null || fail "kernel lock did not exclude an update"
+kill -KILL "$kernel_lock_holder_pid"
+set +e
+wait "$kernel_lock_holder_pid"
+kernel_lock_holder_status=$?
+set -e
+[ "$kernel_lock_holder_status" -ne 0 ] || fail "crashed kernel lock holder exited cleanly"
+wait "$kernel_lock_update_pid"
+jq -e '.files | has("kernel-lock.py")' "$concurrent_state_file" >/dev/null \
+  || fail "state update did not recover after a crashed lock holder"
+[ -f "$state_root/.lock" ] && [ ! -L "$state_root/.lock" ] \
+  || fail "state lock is not a regular persistent file"
+atomic_ready="$tmp_dir/atomic-write-ready"
+atomic_target="$tmp_dir/atomic-write-target.json"
+(
+  XDG_CACHE_HOME="$cache_dir"
+  PATH="$fake_bin:$PATH"
+  . "$state_helper"
+  mv() {
+    bash -c 'printf "%s\n" "$PPID"' > "$atomic_ready"
+    while :; do sleep 1; done
+  }
+  fg_state_atomic_write "$state_root" "$atomic_target" '{"metadata":"only"}'
+) &
+atomic_holder_pid=$!
+for _ in $(seq 1 80); do
+  [ -f "$atomic_ready" ] && break
+  sleep 0.05
+done
+[ -f "$atomic_ready" ] || fail "atomic write did not reach move"
+atomic_owner_pid=$(cat "$atomic_ready")
+kill -0 "$atomic_owner_pid" 2>/dev/null || fail "atomic write owner was not live"
+kill -TERM "$atomic_owner_pid"
+set +e
+wait "$atomic_holder_pid"
+atomic_holder_status=$?
+set -e
+[ "$atomic_holder_status" -ne 0 ] || fail "interrupted atomic write exited cleanly"
+[ ! -e "$atomic_target" ] || fail "interrupted atomic write reached its destination"
+[ -z "$(find "$state_root" -type f -name '.state.*' -print)" ] \
+  || fail "interrupted atomic write left a state temp"
+
+concurrent_record=$(record_for_rule test/concurrent)
+stale_concurrent_state="$state_root/expired-concurrent.json"
+state_for_path 'expired-concurrent.py' > "$stale_concurrent_state"
+chmod 600 "$stale_concurrent_state"
+touch -t 200001010000 "$stale_concurrent_state"
+run_state_update "$concurrent_root" 'one.py' "$concurrent_record" &
+concurrent_one_pid=$!
+run_state_update "$concurrent_root" 'two.py' "$concurrent_record" &
+concurrent_two_pid=$!
+wait "$concurrent_one_pid"
+wait "$concurrent_two_pid"
+[ ! -e "$stale_concurrent_state" ] || fail "serialized prune retained stale state"
+jq -e '(.files | keys | sort) == ["kernel-lock.py", "one.py", "two.py"]' "$concurrent_state_file" >/dev/null \
+  || fail "concurrent state updates lost an entry"
+[ -f "$state_root/.lock" ] && [ ! -L "$state_root/.lock" ] \
+  || fail "concurrent updates did not retain a regular lock file"
+
+paused_record=$(record_for_rule test/paused)
+paused_ready="$tmp_dir/paused-mv-ready"
+paused_release="$tmp_dir/paused-mv-release"
+run_paused_state_update "$paused_root" 'one.py' "$paused_record" "$paused_ready" "$paused_release" &
+paused_one_pid=$!
+for _ in $(seq 1 80); do
+  [ -f "$paused_ready" ] && break
+  sleep 0.05
+done
+[ -f "$paused_ready" ] || fail "paused update did not reach rename"
+run_state_update "$paused_root" 'two.py' "$paused_record" &
+paused_two_pid=$!
+sleep 0.1
+kill -0 "$paused_two_pid" 2>/dev/null || fail "second update bypassed the paused writer"
+touch "$paused_release"
+wait "$paused_one_pid"
+wait "$paused_two_pid"
+jq -e '(.files | keys | sort) == ["one.py", "two.py"]' "$paused_state_file" >/dev/null \
+  || fail "paused concurrent updates lost an entry"
+
+run_scan clean
+assert_status "$scan_status" 0
+[ ! -e "$state_file" ] || fail "clean scan did not remove state"
+[ -f "$other_state_file" ] || fail "clean scan removed another workspace state"
+run_restore "$other_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" "finding $other_finding_identifier"
+
+run_scan finding
+assert_status "$scan_status" 2
+state_content=$(cat "$state_file")
+run_scan invalid
+assert_status "$scan_status" 0
+[ "$(cat "$state_file")" = "$state_content" ] || fail "invalid scanner output cleared state"
+run_scan error
+assert_status "$scan_status" 0
+[ "$(cat "$state_file")" = "$state_content" ] || fail "scanner error cleared state"
+run_scan empty_error
+assert_status "$scan_status" 0
+[ "$(cat "$state_file")" = "$state_content" ] || fail "empty scanner error cleared state"
+
+for index in $(seq 1 65); do
+  capacity_fixture="$capacity_root/.github/capacity-$index.py"
+  printf 'x = %s\n' "$index" > "$capacity_fixture"
+  capacity_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" --arg path "$capacity_fixture" \
+    '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+  run_scan finding "$capacity_payload"
+  assert_status "$scan_status" 2
+done
+[ -f "$capacity_state_file" ] || fail "capacity test did not create state"
+omitted_capacity_key=$(fingerprint_for_test "foxguard-claude-code-omitted-path-v1" '.github/capacity-65.py')
+jq -e --arg omitted "$omitted_capacity_key" \
+  '.version == 3 and .overflow == 0 and .omitted == [$omitted] and (.files | length) == 64' "$capacity_state_file" >/dev/null \
+  || fail "65th successful scan did not record its omitted path"
+run_restore "$capacity_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'Some successful scan results were omitted because the local continuity cache reached capacity.'
+
+capacity_unrelated_fixture="$capacity_root/.github/unrelated.py"
+printf 'x = 0\n' > "$capacity_unrelated_fixture"
+capacity_unrelated_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" --arg path "$capacity_unrelated_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+run_scan clean "$capacity_unrelated_payload"
+assert_status "$scan_status" 0
+jq -e --arg omitted "$omitted_capacity_key" '.omitted == [$omitted]' "$capacity_state_file" >/dev/null \
+  || fail "unrelated clean scan cleared an omitted-path marker"
+
+capacity_first_fixture="$capacity_root/.github/capacity-1.py"
+capacity_first_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" --arg path "$capacity_first_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+run_scan clean "$capacity_first_payload"
+assert_status "$scan_status" 0
+capacity_last_fixture="$capacity_root/.github/capacity-65.py"
+capacity_last_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" --arg path "$capacity_last_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+run_scan finding "$capacity_last_payload"
+assert_status "$scan_status" 2
+jq -e --arg path '.github/capacity-65.py' \
+  '.overflow == 0 and .omitted == [] and (.files | length) == 64 and (.files | has($path))' "$capacity_state_file" >/dev/null \
+  || fail "freed capacity did not retain the formerly omitted path"
+run_restore "$capacity_compact_payload"
+assert_status "$restore_status" 0
+assert_not_contains "$restore_output" 'Some successful scan results were omitted because the local continuity cache reached capacity.'
+for index in $(seq 1 65); do
+  capacity_fixture="$capacity_root/.github/capacity-$index.py"
+  capacity_payload=$(jq -cn --arg session "$session_id" --arg cwd "$capacity_root" --arg path "$capacity_fixture" \
+    '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+  run_scan clean "$capacity_payload"
+  assert_status "$scan_status" 0
+done
+[ ! -e "$capacity_state_file" ] || fail "clean scans did not remove all capacity state"
+run_restore "$capacity_compact_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "cleared capacity state still emitted a warning"
+
+large_record=$(jq -cn '
+  [range(0;64) |
+    . as $index |
+    {
+      fingerprint: ([range(0;64) | "f"] | join("")),
+      rule_id: ("test/" + ([range(0;115) | "a"] | join("")) + "-" + ($index | tostring)),
+      severity: "high",
+      line: ($index + 1),
+      column: 1
+    }
+  ] | {total: length, truncated: false, findings: .}
+')
+
+run_state_update_with_limits 2048 0 "$untracked_root" 'untracked.py' "$large_record"
+jq -e '.version == 3 and .overflow == 1 and .omitted == [] and .files == {}' "$untracked_state_file" >/dev/null \
+  || fail "untrackable capacity overflow was not retained"
+untracked_other_fixture="$untracked_root/other.py"
+printf 'x = 0\n' > "$untracked_other_fixture"
+untracked_other_payload=$(jq -cn --arg session "$session_id" --arg cwd "$untracked_root" --arg path "$untracked_other_fixture" \
+  '{session_id:$session, cwd:$cwd, tool_input:{file_path:$path}}')
+run_scan clean "$untracked_other_payload"
+assert_status "$scan_status" 0
+jq -e '.overflow == 1 and .omitted == []' "$untracked_state_file" >/dev/null \
+  || fail "unrelated clean scan cleared untracked overflow"
+untracked_compact_payload=$(jq -cn --arg session "$session_id" --arg cwd "$untracked_root" \
+  '{session_id:$session, cwd:$cwd, source:"compact"}')
+run_restore "$untracked_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'Some successful scan results were omitted because the local continuity cache reached capacity.'
+for index in $(seq 1 20); do
+  run_state_update "$byte_root" ".github/large-$index.py" "$large_record"
+  if [ -f "$byte_state_file" ] && jq -e '(.overflow > 0 or (.omitted | length) > 0)' "$byte_state_file" >/dev/null; then
+    break
+  fi
+done
+jq -e '.version == 3 and (.overflow > 0 or (.omitted | length) > 0) and (.files | length) < 64' "$byte_state_file" >/dev/null \
+  || fail "state byte limit did not record cache overflow"
+run_restore "$byte_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'Some successful scan results were omitted because the local continuity cache reached capacity.'
+old_rescan_record=$(record_for_rule test/old-rule)
+run_state_update "$rescan_root" 'rescan.py' "$old_rescan_record"
+[ -f "$rescan_state_file" ] || fail "rescan state did not create old finding"
+run_state_update_with_limit 2048 "$rescan_root" 'rescan.py' "$large_record"
+jq -e '(.overflow > 0 or (.omitted | length) > 0) and (.files | has("rescan.py") | not)' "$rescan_state_file" >/dev/null \
+  || fail "byte-cap rescan retained stale finding"
+assert_not_contains "$(cat "$rescan_state_file")" 'test/old-rule'
+run_restore "$rescan_compact_payload"
+assert_status "$restore_status" 0
+assert_contains "$restore_output" 'Some successful scan results were omitted because the local continuity cache reached capacity.'
+assert_not_contains "$restore_output" 'test/old-rule'
+
+rm -f "$state_file"
+run_restore "$compact_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "missing state produced a summary"
+printf '{not-json\n' > "$state_file"
+run_restore "$compact_payload"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "corrupt state produced a summary"
+
+restore_sentinel='RAW_PROMPT_INJECTION_SHOULD_NOT_REACH_SESSIONSTART'
+restore_bad_cache="$tmp_dir/$restore_sentinel"
+printf '%s\n' "$restore_sentinel" > "$restore_bad_cache"
+run_restore_with_cache "$compact_payload" "$restore_bad_cache"
+assert_status "$restore_status" 0
+[ -z "$restore_output" ] || fail "unusable cache emitted SessionStart output"
+
+run_scan many
+assert_status "$scan_status" 2
+jq -n '
+  [range(0;7) |
+    . as $index |
+    {
+      key: ("dir-" + ($index | tostring) + "/" + ([range(0;210) | "p"] | join("")) + ".py"),
+      value: {
+        threshold: "medium",
+        total: 2,
+        truncated: false,
+        findings: [
+          {
+            fingerprint: ([range(0;64) | "f"] | join("")),
+            rule_id: ("test/" + ([range(0;100) | "a"] | join("")) + "-" + ($index | tostring)),
+            severity: "critical",
+            line: 1,
+            column: 1
+          },
+          {
+            fingerprint: ([range(0;64) | "e"] | join("")),
+            rule_id: ("test/" + ([range(0;100) | "b"] | join("")) + "-" + ($index | tostring)),
+            severity: "high",
+            line: 2,
+            column: 2
+          }
+        ]
+      }
+    }
+  ] | from_entries | {version: 1, files: .}
+' > "$state_file"
+chmod 600 "$state_file"
+run_restore "$compact_payload"
+assert_status "$restore_status" 0
+summary_bytes=$(printf '%s\n' "$restore_output" | wc -c | tr -d ' ')
+[ "$summary_bytes" -le 3072 ] || fail "summary exceeded byte bound"
+assert_contains "$restore_output" 'Additional finding details omitted.'
+assert_not_contains "$restore_output" FINDING_SECRET
+assert_not_contains "$restore_output" SOURCE_SNIPPET_SECRET
+
+printf 'ok: Claude Code compaction state hooks\n'


### PR DESCRIPTION
## Summary

- Preserve unresolved Claude Code scan findings across compaction with durable metadata-only continuity.
- Restore only opaque finding IDs, severities, and locations; no paths, rules, snippets, descriptions, secrets, or raw scanner output.
- Tests: `bash plugins/claude-code/tests/test-compaction-state.sh`; `claude plugin validate plugins/claude-code`; Perl no-follow locking capability/syntax; `git diff --cached --check origin/main`.

## Checklist

- [x] Tests pass (`bash plugins/claude-code/tests/test-compaction-state.sh`)
- [x] Plugin validation passes (`claude plugin validate plugins/claude-code`)
- [x] Perl no-follow locking capability and syntax checked
- [x] Diff check passes

Fixes #588