### PR TITLE
fix(www): show copy success only after clipboard writes

### DIFF
--- a/www/src/components/ui/InstallTabs.astro
+++ b/www/src/components/ui/InstallTabs.astro
@@ -24,11 +24,16 @@ const { id = 'install' } = Astro.props;
   };
   let currentCmd = 'npx foxguard .';
 
-  function flash() {
+  async function flash() {
     const cmdEl = document.querySelector(`[data-cmd="${id}"]`);
     const box = document.querySelector(`[data-area="${id}"]`)?.parentElement;
     if (!cmdEl || !box) return;
-    navigator.clipboard.writeText(currentCmd);
+    try {
+      await navigator.clipboard.writeText(currentCmd);
+    } catch {
+      // Leave the command visible without claiming a denied copy succeeded.
+      return;
+    }
     box.classList.remove('copy-flash');
     box.offsetWidth;
     box.classList.add('copy-flash');


### PR DESCRIPTION
## Change
Await clipboard writes before flashing copy success. If clipboard access is denied or unavailable, leave the install command visible without false success feedback.

## Verification
- npm run build: 20 static pages built.
- Chromium production-page smoke with an instrumented page-world clipboard: denied write attempted npx foxguard . and did not flash; successful write copied cargo install foxguard and flashed.
- Hero and footer install widgets remained independent.
- Visual homepage check completed.

No public API or documentation contract changes.