### PR TITLE
fix(action): expose usable scan and badge outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,46 @@ jobs:
       - run: node --test scripts/verify-vscode-marketplace.test.mjs
       - run: bash -n scripts/release.sh
 
+  action-outputs:
+    name: Action Outputs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BADGE_LABEL: 'audit "quoted" \ label'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create clean scan fixture
+        run: |
+          mkdir -p "$RUNNER_TEMP/action-fixture"
+          printf 'print("safe")\n' > "$RUNNER_TEMP/action-fixture/safe.py"
+      - name: Scan through the composite action
+        id: scan
+        uses: ./action
+        with:
+          path: ${{ runner.temp }}/action-fixture
+          version: v0.12.0
+          upload-sarif: "false"
+          badge-label: ${{ env.BADGE_LABEL }}
+      - name: Consume public action outputs
+        env:
+          FINDINGS_COUNT: ${{ steps.scan.outputs.findings-count }}
+          SCAN_REPORT: ${{ steps.scan.outputs.sarif-file }}
+          BADGE_REPORT: ${{ steps.scan.outputs.badge-json }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          assert os.environ["FINDINGS_COUNT"] == "0", "missing or incorrect findings-count output"
+          with open(os.environ["SCAN_REPORT"]) as report_file:
+              report = json.load(report_file)
+          assert report["runs"][0]["results"] == []
+          with open(os.environ["BADGE_REPORT"]) as badge_file:
+              badge = json.load(badge_file)
+          assert badge["label"] == os.environ["BADGE_LABEL"]
+          assert badge["message"] == "clean"
+          PY
+
   precision-corpus-metadata:
     name: Precision Corpus Metadata
     runs-on: ubuntu-latest

--- a/action/action.yml
+++ b/action/action.yml
@@ -44,15 +44,19 @@ inputs:
 outputs:
   findings-count:
     description: "Number of findings detected"
+    value: ${{ steps.scan.outputs.findings-count }}
   sarif-file:
     description: "Path to the SARIF output file"
+    value: ${{ steps.scan.outputs.sarif-file }}
   badge-json:
     description: "Path to shields.io endpoint JSON file for dynamic badges"
+    value: ${{ steps.scan.outputs.badge-json }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Foxguard
+      id: scan
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -175,14 +175,20 @@ else
     BADGE_COLOR="f59e0b"
 fi
 
-cat > "${BADGE_FILE}" <<BADGE_EOF
-{
-  "schemaVersion": 1,
-  "label": "${BADGE_LABEL}",
-  "message": "${BADGE_MESSAGE}",
-  "color": "${BADGE_COLOR}"
-}
-BADGE_EOF
+BADGE_LABEL="${BADGE_LABEL}" BADGE_MESSAGE="${BADGE_MESSAGE}" BADGE_COLOR="${BADGE_COLOR}" \
+python3 - <<'PY' > "${BADGE_FILE}"
+import json
+import os
+import sys
+
+json.dump({
+    "schemaVersion": 1,
+    "label": os.environ["BADGE_LABEL"],
+    "message": os.environ["BADGE_MESSAGE"],
+    "color": os.environ["BADGE_COLOR"],
+}, sys.stdout, indent=2)
+sys.stdout.write("\n")
+PY
 
 echo "badge-json=${BADGE_FILE}" >> "${GITHUB_OUTPUT:-/dev/null}"
 echo "Badge JSON written to: ${BADGE_FILE}"


### PR DESCRIPTION
## Change
Expose findings-count, sarif-file, and badge-json through the composite action's public outputs. Serialize badge data with Python's JSON encoder so labels containing quotes, backslashes, or newlines produce valid JSON.

## Reproduction and verification
- Added a real GitHub Actions consumer regression using the released v0.12.0 scanner, not a mock.
- Pre-fix run 34447180817 / Action Outputs: scanner step succeeded; Consume public action outputs failed because outputs were not exposed.
- Local pre-fix entrypoint run with label `audit "quoted" \\ label` produced invalid JSON.
- Local fixed entrypoint run downloaded and checksum-verified v0.12.0, scanned a clean Python fixture, reported 0 findings, and produced parseable SARIF and badge JSON preserving the exact label.
- bash -n action/entrypoint.sh passed.
- The same CI consumer regression validates all three public outputs and the quoted label after the fix.

The public output names and artifact schemas remain unchanged.