### PR TITLE
fix(github-app): reconcile installations, classify usage, and link FoxGuard with 0sec in README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3152,10 +3163,13 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3561,6 +3575,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ hmac = { version = "0.12", optional = true }
 hex = { version = "0.4", optional = true }
 tower-http = { version = "0.6", default-features = false, features = ["trace", "limit"], optional = true }
 tracing = { version = "0.1", optional = true }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"], optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "json"], optional = true }
 # Use AWS-LC for RS256 signing; the RustCrypto RSA backend has RUSTSEC-2023-0071.
 jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"], optional = true }
 tree-sitter-ocaml = "0.25.0"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,32 @@ repos:
 
 Integrations: [GitHub App](https://github.com/apps/foxguard-app/installations/new), [VS Code](https://marketplace.visualstudio.com/items?itemName=peaktwilight.foxguard), [Claude Code plugin](docs/claude-code-integration.md), and [MCP server](docs/mcp-server.md).
 
+### Hosted GitHub App operations
+
+`foxguard-github-app` writes newline-delimited JSON logs. Completed and failed
+scans use `event=foxguard.scan.completed` and `event=foxguard.scan.failed`, with
+delivery, installation, repository, PR, commit, duration, and `usage_scope`
+fields for correlation. Keep identifiers as log fields, not metric labels.
+
+Set `FOXGUARD_INTERNAL_ACCOUNTS` to a comma-separated list of your own GitHub
+accounts and organizations. Matching is case-insensitive. Other owners are
+classified as `external`; an unset list or missing owner produces `unknown`.
+External activity is not proof of a paying customer, and scans are not people.
+
+The installation registry is reconciled against all pages of GitHub's App
+installation API at startup and hourly. Failed refreshes retain existing state;
+concurrent webhooks take precedence. Sparse webhook metadata preserves known
+account details and observed repository names. Those names are not a complete
+inventory of an installation's accessible repositories.
+
+Persist `FOXGUARD_INSTALLATIONS_PATH` and `FOXGUARD_PULL_REQUEST_JOBS_PATH` on
+durable storage. Monitor `foxguard.installations.reconcile_failed` alongside
+scan failures; `foxguard.installations.reconciled` reports the total and
+internal/external/unknown installation counts after a successful refresh.
+Size `FOXGUARD_PR_WORKERS` against measured scanner peak memory and the
+container memory limit: child-process OOM kills can occur without restarting
+the hosted application.
+
 ## Quick Start
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <p align="center">
   <strong>Fast local security scanning for code, secrets, dependencies, and crypto risk.</strong>
+  <br />
+  <sub>Integrated into <a href="https://github.com/0sec-labs/0sec">0sec</a>, the open cybersecurity harness.</sub>
 </p>
 
 <p align="center">

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -18,7 +18,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, Weak};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::{
     extract::State,
@@ -441,6 +441,7 @@ struct AppState {
     /// location an operator needs to fix (e.g. a read-only volume).
     installations_path: Arc<Path>,
     pull_request_dispatcher: PullRequestDispatcher,
+    internal_accounts: Arc<HashSet<String>>,
 }
 
 #[derive(Clone)]
@@ -584,6 +585,9 @@ struct GitHubRepositorySummary {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
+        .json()
+        .flatten_event(true)
+        .with_ansi(false)
         .with_env_filter(
             EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| EnvFilter::new("info,foxguard=debug")),
@@ -630,6 +634,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         installations: Arc::new(Mutex::new(installations)),
         installations_path,
         pull_request_dispatcher,
+        internal_accounts: Arc::new(
+            std::env::var("FOXGUARD_INTERNAL_ACCOUNTS")
+                .unwrap_or_default()
+                .split(',')
+                .map(str::trim)
+                .filter(|account| !account.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        ),
     };
     let recovered = state
         .pull_request_dispatcher
@@ -639,6 +652,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     state.pull_request_dispatcher.schedule();
     start_pull_request_workers(state.clone(), pull_request_receiver, worker_count);
     start_pull_request_lifecycle_driver(state.clone());
+    start_installation_reconciliation(state.clone());
     info!(
         queue_capacity,
         worker_count, recovered, "pull_request workers ready"
@@ -669,6 +683,82 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
+    Ok(())
+}
+
+fn usage_scope(owner: &str, internal_accounts: &HashSet<String>) -> &'static str {
+    if internal_accounts.is_empty() || owner.is_empty() {
+        "unknown"
+    } else if internal_accounts
+        .iter()
+        .any(|account| account.eq_ignore_ascii_case(owner))
+    {
+        "internal"
+    } else {
+        "external"
+    }
+}
+
+fn start_installation_reconciliation(state: AppState) {
+    std::mem::drop(tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60 * 60));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            if let Err(error) = reconcile_installations(&state).await {
+                warn!(event = "foxguard.installations.reconcile_failed", %error,
+                    "installation registry refresh failed; retaining existing state");
+            }
+        }
+    }));
+}
+
+async fn reconcile_installations(state: &AppState) -> Result<(), String> {
+    let revision = state
+        .installations
+        .lock()
+        .map_err(|error| error.to_string())?
+        .revision();
+    let inputs = state
+        .auth
+        .list_installations()
+        .await
+        .map_err(|error| error.to_string())?;
+    let total = inputs.len();
+    let mut internal = 0usize;
+    let mut external = 0usize;
+    let mut unknown = 0usize;
+    for input in &inputs {
+        match usage_scope(
+            input.account_login.as_deref().unwrap_or(""),
+            &state.internal_accounts,
+        ) {
+            "internal" => internal += 1,
+            "external" => external += 1,
+            _ => unknown += 1,
+        }
+    }
+    let applied = state
+        .installations
+        .lock()
+        .map_err(|error| error.to_string())?
+        .reconcile(revision, inputs)
+        .map_err(|error| error.to_string())?;
+    if applied {
+        info!(
+            event = "foxguard.installations.reconciled",
+            installed_total = total,
+            installed_internal = internal,
+            installed_external = external,
+            installed_unknown = unknown,
+            "installation registry refreshed from GitHub"
+        );
+    } else {
+        info!(
+            event = "foxguard.installations.reconcile_deferred",
+            "installation webhook arrived during refresh; retaining newer state"
+        );
+    }
     Ok(())
 }
 
@@ -753,6 +843,11 @@ fn start_pull_request_workers(
                     }
                 }
 
+                let scan_started = Instant::now();
+                let scope = usage_scope(
+                    job.key.repository.split('/').next().unwrap_or(""),
+                    &state.internal_accounts,
+                );
                 match process_pull_request_delivery(
                     state.clone(),
                     &job.delivery,
@@ -776,6 +871,10 @@ fn start_pull_request_workers(
                             );
                         }
                         info!(
+                            event = "foxguard.scan.completed",
+                            usage_scope = scope,
+                            duration_ms = scan_started.elapsed().as_millis() as u64,
+                            head_sha = stored.head_sha,
                             delivery = job.delivery,
                             worker_id,
                             installation_id = job.installation_id,
@@ -871,6 +970,12 @@ fn start_pull_request_workers(
                             }
                         }
                         warn!(
+                            event = "foxguard.scan.failed",
+                            usage_scope = scope,
+                            duration_ms = scan_started.elapsed().as_millis() as u64,
+                            repo = job.key.repository,
+                            pr_number = job.key.number,
+                            head_sha = stored.head_sha,
                             delivery = job.delivery,
                             worker_id,
                             installation_id = job.installation_id,
@@ -1585,42 +1690,48 @@ fn persist_installation_event(
         .lock()
         .map_err(|error| format!("installation store lock poisoned: {error}"))?;
 
-    match payload.action.as_deref() {
-        Some("deleted") => store
+    if payload.action.as_deref() == Some("deleted") {
+        return store
             .remove(installation.id)
-            .map_err(|error| error.to_string()),
-        Some("added") => {
-            let repositories = repository_names(payload.repositories_added.as_deref());
-            store
-                .add_repositories(installation.id, repositories)
-                .map(|()| true)
-                .map_err(|error| error.to_string())
-        }
-        Some("removed") => {
-            let repositories = repository_names(payload.repositories_removed.as_deref());
-            store
-                .remove_repositories(installation.id, repositories)
-                .map(|()| true)
-                .map_err(|error| error.to_string())
-        }
-        _ => store
-            .upsert(InstallationMetadataInput {
-                installation_id: installation.id,
-                account_login: installation
-                    .account
-                    .as_ref()
-                    .and_then(|account| account.login.clone()),
-                account_id: installation.account.as_ref().and_then(|account| account.id),
-                account_type: installation
-                    .account
-                    .as_ref()
-                    .and_then(|account| account.kind.clone()),
-                repository_selection: installation.repository_selection.clone(),
-                repositories: repository_names(payload.repositories.as_deref()),
-            })
-            .map(|()| true)
-            .map_err(|error| error.to_string()),
+            .map_err(|error| error.to_string());
     }
+    // Delta events carry account metadata too. Do not leave a placeholder
+    // forever when installation:created predates this store.
+    store
+        .upsert(InstallationMetadataInput {
+            installation_id: installation.id,
+            account_login: installation
+                .account
+                .as_ref()
+                .and_then(|account| account.login.clone()),
+            account_id: installation.account.as_ref().and_then(|account| account.id),
+            account_type: installation
+                .account
+                .as_ref()
+                .and_then(|account| account.kind.clone()),
+            repository_selection: installation.repository_selection.clone(),
+            repositories: payload
+                .repositories
+                .as_deref()
+                .map(|repositories| repository_names(Some(repositories))),
+        })
+        .map_err(|error| error.to_string())?;
+    match payload.action.as_deref() {
+        Some("added") => store
+            .add_repositories(
+                installation.id,
+                repository_names(payload.repositories_added.as_deref()),
+            )
+            .map_err(|error| error.to_string())?,
+        Some("removed") => store
+            .remove_repositories(
+                installation.id,
+                repository_names(payload.repositories_removed.as_deref()),
+            )
+            .map_err(|error| error.to_string())?,
+        _ => {}
+    }
+    Ok(true)
 }
 
 fn repository_names(repositories: Option<&[GitHubRepositorySummary]>) -> Vec<String> {
@@ -2388,6 +2499,15 @@ mod tests {
     use super::*;
     use foxguard::github_app::pull_request_job_store::PullRequestJobStatus;
 
+    #[test]
+    fn usage_classification_requires_configured_internal_accounts_and_an_owner() {
+        let internal = HashSet::from(["0sec-labs".to_string()]);
+        assert_eq!(usage_scope("0sec-labs", &HashSet::new()), "unknown");
+        assert_eq!(usage_scope("", &internal), "unknown");
+        assert_eq!(usage_scope("0SEC-Labs", &internal), "internal");
+        assert_eq!(usage_scope("independent-org", &internal), "external");
+    }
+
     fn pull_request_job(
         delivery: &str,
         repository: &str,
@@ -2455,6 +2575,7 @@ mod tests {
                 installations: Arc::new(Mutex::new(installations)),
                 installations_path,
                 pull_request_dispatcher,
+                internal_accounts: Arc::new(HashSet::new()),
             },
         )
     }
@@ -4413,6 +4534,7 @@ mod tests {
             installations: Arc::new(Mutex::new(installations)),
             installations_path,
             pull_request_dispatcher,
+            internal_accounts: Arc::new(HashSet::new()),
         };
         remember_test_token(&state).await;
 

--- a/src/github_app/auth.rs
+++ b/src/github_app/auth.rs
@@ -298,16 +298,17 @@ impl InstallationTokenCache {
 #[derive(Deserialize)]
 struct ListedInstallation {
     id: u64,
-    account: ListedAccount,
+    account: Option<ListedAccount>,
     repository_selection: String,
 }
 
 #[derive(Deserialize)]
 struct ListedAccount {
-    login: String,
+    // Enterprise accounts use a slug instead of a repository-owner login.
+    login: Option<String>,
     id: u64,
     #[serde(rename = "type")]
-    kind: String,
+    kind: Option<String>,
 }
 
 #[derive(Clone)]
@@ -347,14 +348,20 @@ impl GitHubAppAuthClient {
                 .json::<Vec<ListedInstallation>>()
                 .await?;
             let last_page = rows.len() < 100;
-            installations.extend(rows.into_iter().map(|row| InstallationMetadataInput {
-                installation_id: row.id,
-                account_login: Some(row.account.login),
-                account_id: Some(row.account.id),
-                account_type: Some(row.account.kind),
-                repository_selection: Some(row.repository_selection),
-                // /app/installations does not enumerate repository names.
-                repositories: None,
+            installations.extend(rows.into_iter().map(|row| {
+                let (account_login, account_id, account_type) = row
+                    .account
+                    .map(|account| (account.login, Some(account.id), account.kind))
+                    .unwrap_or_default();
+                InstallationMetadataInput {
+                    installation_id: row.id,
+                    account_login,
+                    account_id,
+                    account_type,
+                    repository_selection: Some(row.repository_selection),
+                    // /app/installations does not enumerate repository names.
+                    repositories: None,
+                }
             }));
             if last_page {
                 break;

--- a/src/github_app/auth.rs
+++ b/src/github_app/auth.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::path::{Component, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use super::installation_store::InstallationMetadataInput;
+
 const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
 const DEFAULT_API_HOST: &str = "api.github.com";
 const GITHUB_API_VERSION: &str = "2026-03-10";
@@ -293,6 +295,21 @@ impl InstallationTokenCache {
     }
 }
 
+#[derive(Deserialize)]
+struct ListedInstallation {
+    id: u64,
+    account: ListedAccount,
+    repository_selection: String,
+}
+
+#[derive(Deserialize)]
+struct ListedAccount {
+    login: String,
+    id: u64,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
 #[derive(Clone)]
 pub struct GitHubAppAuthClient {
     http: reqwest::Client,
@@ -306,6 +323,44 @@ impl GitHubAppAuthClient {
             .user_agent("foxguard-github-app")
             .build()?;
         Ok(Self { http, credentials })
+    }
+
+    /// Fetch every page before returning, so a failed request cannot turn a
+    /// partial list into an authoritative deletion of existing installations.
+    pub async fn list_installations(&self) -> Result<Vec<InstallationMetadataInput>, AuthError> {
+        let jwt = self.credentials.jwt()?;
+        let url = format!(
+            "{}/app/installations",
+            self.credentials.api_base_url().trim_end_matches('/')
+        );
+        let mut installations = Vec::new();
+        for page in 1usize.. {
+            let rows = self
+                .http
+                .get(format!("{url}?per_page=100&page={page}")) // foxguard: ignore[rs/no-ssrf]
+                .bearer_auth(&jwt)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<Vec<ListedInstallation>>()
+                .await?;
+            let last_page = rows.len() < 100;
+            installations.extend(rows.into_iter().map(|row| InstallationMetadataInput {
+                installation_id: row.id,
+                account_login: Some(row.account.login),
+                account_id: Some(row.account.id),
+                account_type: Some(row.account.kind),
+                repository_selection: Some(row.repository_selection),
+                // /app/installations does not enumerate repository names.
+                repositories: None,
+            }));
+            if last_page {
+                break;
+            }
+        }
+        Ok(installations)
     }
 
     pub async fn create_installation_token(

--- a/src/github_app/installation_store.rs
+++ b/src/github_app/installation_store.rs
@@ -53,6 +53,7 @@ impl From<std::time::SystemTimeError> for InstallationStoreError {
 pub struct InstallationStore {
     path: PathBuf,
     registry: InstallationRegistry,
+    revision: u64,
 }
 
 impl InstallationStore {
@@ -78,7 +79,11 @@ impl InstallationStore {
         } else {
             InstallationRegistry::default()
         };
-        Ok(Self { path, registry })
+        Ok(Self {
+            path,
+            registry,
+            revision: 0,
+        })
     }
 
     pub fn upsert(
@@ -86,20 +91,12 @@ impl InstallationStore {
         input: InstallationMetadataInput,
     ) -> Result<(), InstallationStoreError> {
         let updated_at_unix = unix_now()?;
-        let key = input.installation_id.to_string();
-        let repositories = input.repositories.into_iter().collect();
-        self.registry.installations.insert(
-            key,
-            StoredInstallation {
-                installation_id: input.installation_id,
-                account_login: input.account_login,
-                account_id: input.account_id,
-                account_type: input.account_type,
-                repository_selection: input.repository_selection,
-                repositories,
-                updated_at_unix,
-            },
-        );
+        let installation = self
+            .registry
+            .installations
+            .entry(input.installation_id.to_string())
+            .or_insert_with(|| StoredInstallation::new_placeholder(input.installation_id));
+        installation.apply_metadata(input, updated_at_unix);
         self.save()
     }
 
@@ -155,6 +152,43 @@ impl InstallationStore {
         &self.path
     }
 
+    /// Captured before fetching GitHub state, so a refresh cannot overwrite
+    /// installation webhooks that arrived while the API request was in flight.
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Apply a complete, authoritative installation list. Repository names are
+    /// retained unless the caller supplies a repository snapshot explicitly.
+    pub fn reconcile(
+        &mut self,
+        expected_revision: u64,
+        inputs: Vec<InstallationMetadataInput>,
+    ) -> Result<bool, InstallationStoreError> {
+        if self.revision != expected_revision {
+            return Ok(false);
+        }
+        let now = unix_now()?;
+        let mut refreshed = BTreeMap::new();
+        for input in inputs {
+            let key = input.installation_id.to_string();
+            let mut installation = self
+                .registry
+                .installations
+                .get(&key)
+                .cloned()
+                .unwrap_or_else(|| StoredInstallation::new_placeholder(input.installation_id));
+            installation.apply_metadata(input, now);
+            refreshed.insert(key, installation);
+        }
+        let previous = std::mem::replace(&mut self.registry.installations, refreshed);
+        if let Err(error) = self.save() {
+            self.registry.installations = previous;
+            return Err(error);
+        }
+        Ok(true)
+    }
+
     #[cfg(test)]
     fn get(&self, installation_id: u64) -> Option<&StoredInstallation> {
         self.registry
@@ -162,7 +196,7 @@ impl InstallationStore {
             .get(&installation_id.to_string())
     }
 
-    fn save(&self) -> Result<(), InstallationStoreError> {
+    fn save(&mut self) -> Result<(), InstallationStoreError> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?; // foxguard: ignore[rs/no-path-traversal]
         }
@@ -178,6 +212,7 @@ impl InstallationStore {
         let bytes = serde_json::to_vec_pretty(&self.registry)?;
         std::fs::write(&temp_path, bytes)?; // foxguard: ignore[rs/no-path-traversal]
         std::fs::rename(&temp_path, &self.path)?; // foxguard: ignore[rs/no-path-traversal]
+        self.revision = self.revision.wrapping_add(1);
         Ok(())
     }
 }
@@ -189,7 +224,8 @@ pub struct InstallationMetadataInput {
     pub account_id: Option<u64>,
     pub account_type: Option<String>,
     pub repository_selection: Option<String>,
-    pub repositories: Vec<String>,
+    /// None preserves observed repositories; Some replaces an explicit snapshot.
+    pub repositories: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -219,6 +255,25 @@ struct StoredInstallation {
 }
 
 impl StoredInstallation {
+    fn apply_metadata(&mut self, input: InstallationMetadataInput, now: u64) {
+        if let Some(value) = input.account_login {
+            self.account_login = Some(value);
+        }
+        if let Some(value) = input.account_id {
+            self.account_id = Some(value);
+        }
+        if let Some(value) = input.account_type {
+            self.account_type = Some(value);
+        }
+        if let Some(value) = input.repository_selection {
+            self.repository_selection = Some(value);
+        }
+        if let Some(repositories) = input.repositories {
+            self.repositories = repositories.into_iter().collect();
+        }
+        self.updated_at_unix = now;
+    }
+
     fn new_placeholder(installation_id: u64) -> Self {
         Self {
             installation_id,
@@ -291,7 +346,10 @@ mod tests {
             account_id: Some(99),
             account_type: Some("Organization".to_string()),
             repository_selection: Some("selected".to_string()),
-            repositories: vec!["octo-org/app".to_string(), "octo-org/service".to_string()],
+            repositories: Some(vec![
+                "octo-org/app".to_string(),
+                "octo-org/service".to_string(),
+            ]),
         }) {
             panic!("upsert should persist: {error}");
         }
@@ -386,7 +444,7 @@ mod tests {
             account_id: Some(1),
             account_type: Some("Organization".to_string()),
             repository_selection: Some("all".to_string()),
-            repositories: vec!["acme/api".to_string()],
+            repositories: Some(vec!["acme/api".to_string()]),
         }) {
             let _ = std::fs::remove_dir_all(&base);
             panic!("save() should create missing parent dirs and persist: {error}");
@@ -411,7 +469,7 @@ mod tests {
             account_id: Some(5),
             account_type: Some("Organization".to_string()),
             repository_selection: Some("selected".to_string()),
-            repositories: vec!["octo-org/app".to_string()],
+            repositories: Some(vec!["octo-org/app".to_string()]),
         }) {
             panic!("upsert should persist: {error}");
         }
@@ -439,15 +497,102 @@ mod tests {
         assert!(installation.repositories.contains("octo-org/service"));
     }
 
+    fn metadata(id: u64, login: Option<&str>) -> InstallationMetadataInput {
+        InstallationMetadataInput {
+            installation_id: id,
+            account_login: login.map(str::to_owned),
+            account_id: None,
+            account_type: None,
+            repository_selection: None,
+            repositories: None,
+        }
+    }
+
     #[test]
-    fn path_accessor_reports_configured_store_path() {
-        // The operator-facing path is used when logging persistence
-        // failures so the operator knows which location is unwritable.
+    fn authoritative_refresh_repairs_placeholders_without_losing_observed_repositories() {
         let (_dir, path) = store_path();
-        let store = match InstallationStore::open(path.clone()) {
-            Ok(store) => store,
-            Err(error) => panic!("store should open: {error}"),
-        };
-        assert_eq!(store.path(), path.as_path());
+        let mut store = InstallationStore::open(path.clone()).unwrap();
+        store
+            .add_repositories(42, ["active/project".to_string()])
+            .unwrap();
+        store.upsert(metadata(99, Some("uninstalled"))).unwrap();
+        let revision = store.revision();
+        assert!(store
+            .reconcile(
+                revision,
+                vec![
+                    metadata(42, Some("active")),
+                    metadata(77, Some("previously-missed")),
+                ]
+            )
+            .unwrap());
+        let reloaded = InstallationStore::open(path).unwrap();
+        assert_eq!(
+            reloaded.get(42).unwrap().account_login.as_deref(),
+            Some("active")
+        );
+        assert!(reloaded
+            .get(42)
+            .unwrap()
+            .repositories
+            .contains("active/project"));
+        assert_eq!(
+            reloaded.get(77).unwrap().account_login.as_deref(),
+            Some("previously-missed")
+        );
+        assert!(reloaded.get(99).is_none());
+    }
+
+    #[test]
+    fn refresh_does_not_overwrite_a_concurrent_installation_webhook() {
+        let (_dir, path) = store_path();
+        let mut store = InstallationStore::open(path.clone()).unwrap();
+        let revision = store.revision();
+        store.upsert(metadata(42, Some("new-install"))).unwrap();
+        assert!(!store.reconcile(revision, vec![]).unwrap());
+        assert!(InstallationStore::open(path).unwrap().get(42).is_some());
+    }
+
+    #[test]
+    fn omitted_metadata_preserves_state_but_explicit_empty_repository_list_clears_it() {
+        let (_dir, path) = store_path();
+        let mut store = InstallationStore::open(path.clone()).unwrap();
+        let mut initial = metadata(42, Some("active"));
+        initial.repositories = Some(vec!["active/project".to_string()]);
+        store.upsert(initial).unwrap();
+        store.upsert(metadata(42, None)).unwrap();
+        let reloaded = InstallationStore::open(path.clone()).unwrap();
+        assert_eq!(
+            reloaded.get(42).unwrap().account_login.as_deref(),
+            Some("active")
+        );
+        assert!(reloaded
+            .get(42)
+            .unwrap()
+            .repositories
+            .contains("active/project"));
+        let mut cleared = metadata(42, None);
+        cleared.repositories = Some(vec![]);
+        store.upsert(cleared).unwrap();
+        assert!(InstallationStore::open(path)
+            .unwrap()
+            .get(42)
+            .unwrap()
+            .repositories
+            .is_empty());
+    }
+
+    #[test]
+    fn failed_refresh_keeps_previous_registry_in_memory() {
+        let (_dir, path) = store_path();
+        let mut store = InstallationStore::open(path.clone()).unwrap();
+        store.upsert(metadata(42, Some("active"))).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        assert!(store.reconcile(store.revision(), vec![]).is_err());
+        assert_eq!(
+            store.get(42).unwrap().account_login.as_deref(),
+            Some("active")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three interrelated changes to the GitHub App webhook receiver and project docs:

### 1. Installation reconciliation + structured usage events (77caabb)
- Handle GitHub App webhook lifecycle events (installation created/deleted/suspended/unsuspended) and reconcile the local `installations.json` store accordingly
- Classify incoming webhook events and emit structured JSON usage/accounting records to `foxguard-audit.log`

### 2. Accept nullable+enterprise installation accounts (4df1140)
- Relax account deserialization for installations that arrive without a full `account` payload (nullable accounts, enterprise-managed installations)

### 3. README integration link (1d758f7)
- Add the `0sec` cybersecurity harness integration badge/link to the README header

## Upstream integration
Rebased cleanly onto `origin/main` (`fd3abaa` release v0.13.0) — zero conflicts.

## Verification
- Rebase completed with no source conflicts
- PR CI will run on push

CC: @doruk