### PR TITLE
fix: harden autofix paths and isolate CodeQL output

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ foxguard --format sarif . > results.sarif
 foxguard --format semgrep-json .        # Semgrep CLI-compatible JSON
 ```
 
+Use `foxguard --fix src/` or `foxguard --fix src/app.py` to apply supported taint
+fixes in place. Targets are checked against the canonical scan directory or the
+selected file; findings outside that scope are skipped. Python command-injection
+fixes add `import subprocess` when needed, preserving module docstrings and future
+imports. Review generated changes before committing.
+
 ## Language Coverage
 
 | Language | Built-in rules | Taint tracking | Framework-aware rules |

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -2669,8 +2669,29 @@ mod tests {
         let (second_request_tx, second_request_rx) = tokio::sync::mpsc::unbounded_channel();
         let handle = std::thread::spawn(move || {
             let read_request = |stream: &mut TcpStream| {
+                // Accepted sockets inherit nonblocking mode on macOS, unlike Linux.
+                stream
+                    .set_nonblocking(false)
+                    .expect("mock request stream should become blocking");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .expect("mock request read should be bounded");
                 let mut request = [0_u8; 8192];
-                let _ = stream.read(&mut request);
+                let mut received = 0;
+                loop {
+                    let count = stream
+                        .read(&mut request[received..])
+                        .expect("mock server should read the request");
+                    assert!(count > 0, "mock request headers must fit and be complete");
+                    let start = received.saturating_sub(3);
+                    received += count;
+                    if request[start..received]
+                        .windows(4)
+                        .any(|bytes| bytes == b"\r\n\r\n")
+                    {
+                        break;
+                    }
+                }
             };
             let write_response = |stream: &mut TcpStream, body: &str| {
                 let response = format!(
@@ -2771,8 +2792,29 @@ mod tests {
         let (newer_request_tx, newer_request_rx) = tokio::sync::mpsc::unbounded_channel();
         let handle = std::thread::spawn(move || {
             let read_request = |stream: &mut TcpStream| {
+                // Accepted sockets inherit nonblocking mode on macOS, unlike Linux.
+                stream
+                    .set_nonblocking(false)
+                    .expect("mock request stream should become blocking");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .expect("mock request read should be bounded");
                 let mut request = [0_u8; 8192];
-                let _ = stream.read(&mut request);
+                let mut received = 0;
+                loop {
+                    let count = stream
+                        .read(&mut request[received..])
+                        .expect("mock server should read the request");
+                    assert!(count > 0, "mock request headers must fit and be complete");
+                    let start = received.saturating_sub(3);
+                    received += count;
+                    if request[start..received]
+                        .windows(4)
+                        .any(|bytes| bytes == b"\r\n\r\n")
+                    {
+                        break;
+                    }
+                }
             };
             let write_response = |stream: &mut TcpStream, body: &str| {
                 let response = format!(

--- a/src/engine/codeql.rs
+++ b/src/engine/codeql.rs
@@ -631,10 +631,19 @@ pub fn scan_with_notices_for_target(
 fn run_codeql_database_analyze(database: &Path, query: &Path) -> Result<String, String> {
     use crate::engine::process::{wait_with_output_timeout, TimedOutput};
 
-    let output = tempfile::NamedTempFile::new()
-        .map_err(|e| format!("failed to create temporary SARIF output: {}", e))?;
-    let output_path = output.path().to_path_buf();
-    drop(output);
+    // Keep the output namespace reserved until CodeQL exits and its SARIF is read.
+    // Dropping a NamedTempFile before spawning loses ownership of that path.
+    let mut output_builder = tempfile::Builder::new();
+    output_builder.prefix("foxguard-codeql-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        output_builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    let output_dir = output_builder
+        .tempdir()
+        .map_err(|e| format!("failed to create temporary SARIF directory: {}", e))?;
+    let output_path = output_dir.path().join("results.sarif");
     let mut output_arg = OsString::from("--output=");
     output_arg.push(output_path.as_os_str());
 

--- a/src/fix/command_injection.rs
+++ b/src/fix/command_injection.rs
@@ -36,11 +36,45 @@ pub fn fix_python(
 
     let replacement = format!("subprocess.run([{}])", list_items.join(", "));
 
-    Some(vec![CodeEdit {
+    let mut edits = vec![CodeEdit {
         start_byte: call_node.start_byte(),
         end_byte: call_node.end_byte(),
         replacement,
-    }])
+    }];
+    let mut imported = false;
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.kind() == "import_statement" {
+            let mut imports = statement.walk();
+            if statement
+                .named_children(&mut imports)
+                .any(|name| name.kind() == "dotted_name" && node_text(name, source) == "subprocess")
+            {
+                imported = true;
+                break;
+            }
+        }
+    }
+    if !imported {
+        // Keep shebangs, encoding comments, module docstrings and future imports first.
+        let mut cursor = root.walk();
+        let insertion = root
+            .named_children(&mut cursor)
+            .find(|node| match node.kind() {
+                "comment" | "future_import_statement" => false,
+                "expression_statement" => !node
+                    .named_child(0)
+                    .is_some_and(|child| matches!(child.kind(), "string" | "concatenated_string")),
+                _ => true,
+            })
+            .map_or(0, |node| node.start_byte());
+        edits.push(CodeEdit {
+            start_byte: insertion,
+            end_byte: insertion,
+            replacement: "import subprocess\n".to_string(),
+        });
+    }
+    Some(edits)
 }
 
 /// Fix JavaScript command injection: rewrite `exec(cmd)` to `execFile(name, [args])`.
@@ -308,11 +342,29 @@ mod tests {
     fn test_fix_python_os_system() {
         let source = r#"os.system("ls " + user_input)"#;
         let tree = parse_file(source, Language::Python).unwrap();
-        let edits = fix_python(source, &tree, 0, source.len()).unwrap();
-        assert_eq!(edits.len(), 1);
+        let mut edits = fix_python(source, &tree, 0, source.len()).unwrap();
         assert_eq!(
-            edits[0].replacement,
-            r#"subprocess.run(["ls", user_input])"#
+            crate::fix::apply_edits(source, &mut edits),
+            "import subprocess\nsubprocess.run([\"ls\", user_input])"
+        );
+    }
+
+    #[test]
+    fn python_command_fixes_preserve_preamble_and_share_import() {
+        let preamble = "#!/usr/bin/env python3\n\"\"\"Module documentation.\"\"\"\nfrom __future__ import annotations\n";
+        let source = format!("{preamble}os.system(\"ls \" + first)\nos.system(\"ls \" + second)\n");
+        let tree = parse_file(&source, Language::Python).unwrap();
+        let mut edits = Vec::new();
+        for name in ["first", "second"] {
+            let end = source.find(&format!("{name})")).unwrap() + name.len() + 1;
+            let start = source[..end].rfind("os.system(").unwrap();
+            edits.extend(fix_python(&source, &tree, start, end).unwrap());
+        }
+        assert_eq!(
+            crate::fix::apply_edits(&source, &mut edits),
+            format!(
+                "{preamble}import subprocess\nsubprocess.run([\"ls\", first])\nsubprocess.run([\"ls\", second])\n"
+            )
         );
     }
 

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -45,14 +45,22 @@ fn generate_fix(
     }
 }
 
-/// Apply byte-range edits to source, processing in reverse order so offsets stay valid.
+/// Apply edits in reverse byte order, skipping overlaps and duplicate edits.
 pub fn apply_edits(source: &str, edits: &mut [CodeEdit]) -> String {
     edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
 
     let mut result = source.to_string();
     let mut last_start = usize::MAX;
+    let mut last_edit: Option<&CodeEdit> = None;
 
     for edit in edits.iter() {
+        if last_edit.is_some_and(|previous| {
+            previous.start_byte == edit.start_byte
+                && previous.end_byte == edit.end_byte
+                && previous.replacement == edit.replacement
+        }) {
+            continue;
+        }
         // Skip overlapping edits
         if edit.end_byte > last_start {
             continue;
@@ -61,6 +69,7 @@ pub fn apply_edits(source: &str, edits: &mut [CodeEdit]) -> String {
         let end = edit.end_byte.min(result.len());
         result.replace_range(start..end, &edit.replacement);
         last_start = edit.start_byte;
+        last_edit = Some(edit);
     }
 
     result
@@ -68,7 +77,14 @@ pub fn apply_edits(source: &str, edits: &mut [CodeEdit]) -> String {
 
 /// Generate and apply fixes for all fixable findings. Returns the number of files modified.
 pub fn apply_all_fixes(findings: &[Finding], scan_root: &str) -> usize {
-    let root = Path::new(scan_root);
+    let root = match Path::new(scan_root).canonicalize() {
+        Ok(root) => root,
+        Err(error) => {
+            eprintln!("Error resolving scan root {}: {}", scan_root, error);
+            return 0;
+        }
+    };
+    let single_file = root.is_file();
 
     // Group findings by file
     let mut by_file: HashMap<&str, Vec<&Finding>> = HashMap::new();
@@ -81,7 +97,26 @@ pub fn apply_all_fixes(findings: &[Finding], scan_root: &str) -> usize {
     let mut files_fixed = 0;
 
     for (file, file_findings) in &by_file {
-        let file_path = root.join(file);
+        // Scanner finding paths are relative to the process directory, not the
+        // scan root. Resolve once and use the same target for reading and writing.
+        let file_path = match Path::new(file).canonicalize() {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
+        let in_scope = if single_file {
+            file_path == root
+        } else {
+            file_path.starts_with(&root)
+        };
+        if !in_scope {
+            eprintln!(
+                "Warning: skipping fix for {} — path escapes scan root {}",
+                file,
+                root.display()
+            );
+            continue;
+        }
+
         let source = match std::fs::read_to_string(&file_path) {
             Ok(s) => s,
             Err(_) => continue,
@@ -277,5 +312,70 @@ mod tests {
         // The 4..8 edit is applied first (higher start), then 2..6 is skipped because end_byte(6) > last_start(4).
         let result = apply_edits(source, &mut edits);
         assert_eq!(result, "abcdYY");
+    }
+
+    const FIXABLE_SOURCE: &str = "from flask import request\nimport os\n\ndef handler():\n    user_input = request.args.get(\"name\")\n    os.system(\"ls \" + user_input)\n";
+
+    fn scan_fixable_file(path: &Path) -> Vec<Finding> {
+        crate::engine::scan_directory(
+            &path.to_string_lossy(),
+            &crate::rules::RuleRegistry::new(),
+            1024 * 1024,
+            None,
+        )
+        .findings
+    }
+
+    #[test]
+    fn autofix_handles_cwd_relative_directory_and_file_targets() {
+        let workspace = tempfile::tempdir_in(".").expect("temporary workspace");
+        let file = workspace.path().join("app.py");
+        for scan_root in [workspace.path(), file.as_path()] {
+            std::fs::write(&file, FIXABLE_SOURCE).expect("write source");
+            let findings = scan_fixable_file(&file);
+            assert_eq!(apply_all_fixes(&findings, &scan_root.to_string_lossy()), 1);
+            let modified = std::fs::read_to_string(&file).expect("read fixed source");
+            assert!(!modified.contains("os.system("));
+            assert!(modified.contains("subprocess.run("));
+        }
+    }
+
+    #[test]
+    fn autofix_rejects_targets_outside_scan_root() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let root = workspace.path().join("repo");
+        std::fs::create_dir(&root).expect("create scan root");
+        let victim = workspace.path().join("victim.py");
+        std::fs::write(&victim, FIXABLE_SOURCE).expect("write victim");
+        let mut findings = scan_fixable_file(&victim);
+
+        // Establish that these are real fixable findings, not unsupported rules.
+        assert_eq!(apply_all_fixes(&findings, &victim.to_string_lossy()), 1);
+        for path in [victim.clone(), root.join("../victim.py")] {
+            std::fs::write(&victim, FIXABLE_SOURCE).expect("restore victim");
+            for finding in &mut findings {
+                finding.file = path.to_string_lossy().into_owned();
+            }
+            assert_eq!(apply_all_fixes(&findings, &root.to_string_lossy()), 0);
+            assert_eq!(std::fs::read_to_string(&victim).unwrap(), FIXABLE_SOURCE);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn autofix_rejects_symlinks_outside_scan_root() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let root = workspace.path().join("repo");
+        std::fs::create_dir(&root).expect("create scan root");
+        let victim = workspace.path().join("victim.py");
+        std::fs::write(&victim, FIXABLE_SOURCE).expect("write victim");
+        let link = root.join("app.py");
+        std::os::unix::fs::symlink(&victim, &link).expect("create escaping symlink");
+        let mut findings = scan_fixable_file(&victim);
+        for finding in &mut findings {
+            finding.file = link.to_string_lossy().into_owned();
+        }
+        assert_eq!(apply_all_fixes(&findings, &root.to_string_lossy()), 0);
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), FIXABLE_SOURCE);
     }
 }

--- a/tests/codeql_diff.rs
+++ b/tests/codeql_diff.rs
@@ -301,7 +301,9 @@ fn paired_databases_use_sarif_identity_for_moved_findings() {
     fs::create_dir_all(&base).expect("failed to create base database directory");
     fs::create_dir_all(&head).expect("failed to create head database directory");
 
+    let outputs = TempDir::new().expect("failed to create isolated temporary output directory");
     let output = foxguard_diff(repo.path(), fake_bin.path())
+        .env("TMPDIR", outputs.path())
         .args([
             "--rules",
             rules.to_str().expect("non-UTF-8 rules path"),
@@ -331,6 +333,10 @@ fn paired_databases_use_sarif_identity_for_moved_findings() {
         Some("introduced database source")
     );
     assert_eq!(findings[0]["rule_id"].as_str(), Some("test/codeql-diff"));
+    assert!(
+        fs::read_dir(outputs.path()).unwrap().next().is_none(),
+        "raw CodeQL SARIF must not remain in the temporary directory after the comparison"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Changes
- Resolve scanner-emitted finding paths relative to the process directory, not by appending them to the scan root. This fixes nested relative-directory and single-file --fix runs.
- Restrict writes to the canonical scan directory or exact selected file; reject out-of-scope targets and escaping symlinks.
- Add the missing subprocess import to Python command-injection fixes, preserving shebangs, module docstrings, and future imports. Coalesce identical edits when multiple findings need the same import.
- Add behavioral regression coverage and document in-place fixes.

## Verification
- Reproduced a supported Flask command-injection finding where the pre-fix binary left src/app.py unchanged with --fix src.
- Rebuilt CLI fixes both src and src/app.py. Generated two-call Python modules execute successfully with real subprocesses; one subprocess import, docstring and future-import preamble preserved.
- cargo fmt and cargo clippy --locked --all-targets --all-features -- -D warnings passed.
- cargo test --locked --all-features passed in the combined audit workspace: 1,618 passed, 6 explicitly ignored (including live CodeQL and benchmark/debug/doc harnesses).
- cargo build --locked --all-features --bins passed.

Canonical confinement is a scope check, not a claim of race-proof filesystem isolation.

## CodeQL output isolation found during CI
- Keep each external CodeQL output namespace reserved until the child exits and SARIF is parsed; use Unix mode 0700 and automatic cleanup. Previously the NamedTempFile was dropped before spawning, leaving an unowned path and persistent raw SARIF.
- Extended an existing CLI comparison regression: the pre-fix binary fails because raw SARIF remains in the isolated temporary directory; the fix passes.
- All 13 CodeQL diff tests pass. Full Rust suite remained at 1,618 passing tests, 6 ignored; final permission hardening additionally passed Clippy, all CodeQL diff tests, and binary builds.
- Concurrent CLI smoke with a controlled CodeQL output probe: 20 scans, 20 distinct output directories, every directory mode 0700, zero leftover outputs. This exercises the external-tool handoff, not a live CodeQL query engine.


## macOS concurrency-test repair
- Retrieved the canceled macOS run logs: `final_review_rendering_and_newer_admission_share_the_pull_request_gate` was stuck after the other 41 GitHub App tests completed.
- The two interleaving HTTP test servers now explicitly reset accepted sockets to blocking mode (macOS inherits the listener mode), bound request reads, and consume complete headers instead of discarding read errors. Production webhook behavior is unchanged.
- Local verification: Clippy with warnings denied and all 42 GitHub App tests pass. Required Linux/macOS CI reruns on the final commit before merge.
