### PR TITLE
fix(integrations): honor MCP ping and webhook failure contracts

### DIFF
--- a/docs/agent-editor-integration.md
+++ b/docs/agent-editor-integration.md
@@ -68,6 +68,11 @@ Common request fields:
 | `finding` | object | Selector for `explain` filtering and `suppress` suggestions. |
 | `suppression` | string | For `suppress`: `inline`, `config`, or `baseline`. |
 
+For `explain`, `finding.file` matches an exact path or a suffix beginning at a
+path separator (`/` or `\`). Selecting `app.py` does not select `myapp.py`.
+Inline suppression suggestions use the file extension's comment syntax,
+case-insensitively, including `#` for Ruby gemspec and TOML files.
+
 Response fields:
 
 | Field | Type | Meaning |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -4,6 +4,9 @@
 line-delimited JSON-RPC on stdio. It is intended for local agent clients that
 want structured security feedback while editing code.
 
+JSON-RPC `ping` requests return an empty result object (`{}`) with the original
+request ID. Notifications without an ID do not receive a response.
+
 ## Run
 
 Build from source:

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -599,10 +599,12 @@ fn select_findings(findings: Vec<Finding>, selector: Option<&AdapterFindingRef>)
                 .rule_id
                 .as_ref()
                 .is_none_or(|rule_id| &finding.rule_id == rule_id)
-                && selector
-                    .file
-                    .as_ref()
-                    .is_none_or(|file| finding.file == *file || finding.file.ends_with(file))
+                && selector.file.as_ref().is_none_or(|file| {
+                    finding
+                        .file
+                        .strip_suffix(file)
+                        .is_some_and(|prefix| prefix.is_empty() || prefix.ends_with(['/', '\\']))
+                })
                 && selector.line.is_none_or(|line| finding.line == line)
                 && selector
                     .column
@@ -722,10 +724,15 @@ fn is_absolute_path(path: &str) -> bool {
 }
 
 fn comment_prefix_for_path(path: &str) -> &'static str {
-    let lower = path.to_ascii_lowercase();
-    let extension = lower.rsplit_once('.').map(|(_, ext)| ext).unwrap_or("");
-    match extension {
-        "py" | "pyw" | "rb" | "rake" | "yml" | "yaml" | "sh" | "bash" | "zsh" => "#",
+    let file_name = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    let extension = file_name
+        .rsplit_once('.')
+        .map(|(_, ext)| ext)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "py" | "pyw" | "rb" | "rake" | "gemspec" | "yml" | "yaml" | "toml" | "sh" | "bash"
+        | "zsh" => "#",
         _ => "//",
     }
 }
@@ -950,5 +957,78 @@ mod tests {
             Some("# foxguard: ignore[py/no-eval]")
         );
         assert_eq!(suppression.line, Some(12));
+    }
+
+    #[test]
+    fn explain_file_selector_rejects_partial_filename_matches() {
+        let workspace = must(tempfile::tempdir());
+        for name in ["app.py", "myapp.py"] {
+            must(std::fs::write(
+                workspace.path().join(name),
+                "DEBUG = True\n",
+            ));
+        }
+        let mut request = AdapterRequest::new(AdapterCommand::Explain);
+        request.workspace_root = Some(workspace.path().to_string_lossy().into_owned());
+        request.finding = Some(AdapterFindingRef {
+            rule_id: Some("py/no-debug-true".to_string()),
+            file: Some("app.py".to_string()),
+            line: None,
+            column: None,
+        });
+
+        let response = execute_adapter_request(request);
+        assert!(
+            response.ok,
+            "unexpected adapter error: {:?}",
+            response.error
+        );
+        let files: Vec<_> = response
+            .findings
+            .iter()
+            .map(|finding| std::path::Path::new(&finding.file).file_name().unwrap())
+            .collect();
+        assert_eq!(files, [std::ffi::OsStr::new("app.py")]);
+    }
+
+    #[test]
+    fn suppress_inline_comment_matches_file_type() {
+        // Gemspec and toml files use #, not //
+        let suggestion = suppression_suggestion(
+            AdapterSuppressionKind::Inline,
+            "rb/no-eval",
+            "mygem.gemspec",
+            Some(5),
+        );
+        assert_eq!(
+            suggestion.snippet.as_deref(),
+            Some("# foxguard: ignore[rb/no-eval]"),
+            "gemspec files should use # comment prefix"
+        );
+
+        let suggestion = suppression_suggestion(
+            AdapterSuppressionKind::Inline,
+            "rs/no-unsafe",
+            "Cargo.toml",
+            Some(12),
+        );
+        assert_eq!(
+            suggestion.snippet.as_deref(),
+            Some("# foxguard: ignore[rs/no-unsafe]"),
+            "toml files should use # comment prefix"
+        );
+
+        // Case-insensitive extension matching
+        let suggestion = suppression_suggestion(
+            AdapterSuppressionKind::Inline,
+            "py/no-eval",
+            "/PATH/TO/APP.PY",
+            Some(1),
+        );
+        assert_eq!(
+            suggestion.snippet.as_deref(),
+            Some("# foxguard: ignore[py/no-eval]"),
+            "case-insensitive extension matching should work for .PY"
+        );
     }
 }

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -1337,12 +1337,10 @@ fn pull_request_key(payload: &GitHubWebhookPayload) -> Option<PullRequestKey> {
     })
 }
 
-/// Webhook handler. Verifies the GitHub HMAC, parses the event type
-/// from the `X-GitHub-Event` header, and dispatches to a per-kind
-/// stub. Accepted deliveries return 202; a valid pull-request delivery whose
-/// authoritative head cannot be checked or whose durable write fails returns
-/// 503 so GitHub retries it. Verification failures return 401 and oversized or
-/// unparseable inputs return 400.
+/// Verify the GitHub HMAC and dispatch the event.
+/// Accepted deliveries return 202. Failed persistence or an unavailable
+/// authoritative PR head returns 503, leaving the delivery eligible for
+/// redelivery. Verification failures return 401; unparseable payloads return 400.
 async fn webhook(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -1393,37 +1391,39 @@ async fn webhook(
                     if payload.action.as_deref() == Some("deleted") {
                         remove_cached_installation_token(&state, installation.id).await;
                     }
-                    let persisted = match persist_installation_event(&state, &payload) {
-                        Ok(persisted) => persisted,
-                        Err(error) => {
-                            // Surface at error level with the configured
-                            // path: a persistent failure here (e.g. a
-                            // read-only or unwritable store directory)
-                            // means install state is silently lost across
-                            // restarts, and an operator must see it.
-                            error!(
-                                delivery,
-                                installation_id = installation.id,
-                                path = %state.installations_path.display(),
-                                %error,
-                                "failed to persist installation metadata"
-                            );
-                            false
-                        }
-                    };
+                    if let Err(error) = persist_installation_event(&state, &payload) {
+                        // Surface at error level with the configured
+                        // path: a persistent failure here (e.g. a
+                        // read-only or unwritable store directory)
+                        // means install state is silently lost across
+                        // restarts, and an operator must see it.
+                        error!(
+                            delivery,
+                            installation_id = installation.id,
+                            path = %state.installations_path.display(),
+                            %error,
+                            "failed to persist installation metadata"
+                        );
+                        // Do not acknowledge an installation update that was not saved.
+                        return StatusCode::SERVICE_UNAVAILABLE;
+                    }
                     info!(
                         delivery,
                         installation_id = installation.id,
                         action = payload.action.as_deref().unwrap_or("?"),
-                        persisted,
-                        "installation event processed"
+                        "installation event persisted"
                     );
                 } else {
                     warn!(delivery, "installation event missing installation.id");
                 }
             }
             Err(error) => {
-                warn!(delivery, %error, "installation payload was not valid JSON");
+                warn!(
+                    delivery,
+                    %error,
+                    "installation payload was not valid JSON"
+                );
+                return StatusCode::BAD_REQUEST;
             }
         },
         EventKind::PullRequest => match parse_webhook_payload(&body) {
@@ -1542,7 +1542,12 @@ async fn webhook(
                 }
             }
             Err(error) => {
-                warn!(delivery, %error, "pull_request payload was not valid JSON");
+                warn!(
+                    delivery,
+                    %error,
+                    "pull_request payload was not valid JSON"
+                );
+                return StatusCode::BAD_REQUEST;
             }
         },
         EventKind::Other => {
@@ -4268,5 +4273,126 @@ mod tests {
         }
         // Each installation gets exactly one fetch.
         assert_eq!(fetch_count.load(Ordering::SeqCst), 4);
+    }
+
+    fn signed_installation_headers(body: &[u8], delivery: &str) -> HeaderMap {
+        use hmac::Mac;
+
+        let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(b"test-webhook-secret")
+            .expect("HMAC key should be accepted");
+        mac.update(body);
+        let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Hub-Signature-256",
+            signature.parse().expect("signature header should parse"),
+        );
+        headers.insert(
+            "X-GitHub-Event",
+            "installation".parse().expect("event header should parse"),
+        );
+        headers.insert(
+            "X-GitHub-Delivery",
+            delivery.parse().expect("delivery header should parse"),
+        );
+        headers
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn installation_unparseable_payload_returns_400() {
+        let job_dir = tempfile::tempdir().expect("job tempdir should be created");
+        let jobs = PullRequestJobStore::open(job_dir.path().join("pull-request-jobs.json"))
+            .expect("job store should open");
+        let (review_url, _server_handle) = spawn_json_response_server(200, "{}");
+        let (_state_dir, state) = test_state_with_review(jobs, &review_url);
+        remember_test_token(&state).await;
+
+        let malformed_body = b"{";
+        assert_eq!(
+            webhook(
+                State(state),
+                signed_installation_headers(malformed_body, "delivery-malformed"),
+                axum::body::Bytes::from_static(malformed_body),
+            )
+            .await,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pull_request_unparseable_payload_returns_400() {
+        let job_dir = tempfile::tempdir().expect("job tempdir should be created");
+        let jobs = PullRequestJobStore::open(job_dir.path().join("pull-request-jobs.json"))
+            .expect("job store should open");
+        let (review_url, _server_handle) = spawn_json_response_server(200, "{}");
+        let (_state_dir, state) = test_state_with_review(jobs, &review_url);
+        remember_test_token(&state).await;
+
+        let malformed_body = b"{";
+        assert_eq!(
+            webhook(
+                State(state),
+                signed_pull_request_headers(malformed_body),
+                axum::body::Bytes::from_static(malformed_body),
+            )
+            .await,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn installation_persistence_failure_returns_503() {
+        let job_dir = tempfile::tempdir().expect("job tempdir should be created");
+        let jobs = PullRequestJobStore::open(job_dir.path().join("pull-request-jobs.json"))
+            .expect("job store should open");
+
+        // Create an installation store whose save() will fail by
+        // replacing the target path with a directory, reproducing
+        // the native reproduction Main confirmed.
+        let install_dir = tempfile::tempdir().expect("install tempdir should be created");
+        let install_path = install_dir.path().join("installations.json");
+        let installations =
+            InstallationStore::open(install_path.clone()).expect("install store should open");
+        let installations_path: Arc<Path> = Arc::from(installations.path());
+        std::fs::create_dir(&install_path).expect("dir should replace store target");
+
+        let (pull_request_dispatcher, _receiver) = PullRequestDispatcher::new(1, jobs);
+        let credentials = AppCredentials::new(1, b"not-a-real-private-key".to_vec());
+        let (review_url, _server_handle) = spawn_json_response_server(200, "{}");
+        let review = GitHubReviewClient::new(&review_url, 1).expect("review client should build");
+        let state = AppState {
+            webhook_secret: b"test-webhook-secret".to_vec(),
+            auth: GitHubAppAuthClient::new(credentials).expect("auth client should build"),
+            review,
+            installation_tokens: Arc::new(tokio::sync::Mutex::new(InstallationTokenCache::new())),
+            installation_token_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            check_lifecycle_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            pull_request_admission_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            installations: Arc::new(Mutex::new(installations)),
+            installations_path,
+            pull_request_dispatcher,
+        };
+        remember_test_token(&state).await;
+
+        let body = br#"{
+            "action":"created",
+            "installation":{
+                "id":99,
+                "account":{"id":7,"login":"test-org","type":"Organization"},
+                "repository_selection":"selected"
+            },
+            "repositories":[
+                {"full_name":"test-org/test-repo"}
+            ]
+        }"#;
+        assert_eq!(
+            webhook(
+                State(state),
+                signed_installation_headers(body, "delivery-persist-fail"),
+                axum::body::Bytes::from_static(body),
+            )
+            .await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 }

--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -64,6 +64,7 @@ fn handle_request(request: &Value, registry: &RuleRegistry) -> Option<Value> {
 
     let result = match method {
         "initialize" => handle_initialize(),
+        "ping" => Ok(json!({})),
         "tools/list" => handle_tools_list(),
         "tools/call" => handle_tools_call(request, registry),
         _ => {
@@ -698,16 +699,13 @@ fn suggest_suppression(arguments: &Value) -> Result<Value, String> {
 }
 
 fn comment_prefix_for_path(path: &str) -> &'static str {
-    let file_name = match path.rsplit(['/', '\\']).next() {
-        Some(file_name) => file_name,
-        None => path,
-    };
-    let extension = match file_name.rsplit_once('.') {
-        Some((_, extension)) => extension,
-        None => "",
-    };
-
-    match extension {
+    let file_name = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    let extension = file_name
+        .rsplit_once('.')
+        .map(|(_, ext)| ext)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match extension.as_str() {
         "py" | "pyw" | "rb" | "rake" | "gemspec" | "yml" | "yaml" | "toml" | "sh" | "bash"
         | "zsh" => "#",
         _ => "//",
@@ -803,6 +801,18 @@ fn optional_severity(value: &Value, key: &str) -> Result<Option<SeverityFilter>,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ping_returns_empty_result() {
+        let registry = RuleRegistry::empty();
+        let request = json!({"jsonrpc": "2.0", "id": "keepalive", "method": "ping"});
+        assert_eq!(
+            handle_request(&request, &registry),
+            Some(json!({"jsonrpc": "2.0", "id": "keepalive", "result": {}}))
+        );
+        let notification = json!({"jsonrpc": "2.0", "method": "ping"});
+        assert!(handle_request(&notification, &registry).is_none());
+    }
 
     #[test]
     fn diff_interface_accepts_paired_codeql_databases() {

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -19,6 +19,11 @@ cargo build --release --features github-app --bin foxguard-github-app
 - `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, persists installation metadata, and admits pull-request work to a bounded queue (128 pending jobs and 4 workers by default). Replayed GitHub delivery IDs are deduplicated; concurrent updates for the same repository/PR coalesce so the newest head gets one follow-up scan instead of racing or being lost. Overload is acknowledged with `202 Accepted` and logged. Workers prepare installation auth, clone and scan pull-request heads in a bounded temp workspace, create or update one marker-tagged foxguard PR summary comment, delete legacy inline foxguard comments, post a check run with annotations, and clean up after completion.
 - `review.rs` — installation-token GitHub REST client for PR summary comments and check runs. It lists existing marker-tagged bot issue comments and legacy comments, lists changed PR files, filters findings to changed lines, creates or updates exactly one Markdown summary without inline comment payloads, and pins each finding link to the scanned PR-head SHA (with file-only findings linked without a line anchor). It deletes legacy inline foxguard comments and creates a `foxguard` check run with up to 50 annotations.
 
+Signed installation and pull-request payloads that cannot be decoded return
+`400 Bad Request`. Installation persistence failures return `503 Service Unavailable`
+rather than acknowledging an update that was not saved. After repairing the store,
+redeliver the failed event from GitHub's delivery dashboard or API.
+
 ## App configuration (registered & live)
 
 The production App is registered under `0sec-labs` and installed at `https://foxguard.0sec.ai`. It requests **exactly** the permissions and webhook events the receiver consumes — anything less fails at runtime, anything more is over-scoped:

--- a/src/github_app/webhook.rs
+++ b/src/github_app/webhook.rs
@@ -73,14 +73,11 @@ pub fn verify_signature(secret: &[u8], header: &str, body: &[u8]) -> Result<(), 
 }
 
 /// Subset of the GitHub event types this receiver currently routes.
-/// Any other event maps to [`EventKind::Other`] and is acknowledged
-/// with a 202 so GitHub's delivery dashboard stays clean instead of
-/// retrying.
+/// Unsupported events are acknowledged with 202 without further action.
 ///
-/// Variants are added as the matching handlers come online; today
-/// none of these events do anything beyond log + 202 from the
-/// binary, but having the enum landed early means follow-up PRs can
-/// wire handlers without re-touching this module.
+/// * `Installation` persists install metadata and repository membership.
+/// * `PullRequest` queues repository scans and publishes reviews and check runs.
+/// * `Ping` and `Other` are logged and acknowledged with 202.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventKind {
     /// `installation` / `installation_repositories` — App was added

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -9,7 +9,10 @@
 //! - `mode: taint` with `languages: [python]`, `languages: [javascript]` /
 //!   `[typescript]` / `[js]` / `[ts]`, `languages: [go]` / `[golang]`,
 //!   `languages: [java]`, `languages: [c]`, `languages: [kotlin]` /
-//!   `[kt]`, `languages: [ruby]` / `[rb]`, or `languages: [php]`.
+//!   `[kt]`, `languages: [ruby]` / `[rb]`, `languages: [php]`,
+//!   `languages: [csharp]` / `[cs]` / `[c#]`, `languages: [bash]` /
+//!   `[sh]` / `[shell]`, `languages: [solidity]` / `[sol]`,
+//!   `languages: [scala]`, `languages: [apex]`, or `languages: [swift]`.
 //!   Other languages are rejected with a warning and the rule is skipped;
 //!   non-taint rules fall through to the regular Semgrep bridge.
 //! - `pattern-sources`, `pattern-sinks`, `pattern-sanitizers` as lists of
@@ -30,7 +33,7 @@
 //! # Unsupported (rule is skipped with a warning)
 //!
 //! - Any `mode: taint` rule that does not target Python, JavaScript/TypeScript,
-//!   Go, Java, C, or Kotlin.
+//!   Go, Java, C, Kotlin, Ruby, PHP, C#, Bash, Solidity, Scala, Apex, or Swift.
 //! - Any `pattern:` string whose shape is not one of:
 //!   - bare identifier (`request`) — compiled to `ParamName`
 //!   - dotted attribute chain (`request.data`, `request.json`) — compiled


### PR DESCRIPTION
## Changes
- Handle MCP ping requests with an empty JSON-RPC result and preserve request IDs; keep notifications silent.
- Restrict adapter explain file selection to exact paths or path-separator suffixes, so app.py does not also select myapp.py.
- Generate case-insensitive inline suppression syntax, including Ruby gemspec and TOML comments.
- Return HTTP 400 for malformed signed installation/PR payloads and HTTP 503 when installation persistence fails, rather than falsely acknowledging the delivery.
- Update integration/webhook contracts and correct the documented Semgrep taint-language coverage.

## Verification
- Rebuilt adapter scanned app.py and myapp.py but returned only the selected app.py finding.
- Real MCP stdin/stdout exercised string and numeric ping IDs, silent notifications, and uppercase Python suppression suggestions.
- Real HTTP GitHub App smoke: health 200, malformed signed installation and PR bodies 400, installation persistence 202, unavailable store 503, restored store/redelivery 202.
- cargo fmt, strict all-target/all-feature Clippy, and all-feature binary build passed.
- Combined audit workspace Rust suite: 1,618 passed, 6 explicitly ignored; all 42 GitHub App binary tests passed.
- VS Code tests, npm installer tests, Claude Code state-hook E2E, action tests, and Marketplace tests passed.

Operational note: GitHub does not automatically redeliver failed webhooks. Operators can redeliver after repairing the persistence failure.