### PR TITLE
fix(github-app): persist and log evaluated finding counts

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -859,9 +859,10 @@ fn start_pull_request_workers(
                 .await
                 {
                     Ok(result) => {
+                        let finding_count = result.findings_for_transport().len();
                         if let Err(error) = state
                             .pull_request_dispatcher
-                            .mark_completed(&job.delivery, result.findings.len())
+                            .mark_completed(&job.delivery, finding_count)
                         {
                             error!(
                                 delivery = job.delivery,
@@ -881,7 +882,7 @@ fn start_pull_request_workers(
                             action = job.action,
                             pr_number = result.pr_number,
                             repo = result.repo,
-                            findings = result.findings.len(),
+                            findings = finding_count,
                             review_messages = result.review_messages,
                             deleted_comments = result.deleted_comments,
                             posted_check_annotations = result.posted_check_annotations,


### PR DESCRIPTION
## Problem
A real hosted scan produced a GitHub policy report with 171 findings while its completed event and durable job metadata reported zero. Full scans move their findings into the policy evaluation, leaving the raw findings field empty.

## Fix
Use the existing findings_for_transport accessor once for both the durable job count and the completed log record. This does not change policy, check conclusions, annotations, or review behavior.

## Verification
- Production reproduction: GitHub check had 171 reportable findings, while foxguard.scan.completed had findings=0.
- cargo test --locked --features github-app --bin foxguard-github-app: 43 passed.
- Final confirmation will compare a real post-rollout completed event against its GitHub check summary.