### PR TITLE
fix(www): render cached star counts as text

### DIFF
--- a/www/src/components/ui/SiteNav.astro
+++ b/www/src/components/ui/SiteNav.astro
@@ -51,14 +51,14 @@ const { backLink, backLabel } = Astro.props;
 
         // Use cache if less than 1 hour old
         if (cached && cachedAt && Date.now() - Number(cachedAt) < 3600000) {
-          if (el) el.innerHTML = '★ ' + cached;
+          if (el) el.textContent = '★ ' + cached;
         } else {
           const r = await fetch('https://api.github.com/repos/0sec-labs/foxguard');
           if (r.ok) {
             const d = await r.json();
             if (el && d.stargazers_count) {
               const count = d.stargazers_count.toLocaleString();
-              el.innerHTML = '★ ' + count;
+              el.textContent = '★ ' + count;
               localStorage.setItem('fg-stars', count);
               localStorage.setItem('fg-stars-at', String(Date.now()));
             }


### PR DESCRIPTION
## Change
Render cached and fetched GitHub star counts with textContent instead of innerHTML.

## Evidence
On the local pre-fix website, a crafted fg-stars localStorage value produced an img element and executed its onerror handler after reload. This requires control of same-origin storage; no remote attacker path into storage was established. After the change, the same value renders literally, with zero injected elements and no handler execution.

## Verification
- npm run build: 20 static pages built.
- Chromium smoke against built static output: payload remained text; primary routes loaded; rules search/reset worked.
- Visual homepage check completed.

No public API or documentation contract changes.