### PR TITLE
release: v0.13.0 terminal usability and integration fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,14 @@ jobs:
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
           cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+          cargo_lock_version=$(python3 -c 'import tomllib; print(next(p["version"] for p in tomllib.load(open("Cargo.lock", "rb"))["package"] if p["name"] == "foxguard"))')
           npm_version=$(node -p "require('./packages/npm/package.json').version")
           vscode_version=$(node -p "require('./vscode-extension/package.json').version")
           vscode_lock_version=$(node -p "require('./vscode-extension/package-lock.json').version")
 
           for entry in \
             "Cargo.toml:${cargo_version}" \
+            "Cargo.lock:${cargo_lock_version}" \
             "packages/npm/package.json:${npm_version}" \
             "vscode-extension/package.json:${vscode_version}" \
             "vscode-extension/package-lock.json:${vscode_lock_version}"
@@ -112,9 +114,9 @@ jobs:
       - name: Build
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
+            cross build --locked --release --bin foxguard --target ${{ matrix.target }}
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --locked --release --bin foxguard --target ${{ matrix.target }}
           fi
         shell: bash
 
@@ -187,7 +189,7 @@ jobs:
       - name: Publish crate
         run: |
           set +e
-          output=$(cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}" 2>&1)
+          output=$(cargo publish --locked --token "${{ secrets.CARGO_REGISTRY_TOKEN }}" 2>&1)
           status=$?
           set -e
           echo "${output}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "foxguard"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxguard"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A security scanner as fast as a linter, written in Rust. 200+ built-in rules across 12 source languages."

--- a/Dockerfile.github-app
+++ b/Dockerfile.github-app
@@ -18,7 +18,7 @@ COPY . .
 RUN apt-get update \
     && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && cargo build --release --features github-app --bin foxguard --bin foxguard-github-app
+    && cargo build --locked --release --features github-app --bin foxguard --bin foxguard-github-app
 
 FROM debian:bookworm-slim
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Prebuilt installs verify release binaries against `checksums.txt`. Release binar
 **GitHub Action:**
 
 ```yaml
-- uses: 0sec-labs/foxguard/action@v0.12.0
+- uses: 0sec-labs/foxguard/action@v0.13.0
   with:
     path: .
     severity: medium
@@ -59,7 +59,7 @@ Prebuilt installs verify release binaries against `checksums.txt`. Release binar
 ```yaml
 repos:
   - repo: https://github.com/0sec-labs/foxguard
-    rev: v0.12.0
+    rev: v0.13.0
     hooks:
       - id: foxguard
 ```

--- a/docs/releases/v0.13.0.md
+++ b/docs/releases/v0.13.0.md
@@ -1,0 +1,68 @@
+# foxguard v0.13.0 — usable terminal reviews and safer integrations
+
+This release improves terminal navigation, fixes autofix and external-engine reporting, and ships the durable GitHub App, PR security policy, CodeQL diff, and Semgrep migration-readiness work merged since v0.12.0.
+
+## Terminal review improvements
+
+- Help is context-aware, resizes with the terminal, and scrolls without disappearing past the end of its content. Close and scroll shortcuts remain visible on the help border.
+- `Ctrl+C` exits from launch, findings, search, and modal views, including raw-terminal mode.
+- Search accepts a literal `?` instead of opening help.
+- `Home` and `End` jump to the first and last filtered findings.
+- Diff-target entry accepts letters and digits previously intercepted as navigation commands. Use arrows or Tab to change modes while editing the target.
+
+## Security and correctness fixes
+
+- Autofix resolves nested relative-directory and single-file targets correctly, rejects targets outside the canonical scan scope, and rejects escaping symlinks. Canonical scope checks are not a claim of race-proof filesystem isolation.
+- Python command-injection fixes add the required `subprocess` import without breaking shebangs, module docstrings, or future imports; shared imports are inserted once.
+- CodeQL analysis retains a private temporary output directory through execution and SARIF parsing, then removes the output. Unix directory permissions are `0700`.
+- Coccinelle findings identify changed source lines rather than the beginning of surrounding diff context. The executable semantic-patch fixture now distinguishes vulnerable and guarded calls using real `spatch`.
+- Rust and website dependency advisories are remediated, including replacing the affected RustCrypto RSA signing backend with AWS-LC for the GitHub App.
+- Cached website star counts render as text, not HTML. Clipboard success is shown only after the write succeeds.
+
+## Integrations and workflow
+
+- GitHub App PR jobs persist across restarts, retain current-head ordering, and reconcile retryable check updates. Malformed signed payloads return HTTP 400; installation persistence failures return HTTP 503 rather than false acknowledgements. GitHub does not automatically redeliver failed webhooks: operators can redeliver after repairing the failure.
+- Versioned PR security policy is shared by the CLI, adapter, and GitHub App, including reporting and blocking thresholds.
+- `foxguard diff` accepts paired base/head CodeQL databases and rejects incomplete or failed comparisons instead of reporting a clean delta.
+- Semgrep migration-readiness reports classify imported rules as exact, degraded, or skipped, with terminal and versioned JSON output.
+- Claude Code hooks preserve unresolved findings across compaction. Precision tooling includes sealed negative-control and held-out capability evidence contracts.
+- MCP ping preserves request IDs and returns an empty result; notifications remain silent. Adapter file selection respects path boundaries, and suppression suggestions handle case-insensitive extensions.
+- GitHub Action consumers receive usable findings-count, SARIF, and badge outputs. Badge labels are JSON-escaped.
+
+## Release preparation
+
+`scripts/release.sh VERSION` now prepares and verifies metadata on a release branch. It does not commit, push, tag, or publish. Review the metadata through a PR, merge required checks, then tag the verified main commit. Cargo lock resolution is preserved with an offline workspace update; release builds and crate publishing use `--locked`.
+
+Published registry versions and their tags must not be rewritten to recover a partially published release. See [releasing.md](../releasing.md).
+
+## Verification
+
+- All-feature Rust tests, strict all-target Clippy, and binary builds.
+- Actual TUI interaction at 80x24 and 40x12, including search, selection boundaries, help scrolling, and interrupt handling.
+- Real CodeQL auto-database creation and C++ query execution; real Coccinelle vulnerable/safe controls and source-location checks.
+- npm installer, VS Code, Claude Code state-hook, GitHub Action, Marketplace propagation-helper, precision, and evidence-contract tests.
+- Website production build and Rust/npm dependency audits.
+
+## Compatibility and upgrade
+
+The native finding contract remains `1.0.0`. Release preparation is intentionally PR-first; callers relying on the old script to push tags must follow the documented manual tagging step.
+
+```sh
+npx foxguard@0.13.0 .
+cargo install foxguard --version 0.13.0 --locked
+foxguard tui .
+```
+
+GitHub Action and pre-commit users can pin `v0.13.0`:
+
+```yaml
+- uses: 0sec-labs/foxguard/action@v0.13.0
+```
+
+```yaml
+repos:
+  - repo: https://github.com/0sec-labs/foxguard
+    rev: v0.13.0
+    hooks:
+      - id: foxguard
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,33 +2,59 @@
 
 ## Normal flow
 
-1. Write and review `docs/releases/vX.Y.Z.md` for the version to publish.
-2. Start from a clean `main`; the new release-note file is the only allowed uncommitted change.
+1. Write release notes at `docs/releases/vX.Y.Z.md` for the version to publish.
+
+2. Start from a clean working tree on a **dedicated release branch**; the new
+   release-note file is the only allowed uncommitted change.
+
 3. Run:
 
-```sh
-./scripts/release.sh X.Y.Z
-```
+   ```sh
+   ./scripts/release.sh X.Y.Z
+   ```
 
-That script:
+   That script:
+   - verifies that the versioned release note exists under `docs/releases/`
+   - blocks on any unrelated dirty or staged changes
+   - checks the tag does not exist locally or on the remote
+   - bumps Cargo, npm, and VS Code extension versions
+   - refreshes `Cargo.lock` and `vscode-extension/package-lock.json`
+   - updates README action-install refs
+   - runs the verification suite
+   - prints instructions — **it does not commit, push, or tag**
 
-- verifies that the versioned release note exists under `docs/releases/`
-- bumps Cargo, npm, and VS Code extension versions
-- refreshes `vscode-extension/package-lock.json`
-- runs the verification suite
-- commits release metadata to `main`
-- pushes `main`
-- creates and pushes the `v*` tag
+4. Review the changes, commit them on the release branch, push, and open a
+   pull request against `main`:
 
-The tag triggers the GitHub `Release` workflow, which:
+   ```sh
+   git add Cargo.toml Cargo.lock
+   git add packages/npm/package.json
+   git add vscode-extension/package.json vscode-extension/package-lock.json
+   git add README.md docs/releases/vX.Y.Z.md
+   git commit -m "Prepare vX.Y.Z release metadata"
+   git push origin <release-branch>
+   # then open the PR on GitHub
+   ```
 
-- verifies secrets exist
-- verifies tag/version alignment
-- builds release binaries
-- creates or updates the GitHub Release
-- publishes crates.io
-- publishes npm
-- publishes the VS Code extension
+5. After the PR passes required checks (CI, review) and merges to `main`,
+   tag the merge commit and push:
+
+   ```sh
+   git switch main
+   git pull --ff-only
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   The tag push triggers the GitHub `Release` workflow, which:
+   - verifies secrets exist
+   - verifies tag/version alignment across all metadata files
+   - builds Linux and macOS binaries for x86_64/aarch64, and Windows x86_64
+   - creates or updates the GitHub Release with checksums and attestations
+   - publishes crates.io
+   - publishes npm
+   - publishes the VS Code extension
+   - publishes the GitHub App image to GHCR
 
 ## Required GitHub secrets
 
@@ -40,28 +66,37 @@ The tag triggers the GitHub `Release` workflow, which:
 
 The release workflow is intended to be rerun-safe.
 
-- GitHub Release: safe to rerun for the same tag
-- crates.io: rerun is treated as success if that version already exists
-- npm: rerun is treated as success if that version already exists
-- VS Code Marketplace: rerun is treated as success if that version already exists
+- **GitHub Release:** safe to rerun for the same tag
+- **crates.io:** rerun is treated as success if that version already exists
+- **npm:** rerun is treated as success if that version already exists
+- **VS Code Marketplace:** rerun is treated as success if that version already exists
 
-This matters when one registry publishes successfully and another fails later in the workflow.
+This matters when one registry publishes successfully and another fails later
+in the workflow.
 
 ## Recovery rules
 
 If a release fails:
 
-1. Check which registries already published the target version
-2. Fix the real cause on `main`
+1. Check which registries already published the target version.
+2. Fix the real cause on `main`.
 3. If the tag should point to the fixed commit:
-   - delete the GitHub Release
-   - delete the remote tag
-   - recreate the tag on the fixed commit
-   - push the tag again
+   - **Only if the version has NOT been published to any registry:**
+     delete the GitHub Release, delete the remote tag, recreate the tag on
+     the fixed commit, and push the tag again.
+   - **If the version was already published to one or more registries:**
+     do NOT move or delete the tag — registries treat published versions
+     as immutable. Instead, publish a new patch version (for example,
+     `v0.13.1` after `v0.13.0`) containing the fix.
 
-If the tag already points to the correct commit and only a registry publish failed transiently, rerunning the workflow should be enough.
+4. If the tag already points to the correct commit and only a registry
+   publish failed transiently, rerunning the workflow should be enough.
 
 ## Notes
 
-- Keep `Cargo.lock` in sync with release metadata commits
-- Do not hand-publish from local scripts anymore; the GitHub tag workflow is the source of truth
+- Keep `Cargo.lock` in sync with release metadata commits.
+- The release script runs `cargo update --workspace --offline` after bumping
+  the workspace version, preserving locked registry and Git dependencies.
+  Dependencies must already be cached for offline resolution.
+- Do not hand-publish from local scripts; the GitHub tag workflow is the
+  source of truth.

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxguard",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A security scanner as fast as a linter, written in Rust. 200+ built-in rules across 12 source languages.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 # Prepare a tag-driven release for foxguard.
 # Usage: ./scripts/release.sh 0.3.3
+#
+# This script prepares release metadata and runs local verification.  It
+# NEVER pushes branches, creates tags, or publishes.  Use it on a release
+# branch, then open a PR.  After the PR merges to main, tag the verified
+# merge commit to trigger the existing Release workflow.
 
 VERSION="${1:?Usage: ./scripts/release.sh <version>}"
 TAG="v${VERSION}"
@@ -16,14 +21,18 @@ if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+if [ -z "${BRANCH}" ] || [ "${BRANCH}" = "main" ]; then
+  echo "Prepare releases on a dedicated release branch"
+  exit 1
+fi
+
 if [ ! -f "${RELEASE_NOTES}" ]; then
   echo "Write release notes at ${RELEASE_NOTES} before preparing ${TAG}"
   exit 1
 fi
 
-# The versioned release note may be newly authored and untracked; the release
-# metadata commit below stages it. Every other local or staged change is a
-# release blocker so the tag always points at a deliberate, reviewable tree.
+# The new release note may be untracked. Every other local or staged change
+# blocks preparation so the release metadata can be reviewed independently.
 DIRTY_PATHS="$(
   {
     git diff --name-only
@@ -39,17 +48,13 @@ if [ -n "${UNEXPECTED_PATHS}" ]; then
   exit 1
 fi
 
-if [ "${BRANCH}" != "main" ]; then
-  echo "Run releases from main (current branch: ${BRANCH})"
-  exit 1
-fi
-
 if git rev-parse "${TAG}" >/dev/null 2>&1; then
   echo "Tag ${TAG} already exists locally"
   exit 1
 fi
 
-if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+REMOTE_TAG="$(git ls-remote --tags origin "refs/tags/${TAG}")"
+if [ -n "${REMOTE_TAG}" ]; then
   echo "Tag ${TAG} already exists on origin"
   exit 1
 fi
@@ -71,6 +76,10 @@ done
 # to the version users are about to receive.
 perl -i -pe 's{(0sec-labs/foxguard/action)\@v[0-9]+\.[0-9]+\.[0-9]+}{$1\@v'"${VERSION}"'}g' README.md
 perl -i -pe 's{(\s+rev:\s+)v[0-9]+\.[0-9]+\.[0-9]+}{${1}v'"${VERSION}"'}g' README.md
+
+# Refresh Cargo.lock root-package version so that subsequent --locked checks
+# pass without fetching registry data or upgrading unrelated dependencies.
+cargo update --workspace --offline
 
 (
   cd vscode-extension
@@ -96,25 +105,39 @@ cargo test --locked --all-features
   npm pack --dry-run
 )
 
-echo "Committing release metadata..."
-git add Cargo.toml Cargo.lock packages/npm/package.json vscode-extension/package.json vscode-extension/package-lock.json README.md "${RELEASE_NOTES}"
-git commit -m "Prepare ${TAG} release metadata" -m "Bump crate, npm, and VS Code extension versions to ${VERSION} so the
-tag-driven release workflow can publish a coherent release.
-
-Constraint: Release automation now validates tag-to-version alignment before publishing
-Rejected: Keep manual publish steps in the local script | duplicates the release workflow and increases drift risk
-Confidence: high
-Scope-risk: narrow
-Reversibility: clean
-Directive: Use this script to prepare release metadata, then let the tag-triggered GitHub workflow publish artifacts
-Tested: cargo fmt --check; cargo clippy --locked --all-targets --all-features -- -D warnings; cargo test --locked --all-features; npm ci && npm run build (www); npm ci && npm run compile (vscode-extension); npm pack --dry-run (packages/npm)
-Not-tested: Live publish against GitHub Releases, npm, crates.io, and VS Code Marketplace"
-
-echo "Pushing branch and tag..."
-git push origin main
-git tag "${TAG}"
-git push origin "${TAG}"
-
 echo ""
-echo "=== ${TAG} queued ==="
-echo "GitHub Actions release workflow will build binaries, publish artifact attestations, and publish GitHub, crates.io, npm, and VS Code if the required secrets are configured."
+echo "=== ${TAG} metadata prepared ==="
+echo ""
+echo "The working tree now contains version bumps, updated lock files,"
+echo "README action-ref updates, and ${RELEASE_NOTES}."
+echo ""
+echo "To finish this release:"
+echo ""
+echo "  1. Review every changed file:"
+echo ""
+echo "       git diff"
+echo ""
+echo "  2. Commit the release metadata on this branch:"
+echo ""
+echo "       git add Cargo.toml Cargo.lock"
+echo "       git add packages/npm/package.json"
+echo "       git add vscode-extension/package.json vscode-extension/package-lock.json"
+echo "       git add README.md ${RELEASE_NOTES}"
+echo "       git commit -m \"Prepare ${TAG} release metadata\""
+echo ""
+echo "  3. Push the branch and open a pull request against main:"
+echo ""
+echo "       git push origin ${BRANCH}"
+echo ""
+echo "  4. After the PR passes required checks and is merged to main,"
+echo "     check out the merge commit and tag it:"
+echo ""
+echo "       git checkout main"
+echo "       git pull --ff-only"
+echo "       git tag ${TAG}"
+echo "       git push origin ${TAG}"
+echo ""
+echo "  5. The tag push triggers the Release workflow at"
+echo "     https://github.com/0sec-labs/foxguard/actions/workflows/release.yml"
+echo "     to build binaries, create a GitHub Release, and publish"
+echo "     to crates.io, npm, VS Code Marketplace, and GHCR."

--- a/src/engine/coccinelle.rs
+++ b/src/engine/coccinelle.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
+use std::sync::{LazyLock, OnceLock};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -470,27 +470,80 @@ fn parse_spatch_output(
 }
 
 fn diff_hunk_lines(output: &str) -> Vec<usize> {
-    static HUNK_RE: OnceLock<Regex> = OnceLock::new();
-    let hunk_re = HUNK_RE.get_or_init(|| {
-        Regex::new(r"^@@\s+-(?P<line>\d+)(?:,\d+)?\s+\+(?:\d+)(?:,\d+)?\s+@@")
+    static HUNK_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^@@\s+-(?P<line>\d+)(?:,(?P<count>\d+))?\s+\+\d+(?:,\d+)?\s+@@")
             .expect("invalid Coccinelle hunk regex")
     });
-    static CONTEXT_HUNK_RE: OnceLock<Regex> = OnceLock::new();
-    let context_hunk_re = CONTEXT_HUNK_RE.get_or_init(|| {
+    static CONTEXT_HUNK_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"^\*\*\*\s+(?P<line>\d+)(?:,\d+)?\s+\*\*\*\*")
             .expect("invalid Coccinelle context hunk regex")
     });
 
-    output
-        .lines()
-        .filter_map(|line| {
-            hunk_re
-                .captures(line)
-                .or_else(|| context_hunk_re.captures(line))
-                .and_then(|captures| captures.name("line"))
-                .and_then(|line| line.as_str().parse::<usize>().ok())
-        })
-        .collect()
+    let mut findings = Vec::new();
+    let mut source_line = None;
+    let mut context_diff = false;
+    let mut pending_addition = None;
+    let mut has_removal = false;
+    for line in output.lines() {
+        let unified = HUNK_RE.captures(line);
+        let context = if unified.is_none() {
+            CONTEXT_HUNK_RE.captures(line)
+        } else {
+            None
+        };
+        if unified.is_some()
+            || context.is_some()
+            || line.starts_with("--- ")
+            || line.starts_with("+++ ")
+            || line.starts_with("*** ")
+        {
+            if let Some(line) = pending_addition.take() {
+                findings.push(line);
+            }
+            source_line = unified.as_ref().or(context.as_ref()).and_then(|captures| {
+                let start = captures.name("line")?.as_str().parse::<usize>().ok()?;
+                let empty = captures
+                    .name("count")
+                    .is_some_and(|count| count.as_str() == "0");
+                Some(start.saturating_add(usize::from(empty)).max(1))
+            });
+            context_diff = context.is_some();
+            has_removal = false;
+            continue;
+        }
+        let Some(current) = source_line else {
+            continue;
+        };
+        let marker = if context_diff {
+            match line.get(..2) {
+                Some("- " | "! ") => b'-',
+                Some("  ") => b' ',
+                _ => continue,
+            }
+        } else {
+            match line.as_bytes().first() {
+                Some(marker) => *marker,
+                None => continue,
+            }
+        };
+        match marker {
+            b'-' => {
+                findings.push(current);
+                has_removal = true;
+                pending_addition = None;
+                source_line = Some(current.saturating_add(1));
+            }
+            b' ' => source_line = Some(current.saturating_add(1)),
+            b'+' if !has_removal => {
+                pending_addition.get_or_insert(current);
+            }
+            _ => {}
+        }
+    }
+    if let Some(line) = pending_addition {
+        findings.push(line);
+    }
+    findings
 }
 
 fn file_line_matches(output: &str, target: &Path) -> Vec<usize> {
@@ -790,7 +843,7 @@ rules:
         .unwrap();
 
         let output = format!(
-            "--- {}\n+++ /tmp/cocci-output\n@@ -3,7 +3,7 @@\n",
+            "--- {}\n+++ /tmp/cocci-output\n@@ -1,4 +1,3 @@\n int f(void) {{\n   int ok = 0;\n-  crypto_aead_decrypt(skb);\n }}\n",
             target.display()
         );
         let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), &output);
@@ -812,7 +865,7 @@ rules:
         .unwrap();
 
         let output = format!(
-            "*** {}\n--- /tmp/cocci-output\n***************\n*** 3,7 ****\n",
+            "*** {}\n--- /tmp/cocci-output\n***************\n*** 1,4 ****\n  int f(void) {{\n    int ok = 0;\n!   crypto_aead_decrypt(skb);\n  }}\n--- 1,4 ----\n  int f(void) {{\n    int ok = 0;\n!   checked_decrypt(skb);\n  }}\n",
             target.display()
         );
         let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), &output);
@@ -820,5 +873,26 @@ rules:
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].line, 3);
         assert!(findings[0].snippet.contains("crypto_aead_decrypt"));
+    }
+
+    #[test]
+    fn replacement_and_insertion_diffs_preserve_original_source_locations() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vulnerable.c");
+        std::fs::write(&target, "int f(void) {\n  setup();\n  decrypt();\n}\n").unwrap();
+        let replacement = "@@ -1,4 +1,4 @@\n int f(void) {\n   setup();\n-  decrypt();\n+  checked_decrypt();\n }\n";
+        let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), replacement);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 3);
+        assert_eq!(findings[0].snippet, "  decrypt();");
+
+        let insertion = "@@ -2,0 +3 @@\n+  check_guard();\n";
+        let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), insertion);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 3);
+        assert_eq!(findings[0].snippet, "  decrypt();");
+
+        let empty_hunk = "@@ -1,4 +1,4 @@\n int f(void) {\n   setup();\n   decrypt();\n }\n";
+        assert!(parse_spatch_output(&sample_rule(), &target, dir.path(), empty_hunk).is_empty());
     }
 }

--- a/src/engine/codeql.rs
+++ b/src/engine/codeql.rs
@@ -1769,22 +1769,39 @@ select f
     /// End-to-end auto-DB run. Requires `codeql` on PATH plus the
     /// `codeql/cpp-all` library pack installed; CI runners don't have these
     /// so it stays `#[ignore]`'d. Run locally with:
-    ///   cargo test --test-threads=1 -- --ignored codeql_auto_database_runs_end_to_end
+    ///   cargo test --lib codeql_auto_database_runs_end_to_end -- --ignored --test-threads=1
     #[test]
     #[ignore = "requires codeql CLI and cpp-all qlpack on host"]
     fn codeql_auto_database_runs_end_to_end() {
-        if probe_codeql().is_err() {
-            eprintln!("codeql not on PATH — nothing to verify");
-            return;
-        }
+        probe_codeql().expect("the live integration test requires CodeQL on PATH");
         let source = TempDir::new().expect("source tempdir");
         std::fs::write(
             source.path().join("main.c"),
             "int main(void) { return 0; }\n",
         )
         .unwrap();
+        std::fs::write(
+            source.path().join("Makefile"),
+            "all:\n\tcc main.c -o main\n",
+        )
+        .unwrap();
 
         let query_dir = TempDir::new().expect("query tempdir");
+        std::fs::write(
+            query_dir.path().join("qlpack.yml"),
+            "name: foxguard/live-test\nversion: 0.0.0\ndependencies:\n  codeql/cpp-all: \"*\"\n",
+        )
+        .unwrap();
+        let install = Command::new("codeql")
+            .args(["pack", "install"])
+            .current_dir(query_dir.path())
+            .output()
+            .expect("CodeQL query dependencies should resolve");
+        assert!(
+            install.status.success(),
+            "CodeQL query dependencies failed: {}",
+            String::from_utf8_lossy(&install.stderr)
+        );
         let query_path = query_dir.path().join("trivial.ql");
         std::fs::write(
             &query_path,
@@ -1814,10 +1831,15 @@ select f, "found main"
 
         let result = scan_with_notices_for_target(&[rule], None, Some(source.path()));
         assert!(
-            !result.findings.is_empty() || result.notices.is_empty(),
-            "expected findings or zero notices, got notices: {:?}",
+            result.notices.is_empty(),
+            "unexpected CodeQL notices: {:?}",
             result.notices
         );
+        assert_eq!(result.findings.len(), 1);
+        assert_eq!(result.findings[0].rule_id, "test/trivial");
+        assert_eq!(result.findings[0].file, "main.c");
+        assert_eq!(result.findings[0].line, 1);
+        assert_eq!(result.findings[0].description, "found main");
     }
 
     #[test]

--- a/src/rules/csharp_taint.rs
+++ b/src/rules/csharp_taint.rs
@@ -2127,52 +2127,6 @@ mod tests {
         analyze_tree(tree.root_node(), src, spec, None)
     }
 
-    #[test]
-    #[ignore]
-    fn dump_ast_for_debug() {
-        let src = r#"
-class Controller {
-    public void Handle() {
-        string cmd = Request.QueryString["cmd"];
-        Process.Start(cmd);
-    }
-}
-"#;
-        let Some(tree) = parse_file(src, Language::CSharp) else {
-            panic!("should parse");
-        };
-        fn dump(node: tree_sitter::Node, source: &str, depth: usize) {
-            let indent = "  ".repeat(depth);
-            let text = &source[node.byte_range()];
-            let text_short: String = text.chars().take(50).collect();
-            // Print field names for children via cursor
-            let mut cursor = node.walk();
-            let has_fields = cursor.goto_first_child();
-            if has_fields {
-                loop {
-                    let field_name = cursor.field_name().unwrap_or("<anon>");
-                    eprintln!(
-                        "{}{}.{} = {:?}",
-                        indent,
-                        node.kind(),
-                        field_name,
-                        cursor.node().kind()
-                    );
-                    if !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-            }
-            eprintln!("{}{} = {:?}", indent, node.kind(), text_short);
-            let mut c = node.walk();
-            for child in node.children(&mut c) {
-                dump(child, source, depth + 1);
-            }
-        }
-        dump(tree.root_node(), src, 0);
-        panic!("dump complete — check stderr");
-    }
-
     // ── direct-unit tests (analyze_tree) ─────────────────────────────────
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -15,7 +15,7 @@ use crate::config::{
     load_for_scan,
 };
 use crate::{Finding, Severity};
-use crossterm::event::{self, KeyCode, KeyEvent, MouseEvent, MouseEventKind};
+use crossterm::event::{self, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use std::path::Path;
@@ -31,19 +31,66 @@ pub(super) enum ControlFlow {
 
 impl TuiApp {
     pub(super) fn handle_key(&mut self, key: KeyEvent) -> ControlFlow {
-        if matches!(key.code, KeyCode::Char('?')) {
-            self.show_help = !self.show_help;
+        if key.kind != event::KeyEventKind::Press {
+            return ControlFlow::Continue;
+        }
+        // Ctrl+C / Ctrl+Shift+C always exits, regardless of mode.
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
+        {
+            return ControlFlow::Exit;
+        }
+        if key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
             return ControlFlow::Continue;
         }
 
         if self.show_help {
             return match key.code {
-                KeyCode::Esc | KeyCode::Char('q') => {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
                     self.show_help = false;
+                    self.help_scroll = 0;
+                    ControlFlow::Continue
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.help_scroll = self.help_scroll.saturating_sub(1);
+                    ControlFlow::Continue
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.help_scroll = self.help_scroll.saturating_add(1);
+                    ControlFlow::Continue
+                }
+                KeyCode::PageUp => {
+                    self.help_scroll = self.help_scroll.saturating_sub(8);
+                    ControlFlow::Continue
+                }
+                KeyCode::PageDown => {
+                    self.help_scroll = self.help_scroll.saturating_add(8);
+                    ControlFlow::Continue
+                }
+                KeyCode::Home => {
+                    self.help_scroll = 0;
+                    ControlFlow::Continue
+                }
+                KeyCode::End => {
+                    self.help_scroll = u16::MAX;
                     ControlFlow::Continue
                 }
                 _ => ControlFlow::Continue,
             };
+        }
+
+        if key.code == KeyCode::Char('?')
+            && !self.search_mode
+            && self.severity_picker.is_none()
+            && self.action_menu.is_none()
+            && self.export_menu.is_none()
+        {
+            self.show_help = true;
+            self.help_scroll = 0;
+            return ControlFlow::Continue;
         }
 
         if self.show_launch {
@@ -68,6 +115,17 @@ impl TuiApp {
 
         match key.code {
             KeyCode::Char('q') => ControlFlow::Exit,
+            KeyCode::Home => {
+                self.select_filtered_index(0);
+                ControlFlow::Continue
+            }
+            KeyCode::End => {
+                let len = self.filtered_indices().len();
+                if len > 0 {
+                    self.select_filtered_index(len - 1);
+                }
+                ControlFlow::Continue
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 self.move_selection(1);
                 ControlFlow::Continue
@@ -217,6 +275,10 @@ impl TuiApp {
 
     pub(super) fn handle_launch_key(&mut self, key: KeyCode) -> ControlFlow {
         match key {
+            KeyCode::Char(ch) if self.launch_mode == LaunchMode::Diff => {
+                self.launch_diff_target.push(ch);
+                ControlFlow::Continue
+            }
             KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Exit,
             KeyCode::Up | KeyCode::Char('k') => {
                 self.launch_mode = self.launch_mode.previous();
@@ -244,10 +306,6 @@ impl TuiApp {
             }
             KeyCode::Backspace if self.launch_mode == LaunchMode::Diff => {
                 self.launch_diff_target.pop();
-                ControlFlow::Continue
-            }
-            KeyCode::Char(ch) if self.launch_mode == LaunchMode::Diff => {
-                self.launch_diff_target.push(ch);
                 ControlFlow::Continue
             }
             KeyCode::Enter => {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -43,6 +43,7 @@ pub(super) struct TuiApp {
     pub(super) hover_index: Option<usize>,
     pub(super) show_notices: bool,
     pub(super) show_help: bool,
+    pub(super) help_scroll: u16,
     /// When on, a CNSA 2.0 migration-readiness strip is drawn at the bottom
     /// of the main scan body. Toggled by `Shift+N` (see `handle_key`). Chose
     /// `Shift+N` instead of the issue's suggested `Shift+C` because the
@@ -87,6 +88,7 @@ impl TuiApp {
             hover_index: None,
             show_notices: true,
             show_help: false,
+            help_scroll: 0,
             show_compliance_panel: false,
             runtime_notices: Vec::new(),
             active_request_id: 0,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2503,3 +2503,87 @@ fn list_item_omits_crypto_chip_when_none() {
         "non-crypto finding should not have algorithm chip: {debug}"
     );
 }
+
+#[test]
+fn search_punctuation_is_text_and_does_not_open_help() {
+    let mut app = TuiApp::new(tui_args_for(".".into()));
+    app.show_launch = false;
+    app.handle_key(KeyEvent::from(KeyCode::Char('/')));
+    app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+    assert_eq!(app.search_query, "?");
+    assert!(!app.show_help);
+    app.handle_key(KeyEvent::from(KeyCode::Esc));
+    app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+    assert!(app.show_help);
+}
+
+#[test]
+fn interrupt_exits_from_launch_findings_and_every_modal() {
+    use crossterm::event::KeyModifiers;
+    for mode in [
+        "launch", "findings", "search", "help", "triage", "export", "severity",
+    ] {
+        let mut app = app_with_single_finding(None, None);
+        app.show_launch = mode == "launch";
+        match mode {
+            "search" => app.search_mode = true,
+            "help" => app.show_help = true,
+            "triage" => {
+                app.action_menu = Some(ActionMenu {
+                    actions: vec![TriageAction::AddToBaseline],
+                    selected: 0,
+                });
+            }
+            "export" => {
+                app.open_export_menu();
+                assert!(app.export_menu.is_some());
+            }
+            "severity" => {
+                app.open_severity_picker();
+                assert!(app.severity_picker.is_some());
+            }
+            _ => {}
+        }
+        assert!(
+            matches!(
+                app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+                ControlFlow::Exit
+            ),
+            "{mode}"
+        );
+    }
+}
+
+#[test]
+fn finding_home_and_end_respect_filtered_selection() {
+    let mut app = app_with_single_finding(None, None);
+    app.show_launch = false;
+    let mut second = app.result.as_ref().unwrap().findings[0].clone();
+    second.line += 1;
+    app.result.as_mut().unwrap().findings.push(second);
+    app.handle_key(KeyEvent::from(KeyCode::End));
+    assert_eq!(app.selected, 1);
+    app.handle_key(KeyEvent::from(KeyCode::Home));
+    assert_eq!(app.selected, 0);
+    app.search_query = "no-such-finding-unique".into();
+    app.clamp_selection();
+    app.handle_key(KeyEvent::from(KeyCode::End));
+    app.handle_key(KeyEvent::from(KeyCode::Home));
+    assert_eq!(app.selected, 0);
+    assert!(app.filtered_indices().is_empty());
+}
+
+#[test]
+fn diff_target_accepts_letters_and_digits_reserved_by_navigation() {
+    let mut app = TuiApp::new(tui_args_for(".".into()));
+    app.launch_mode = LaunchMode::Diff;
+    app.launch_diff_target.clear();
+    for ch in "fix/jkq1234".chars() {
+        assert!(matches!(
+            app.handle_key(KeyEvent::from(KeyCode::Char(ch))),
+            ControlFlow::Continue
+        ));
+    }
+    assert_eq!(app.launch_diff_target, "fix/jkq1234");
+    assert_eq!(app.launch_mode, LaunchMode::Diff);
+}

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -781,17 +781,29 @@ impl TuiApp {
 
     pub(super) fn draw_launch_footer(&self, frame: &mut ratatui::Frame, area: Rect) {
         let left = Line::from(vec![
-            footer_key_span("h/l"),
+            footer_key_span(if self.launch_mode == LaunchMode::Diff {
+                "up/down"
+            } else {
+                "j/k"
+            }),
             Span::raw(" move  "),
-            footer_key_span("1-4"),
-            Span::raw(" jump  "),
+            footer_key_span(if self.launch_mode == LaunchMode::Diff {
+                "type"
+            } else {
+                "1-4"
+            }),
+            Span::raw(if self.launch_mode == LaunchMode::Diff {
+                " target  "
+            } else {
+                " jump  "
+            }),
             footer_key_span("Tab"),
             Span::raw(" cycle  "),
             footer_key_span("Enter"),
             Span::raw(" launch  "),
             footer_key_span("?"),
             Span::raw(" help  "),
-            footer_key_span("q"),
+            footer_key_span("Esc"),
             Span::raw(" quit"),
         ]);
         let right = Line::from(vec![
@@ -811,47 +823,89 @@ impl TuiApp {
         draw_status_bar(frame, area, left, right);
     }
 
-    pub(super) fn draw_help(&self, frame: &mut ratatui::Frame) {
-        let area = centered_rect(56, 42, frame.area());
+    pub(super) fn draw_help(&mut self, frame: &mut ratatui::Frame) {
+        let bounds = frame.area();
+        let width = bounds.width.saturating_sub(2).min(88);
+        let height = bounds.height.saturating_sub(2).min(32);
+        let area = Rect::new(
+            bounds.x + (bounds.width - width) / 2,
+            bounds.y + (bounds.height - height) / 2,
+            width,
+            height,
+        );
         frame.render_widget(Clear, area);
-        let help = Paragraph::new(Text::from(vec![
-            Line::from(Span::styled(
-                "foxguard tui help",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from("j/k or arrows  move between findings"),
-            Line::from("/              search findings"),
-            Line::from("0-4            set minimum severity filter"),
-            Line::from("c              cycle session confidence filter"),
-            Line::from("Shift+C        cycle list sort (severity | confidence)"),
-            Line::from("Tab            cycle open target between finding/source/sink"),
-            Line::from("i              open triage actions for the selected finding"),
-            Line::from("Enter          open the current target in your editor"),
-            Line::from("w              show or hide notices panel"),
-            Line::from("Shift+N        toggle CNSA 2.0 compliance panel"),
-            Line::from("e              export findings (CBOM / JSON / SARIF)"),
-            Line::from("PageUp/Down    scroll detail pane"),
-            Line::from("[/]            scroll notices pane"),
-            Line::from("mouse wheel    move between findings"),
-            Line::from("mouse click    select a finding"),
-            Line::from("Shift-drag     terminal-native text selection"),
-            Line::from("r              rescan"),
-            Line::from("q              quit"),
-            Line::from("? or Esc       close this help"),
-        ]))
-        .alignment(Alignment::Left)
-        .style(Style::default().bg(Color::Rgb(22, 24, 29)).fg(Color::White))
-        .block(
-            Block::default()
-                .title("help")
-                .borders(Borders::ALL)
-                .style(Style::default().bg(Color::Rgb(22, 24, 29))),
-        )
-        .wrap(Wrap { trim: false });
-        frame.render_widget(help, area);
+        let inner_width = width.saturating_sub(2).max(1) as usize;
+        let visible_rows = height.saturating_sub(2) as usize;
+        let shortcuts: &[&str] = if self.show_launch && self.launch_mode == LaunchMode::Diff {
+            &[
+                "Arrows/Tab     Select scan mode",
+                "Type           Edit target branch",
+                "Backspace      Delete target character",
+                "Enter          Launch diff scan",
+                "Esc or Ctrl+C  Quit",
+            ]
+        } else if self.show_launch {
+            &[
+                "j/k or arrows  Select scan mode",
+                "Tab            Cycle scan mode",
+                "1-4            Jump to a mode",
+                "Enter          Launch scan",
+                "Diff mode: type the target branch",
+                "Backspace      Edit diff target",
+                "q or Esc       Quit",
+                "Ctrl+C         Quit from any view",
+            ]
+        } else {
+            &[
+                "j/k or arrows  Move between findings",
+                "Home/End       First/last finding",
+                "/              Search findings",
+                "Enter/Esc      Leave search",
+                "0-4            Minimum severity",
+                "c              Confidence filter",
+                "Shift+C        Cycle sort order",
+                "Tab            Finding/source/sink",
+                "i              Triage selected finding",
+                "Enter or o     Open in your editor",
+                "w              Toggle notices",
+                "Shift+N        CNSA 2.0 panel",
+                "e              Export CBOM/JSON/SARIF",
+                "PageUp/Down    Scroll detail",
+                "[/]            Scroll notices",
+                "Mouse wheel    Move between findings",
+                "Mouse click    Select a finding",
+                "Shift-drag     Select terminal text",
+                "r              Rescan",
+                "q              Quit",
+                "Ctrl+C         Quit from any view",
+            ]
+        };
+        // Explicit ASCII wrapping keeps scroll bounds identical to rendered rows.
+        let lines: Vec<Line<'_>> = shortcuts
+            .iter()
+            .flat_map(|text| {
+                text.as_bytes().chunks(inner_width).map(|chunk| {
+                    Line::from(std::str::from_utf8(chunk).expect("help shortcuts are ASCII"))
+                })
+            })
+            .collect();
+        let max_scroll = lines
+            .len()
+            .saturating_sub(visible_rows)
+            .min(u16::MAX as usize) as u16;
+        self.help_scroll = self.help_scroll.min(max_scroll);
+        let title = format!("Help {}/{}", usize::from(self.help_scroll) + 1, lines.len());
+        let block = Block::default()
+            .title(title)
+            .title_bottom("Esc/? close | j/k PgUp/Dn scroll")
+            .borders(Borders::ALL)
+            .style(Style::default().bg(Color::Rgb(22, 24, 29)).fg(Color::White));
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(block)
+                .scroll((self.help_scroll, 0)),
+            area,
+        );
     }
 
     pub(super) fn draw_action_menu(&self, frame: &mut ratatui::Frame) {

--- a/tests/coccinelle_integration.rs
+++ b/tests/coccinelle_integration.rs
@@ -35,7 +35,8 @@ while [ "$#" -gt 0 ]; do
 done
 echo "--- $last"
 echo "+++ /tmp/cocci-output"
-echo "@@ -{hunk_line},7 +{hunk_line},7 @@"
+echo "@@ -{hunk_line},1 +{hunk_line},0 @@"
+echo "-    err = crypto_aead_decrypt(req);"
 exit 0
 "#
     );
@@ -163,4 +164,48 @@ fn missing_spatch_skips_coccinelle_once_without_failing_scan() {
         1,
         "expected a single missing dependency warning, got: {stderr}"
     );
+}
+
+#[test]
+#[ignore = "requires a real spatch executable and its runtime support files"]
+fn real_coccinelle_reports_only_the_unguarded_call_without_editing_sources() {
+    let probe = Command::new("spatch")
+        .arg("--version")
+        .output()
+        .expect("the live integration test requires spatch on PATH");
+    assert!(probe.status.success());
+    let repo = repo_with_c_fixture();
+    fs::copy(
+        fixture_path("dirty_frag_safe.c"),
+        repo.path().join("safe.c"),
+    )
+    .unwrap();
+    let vulnerable = fs::read(repo.path().join("vulnerable.c")).unwrap();
+    let safe = fs::read(repo.path().join("safe.c")).unwrap();
+    let output = foxguard_cmd()
+        .current_dir(repo.path())
+        .args([".", "--no-builtins", "--rules"])
+        .arg(fixture_path("dirty-frag-rules.yml"))
+        .args(["--format", "json"])
+        .output()
+        .expect("foxguard should run the real semantic patch");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let findings = json_findings(&output.stdout);
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0]["file"], "vulnerable.c");
+    assert_eq!(findings[0]["line"], 11);
+    assert!(findings[0]["snippet"]
+        .as_str()
+        .unwrap()
+        .contains("crypto_aead_decrypt"));
+    assert_eq!(
+        fs::read(repo.path().join("vulnerable.c")).unwrap(),
+        vulnerable
+    );
+    assert_eq!(fs::read(repo.path().join("safe.c")).unwrap(), safe);
 }

--- a/tests/fixtures/coccinelle/dirty-frag-inplace-crypto-no-cow.cocci
+++ b/tests/fixtures/coccinelle/dirty-frag-inplace-crypto-no-cow.cocci
@@ -5,6 +5,6 @@ expression skb, req;
 fn(...) {
   <...
   when != skb_cow_data(skb, ...)
-  crypto_aead_decrypt(req)
+* crypto_aead_decrypt(req)
   ...>
 }

--- a/tests/release_provenance.rs
+++ b/tests/release_provenance.rs
@@ -1,57 +1,124 @@
-const RELEASE_WORKFLOW: &str = include_str!("../.github/workflows/release.yml");
-const README: &str = include_str!("../README.md");
-const NPM_README: &str = include_str!("../packages/npm/README.md");
-const PROVENANCE_DOCS: &str = include_str!("../docs/release-provenance.md");
-const RELEASE_SCRIPT: &str = include_str!("../scripts/release.sh");
+#![cfg(unix)]
 
-fn index_of(haystack: &str, needle: &str) -> usize {
-    match haystack.find(needle) {
-        Some(index) => index,
-        None => panic!("missing expected release provenance text: {needle}"),
-    }
-}
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
 
-#[test]
-fn release_workflow_attests_binaries_before_publishing_release() {
-    assert!(RELEASE_WORKFLOW.contains("id-token: write"));
-    assert!(RELEASE_WORKFLOW.contains("attestations: write"));
-    assert!(RELEASE_WORKFLOW.contains("contents: write"));
-
-    assert_eq!(
-        RELEASE_WORKFLOW
-            .matches("uses: actions/attest-build-provenance@v2")
-            .count(),
-        2
+fn git(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    assert!(RELEASE_WORKFLOW.contains("subject-checksums: release/checksums.txt"));
-    assert!(RELEASE_WORKFLOW.contains("subject-path: release/checksums.txt"));
+    String::from_utf8(output.stdout).unwrap()
+}
 
-    let checksum_step = index_of(RELEASE_WORKFLOW, "name: Generate checksums");
-    let attest_step = index_of(RELEASE_WORKFLOW, "name: Attest release binaries");
-    let release_step = index_of(RELEASE_WORKFLOW, "uses: softprops/action-gh-release@v2");
+fn release_fixture() -> TempDir {
+    let root = tempfile::tempdir().unwrap();
+    git(root.path(), &["init", "--initial-branch=release/test"]);
+    git(
+        root.path(),
+        &["config", "user.email", "release-test@example.invalid"],
+    );
+    git(root.path(), &["config", "user.name", "Release test"]);
+    fs::write(
+        root.path().join("Cargo.toml"),
+        "[package]\nname = \"foxguard\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    git(root.path(), &["add", "Cargo.toml"]);
+    git(root.path(), &["commit", "-m", "fixture"]);
+    fs::create_dir_all(root.path().join("docs/releases")).unwrap();
+    fs::write(
+        root.path().join("docs/releases/v0.2.0.md"),
+        "Release fixture\n",
+    )
+    .unwrap();
+    root
+}
 
-    assert!(checksum_step < attest_step);
-    assert!(attest_step < release_step);
+fn assert_preparation_rejected(root: &Path) {
+    let manifest = fs::read(root.join("Cargo.toml")).unwrap();
+    let head = git(root, &["rev-parse", "HEAD"]);
+    let tags = git(root, &["tag", "--list"]);
+    let output = Command::new("bash")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/release.sh"))
+        .arg("0.2.0")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "preparation unexpectedly succeeded"
+    );
+    assert_eq!(fs::read(root.join("Cargo.toml")).unwrap(), manifest);
+    assert_eq!(git(root, &["rev-parse", "HEAD"]), head);
+    assert_eq!(git(root, &["tag", "--list"]), tags);
 }
 
 #[test]
-fn release_notes_are_kept_under_docs_and_required_for_a_release() {
-    assert!(RELEASE_WORKFLOW.contains("body_path: docs/releases/${{ github.ref_name }}.md"));
-    assert!(RELEASE_SCRIPT.contains("RELEASE_NOTES=\"docs/releases/${TAG}.md\""));
-    assert!(RELEASE_SCRIPT.contains("if [ ! -f \"${RELEASE_NOTES}\" ]"));
-    assert!(RELEASE_SCRIPT.contains("git ls-files --others --exclude-standard"));
-    assert!(RELEASE_SCRIPT.contains("grep -Fvx \"${RELEASE_NOTES}\""));
-    assert!(RELEASE_SCRIPT.contains("\"${RELEASE_NOTES}\""));
+fn release_preparation_rejects_unrelated_changes_before_mutating_metadata() {
+    let root = release_fixture();
+    fs::write(root.path().join("unrelated.txt"), "keep this work\n").unwrap();
+    assert_preparation_rejected(root.path());
+    assert_eq!(
+        fs::read_to_string(root.path().join("unrelated.txt")).unwrap(),
+        "keep this work\n"
+    );
 }
 
 #[test]
-fn installer_docs_explain_checksum_and_provenance_behavior() {
-    for docs in [README, NPM_README, PROVENANCE_DOCS] {
-        assert!(docs.contains("checksums.txt"));
-        assert!(docs.contains("gh attestation verify"));
-    }
+fn release_preparation_rejects_missing_notes_and_main_branch() {
+    let root = release_fixture();
+    fs::remove_file(root.path().join("docs/releases/v0.2.0.md")).unwrap();
+    assert_preparation_rejected(root.path());
+    fs::write(
+        root.path().join("docs/releases/v0.2.0.md"),
+        "Release fixture\n",
+    )
+    .unwrap();
+    git(root.path(), &["branch", "-m", "main"]);
+    assert_preparation_rejected(root.path());
+}
 
-    assert!(PROVENANCE_DOCS.contains("SHA-256"));
-    assert!(PROVENANCE_DOCS.contains("Failure modes"));
-    assert!(PROVENANCE_DOCS.contains("Trust model"));
+#[test]
+fn release_preparation_fails_closed_when_origin_cannot_be_checked() {
+    let root = release_fixture();
+    git(
+        root.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            root.path().join("missing.git").to_str().unwrap(),
+        ],
+    );
+    assert_preparation_rejected(root.path());
+}
+
+#[test]
+fn release_preparation_preserves_existing_local_and_remote_tags() {
+    let root = release_fixture();
+    git(root.path(), &["tag", "v0.2.0"]);
+    assert_preparation_rejected(root.path());
+    git(root.path(), &["tag", "-d", "v0.2.0"]);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "--bare"]);
+    git(
+        root.path(),
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    git(root.path(), &["push", "origin", "HEAD:refs/tags/v0.2.0"]);
+    let remote_tag = git(remote.path(), &["rev-parse", "refs/tags/v0.2.0"]);
+    assert_preparation_rejected(root.path());
+    assert_eq!(
+        git(remote.path(), &["rev-parse", "refs/tags/v0.2.0"]),
+        remote_tag
+    );
 }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foxguard",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foxguard",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "foxguard",
   "displayName": "foxguard",
   "description": "A security scanner as fast as a linter, written in Rust.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publisher": "peaktwilight",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Changes
- Responsive, scrollable, context-aware TUI help; literal question-mark search; global Ctrl+C; Home/End finding navigation; complete diff-target text entry.
- Fix real Coccinelle match markers and source-line reporting; preserve original source locations across diff context, replacements, and insertions.
- Strengthen live CodeQL/Coccinelle regressions; remove an obsolete intentionally panicking AST dump and replace release source-string assertions with executable safety checks.
- Make release preparation PR-first and fail closed on origin checks. Keep locked dependency resolution unchanged; verify Cargo.lock/tag alignment and build only published binaries with --locked.
- Prepare coherent v0.13.0 Cargo/npm/VS Code metadata and release notes. No tag or registry publish occurs until this PR is merged after checks.

## Verification
- 1,624 regular Rust tests passed; strict all-target/all-feature Clippy and builds passed.
- All four optional runtime/benchmark tests passed with real CodeQL 2.27.0 and Coccinelle 1.1.1 installed. Two illustrative documentation snippets remain ignored.
- Actual TUI smoke at 80x24 and 40x12: 56 findings; Home/End 1/56 and 56/56; literal ? search; reachable/bounded help; Ctrl+C exits.
- Real Coccinelle before: no executable match marker, then wrong context line 8. After: only vulnerable.c:11, correct decrypt snippet; guarded control clean; source files unchanged.
- Real CodeQL created a C++ database and returned the expected main.c:1 finding.
- npm installer, VS Code, Claude Code hooks, action counts, Marketplace helper, 16 precision tests, 13 negative-control tests, and 58 held-out tests passed. Website builds 20 pages. Cargo and npm audits clean.
- Ran the actual release preparation script successfully in an isolated checkout. Cargo.lock is byte-identical after normalizing only the root package version. Existing unrelated worktrees were left untouched.
